### PR TITLE
refactor: optimize CUE manifests with version variables and URL templates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ jobs:
     name: E2E Test (${{ matrix.os }}/${{ matrix.arch }}, ${{ matrix.mode }})
     needs: integration-test
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         include:
           # Native mode

--- a/e2e/config/dependency-test/parallel.cue
+++ b/e2e/config/dependency-test/parallel.cue
@@ -2,59 +2,77 @@ package toto
 
 // Parallel tool installation test: multiple independent tools
 
+_rgVersion: "14.1.1"
+_fdVersion: "10.2.0"
+_batVersion: "0.26.1"
+
+// Architecture mapping for URL patterns
+_archMap: {
+	arm64: "aarch64"
+	amd64: "x86_64"
+}
+
+// ripgrep: linux-gnu uses gnu, linux-amd64 uses musl (different suffix)
 _rgSource: {
 	if _env.os == "linux" && _env.arch == "arm64" {
-		url: "https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep-14.1.1-aarch64-unknown-linux-gnu.tar.gz"
+		url: "https://github.com/BurntSushi/ripgrep/releases/download/\(_rgVersion)/ripgrep-\(_rgVersion)-\(_archMap[_env.arch])-unknown-linux-gnu.tar.gz"
 		checksum: value: "sha256:c827481c4ff4ea10c9dc7a4022c8de5db34a5737cb74484d62eb94a95841ab2f"
 	}
 	if _env.os == "linux" && _env.arch == "amd64" {
-		url: "https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep-14.1.1-x86_64-unknown-linux-musl.tar.gz"
+		url: "https://github.com/BurntSushi/ripgrep/releases/download/\(_rgVersion)/ripgrep-\(_rgVersion)-\(_archMap[_env.arch])-unknown-linux-musl.tar.gz"
 		checksum: value: "sha256:4cf9f2741e6c465ffdb7c26f38056a59e2a2544b51f7cc128ef28337eeae4d8e"
 	}
+	if _env.os == "darwin" {
+		url: "https://github.com/BurntSushi/ripgrep/releases/download/\(_rgVersion)/ripgrep-\(_rgVersion)-\(_archMap[_env.arch])-apple-darwin.tar.gz"
+	}
 	if _env.os == "darwin" && _env.arch == "arm64" {
-		url: "https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep-14.1.1-aarch64-apple-darwin.tar.gz"
 		checksum: value: "sha256:24ad76777745fbff131c8fbc466742b011f925bfa4fffa2ded6def23b5b937be"
 	}
 	if _env.os == "darwin" && _env.arch == "amd64" {
-		url: "https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep-14.1.1-x86_64-apple-darwin.tar.gz"
 		checksum: value: "sha256:fc87e78f7cb3fea12d69072e7ef3b21509754717b746368fd40d88963630e2b3"
 	}
 }
 
+// fd: consistent pattern across all platforms
 _fdSource: {
+	if _env.os == "linux" {
+		url: "https://github.com/sharkdp/fd/releases/download/v\(_fdVersion)/fd-v\(_fdVersion)-\(_archMap[_env.arch])-unknown-linux-gnu.tar.gz"
+	}
+	if _env.os == "darwin" {
+		url: "https://github.com/sharkdp/fd/releases/download/v\(_fdVersion)/fd-v\(_fdVersion)-\(_archMap[_env.arch])-apple-darwin.tar.gz"
+	}
 	if _env.os == "linux" && _env.arch == "arm64" {
-		url: "https://github.com/sharkdp/fd/releases/download/v10.2.0/fd-v10.2.0-aarch64-unknown-linux-gnu.tar.gz"
 		checksum: value: "sha256:6de8be7a3d8ca27954a6d1e22bc327af4cf6fc7622791e68b820197f915c422b"
 	}
 	if _env.os == "linux" && _env.arch == "amd64" {
-		url: "https://github.com/sharkdp/fd/releases/download/v10.2.0/fd-v10.2.0-x86_64-unknown-linux-gnu.tar.gz"
 		checksum: value: "sha256:5f9030bcb0e1d03818521ed2e3d74fdb046480a45a4418ccff4f070241b4ed25"
 	}
 	if _env.os == "darwin" && _env.arch == "arm64" {
-		url: "https://github.com/sharkdp/fd/releases/download/v10.2.0/fd-v10.2.0-aarch64-apple-darwin.tar.gz"
 		checksum: value: "sha256:ae6327ba8c9a487cd63edd8bddd97da0207887a66d61e067dfe80c1430c5ae36"
 	}
 	if _env.os == "darwin" && _env.arch == "amd64" {
-		url: "https://github.com/sharkdp/fd/releases/download/v10.2.0/fd-v10.2.0-x86_64-apple-darwin.tar.gz"
 		checksum: value: "sha256:991a648a58870230af9547c1ae33e72cb5c5199a622fe5e540e162d6dba82d48"
 	}
 }
 
+// bat: consistent pattern across all platforms
 _batSource: {
+	if _env.os == "linux" {
+		url: "https://github.com/sharkdp/bat/releases/download/v\(_batVersion)/bat-v\(_batVersion)-\(_archMap[_env.arch])-unknown-linux-gnu.tar.gz"
+	}
+	if _env.os == "darwin" {
+		url: "https://github.com/sharkdp/bat/releases/download/v\(_batVersion)/bat-v\(_batVersion)-\(_archMap[_env.arch])-apple-darwin.tar.gz"
+	}
 	if _env.os == "linux" && _env.arch == "arm64" {
-		url: "https://github.com/sharkdp/bat/releases/download/v0.26.1/bat-v0.26.1-aarch64-unknown-linux-gnu.tar.gz"
 		checksum: value: "sha256:422eb73e11c854fddd99f5ca8461c2f1d6e6dce0a2a8c3d5daade5ffcb6564aa"
 	}
 	if _env.os == "linux" && _env.arch == "amd64" {
-		url: "https://github.com/sharkdp/bat/releases/download/v0.26.1/bat-v0.26.1-x86_64-unknown-linux-gnu.tar.gz"
 		checksum: value: "sha256:726f04c8f576a7fd18b7634f1bbf2f915c43494c1c0f013baa3287edb0d5a2a3"
 	}
 	if _env.os == "darwin" && _env.arch == "arm64" {
-		url: "https://github.com/sharkdp/bat/releases/download/v0.26.1/bat-v0.26.1-aarch64-apple-darwin.tar.gz"
 		checksum: value: "sha256:e30beff26779c9bf60bb541e1d79046250cb74378f2757f8eb250afddb19e114"
 	}
 	if _env.os == "darwin" && _env.arch == "amd64" {
-		url: "https://github.com/sharkdp/bat/releases/download/v0.26.1/bat-v0.26.1-x86_64-apple-darwin.tar.gz"
 		checksum: value: "sha256:830d63b0bba1fa040542ec569e3cf77f60d3356b9de75116a344b061e0894245"
 	}
 }
@@ -74,7 +92,7 @@ rg: {
 	metadata: name: "rg"
 	spec: {
 		installerRef: "aqua"
-		version:      "14.1.1"
+		version:      _rgVersion
 		source:       _rgSource
 	}
 }
@@ -85,7 +103,7 @@ fd: {
 	metadata: name: "fd"
 	spec: {
 		installerRef: "aqua"
-		version:      "10.2.0"
+		version:      _fdVersion
 		source:       _fdSource
 	}
 }
@@ -96,7 +114,7 @@ bat: {
 	metadata: name: "bat"
 	spec: {
 		installerRef: "aqua"
-		version:      "0.26.1"
+		version:      _batVersion
 		source:       _batSource
 	}
 }

--- a/e2e/config/dependency-test/runtime-chain.cue
+++ b/e2e/config/dependency-test/runtime-chain.cue
@@ -2,19 +2,10 @@ package toto
 
 // Runtime to Tool dependency chain test: go runtime -> go installer -> gopls
 
+_goVersion: "1.23.5"
+
 _goSource: {
-	if _env.os == "linux" && _env.arch == "arm64" {
-		url: "https://go.dev/dl/go1.23.5.linux-arm64.tar.gz"
-	}
-	if _env.os == "linux" && _env.arch == "amd64" {
-		url: "https://go.dev/dl/go1.23.5.linux-amd64.tar.gz"
-	}
-	if _env.os == "darwin" && _env.arch == "arm64" {
-		url: "https://go.dev/dl/go1.23.5.darwin-arm64.tar.gz"
-	}
-	if _env.os == "darwin" && _env.arch == "amd64" {
-		url: "https://go.dev/dl/go1.23.5.darwin-amd64.tar.gz"
-	}
+	url: "https://go.dev/dl/go\(_goVersion).\(_env.os)-\(_env.arch).tar.gz"
 	checksum: url: "https://go.dev/dl/?mode=json&include=all"
 }
 
@@ -25,13 +16,13 @@ goRuntime: {
 	metadata: name: "go"
 	spec: {
 		type:    "download"
-		version: "1.23.5"
+		version: _goVersion
 		source:  _goSource
 		binaries: ["go", "gofmt"]
 		binDir:      "~/go/bin"
 		toolBinPath: "~/go/bin"
 		env: {
-			GOROOT: "~/.local/share/toto/runtimes/go/1.23.5"
+			GOROOT: "~/.local/share/toto/runtimes/go/\(_goVersion)"
 			GOBIN:  "~/go/bin"
 		}
 		commands: {

--- a/e2e/config/dependency-test/toolref.cue
+++ b/e2e/config/dependency-test/toolref.cue
@@ -2,26 +2,28 @@ package toto
 
 // ToolRef dependency test: aqua -> jq -> jq-installer
 
+_jqVersion: "1.7.1"
+
+// jq: uses "macos" instead of "darwin" in URLs
+_jqOsMap: {
+	linux:  "linux"
+	darwin: "macos"
+}
+
 _jqSource: {
+	url:         "https://github.com/jqlang/jq/releases/download/jq-\(_jqVersion)/jq-\(_jqOsMap[_env.os])-\(_env.arch)"
+	archiveType: "raw"
 	if _env.os == "linux" && _env.arch == "arm64" {
-		url: "https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-arm64"
 		checksum: value: "sha256:4dd2d8a0661df0b22f1bb9a1f9830f06b6f3b8f7d91211a1ef5d7c4f06a8b4a5"
-		archiveType: "raw"
 	}
 	if _env.os == "linux" && _env.arch == "amd64" {
-		url: "https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64"
 		checksum: value: "sha256:5942c9b0934e510ee61eb3e30273f1b3fe2590df93933a93d7c58b81d19c8ff5"
-		archiveType: "raw"
 	}
 	if _env.os == "darwin" && _env.arch == "arm64" {
-		url: "https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-macos-arm64"
 		checksum: value: "sha256:0bbe619e663e0de2c550be2fe0d240d076799d6f8a652b70fa04aea8a8362e8a"
-		archiveType: "raw"
 	}
 	if _env.os == "darwin" && _env.arch == "amd64" {
-		url: "https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-macos-amd64"
 		checksum: value: "sha256:4155822bbf5ea90f5c79cf254665975eb4274d426d0709770c21774de5407443"
-		archiveType: "raw"
 	}
 }
 
@@ -42,7 +44,7 @@ jqTool: {
 	metadata: name: "jq"
 	spec: {
 		installerRef: "aqua"
-		version:      "1.7.1"
+		version:      _jqVersion
 		source:       _jqSource
 	}
 }


### PR DESCRIPTION
- parallel.cue: introduce _rgVersion, _fdVersion, _batVersion variables
  and _archMap for URL templating
- runtime-chain.cue: consolidate 4 OS/arch URL variants into single template
  using _goVersion variable
- toolref.cue: add _jqVersion and _jqOsMap for URL simplification
- ci.yaml: change fail-fast from false to true
