### PR TITLE
phase16: parallel execution engine with progress UI

### DIFF
--- a/e2e/dependency_test.go
+++ b/e2e/dependency_test.go
@@ -3,6 +3,8 @@
 package e2e
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -81,6 +83,90 @@ var _ = Describe("Dependency Resolution", Ordered, func() {
 			output, err := testExec.ExecBash("~/.local/bin/rg --version")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).To(ContainSubstring("ripgrep"))
+		})
+	})
+
+	Describe("Parallel Flag Behavior", func() {
+		BeforeAll(func() {
+			// Reset state.json and clean up tools/symlinks to ensure clean state
+			_, _ = testExec.ExecBash(`echo '{"runtimes":{},"tools":{},"installers":{}}' > ~/.local/share/toto/state.json`)
+			_, _ = testExec.ExecBash(`rm -rf ~/.local/share/toto/tools/rg ~/.local/share/toto/tools/fd ~/.local/share/toto/tools/bat`)
+			_, _ = testExec.ExecBash(`rm -f ~/.local/bin/rg ~/.local/bin/fd ~/.local/bin/bat`)
+		})
+
+		It("installs all tools with --parallel 1 (sequential)", func() {
+			By("Running toto apply with --parallel 1")
+			output, err := testExec.Exec("toto", "apply", "--parallel", "1", "~/dependency-test/parallel.cue")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying rg works")
+			rgOut, err := testExec.ExecBash("~/.local/bin/rg --version")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rgOut).To(ContainSubstring("ripgrep 14.1.1"))
+
+			By("Verifying fd works")
+			fdOut, err := testExec.ExecBash("~/.local/bin/fd --version")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fdOut).To(ContainSubstring("fd 10.2.0"))
+
+			By("Verifying bat works")
+			batOut, err := testExec.ExecBash("~/.local/bin/bat --version")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(batOut).To(ContainSubstring("bat 0.26.1"))
+
+			By("Verifying non-TTY output has Commands: header exactly once")
+			Expect(strings.Count(output, "Commands:")).To(Equal(1))
+		})
+
+		It("shows Commands: header exactly once with default parallelism", func() {
+			By("Reset state for fresh install")
+			_, _ = testExec.ExecBash(`echo '{"runtimes":{},"tools":{},"installers":{}}' > ~/.local/share/toto/state.json`)
+			_, _ = testExec.ExecBash(`rm -rf ~/.local/share/toto/tools/rg ~/.local/share/toto/tools/fd ~/.local/share/toto/tools/bat`)
+			_, _ = testExec.ExecBash(`rm -f ~/.local/bin/rg ~/.local/bin/fd ~/.local/bin/bat`)
+
+			By("Running toto apply without --parallel flag (default)")
+			output, err := testExec.Exec("toto", "apply", "~/dependency-test/parallel.cue")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying all tools installed")
+			_, err = testExec.ExecBash("~/.local/bin/rg --version")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = testExec.ExecBash("~/.local/bin/fd --version")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = testExec.ExecBash("~/.local/bin/bat --version")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying non-TTY output has Commands: header exactly once")
+			Expect(strings.Count(output, "Commands:")).To(Equal(1))
+		})
+	})
+
+	Describe("Runtime and Tool Mixed Parallel Execution", func() {
+		BeforeAll(func() {
+			// Reset state.json to clean state
+			_, _ = testExec.ExecBash(`echo '{"runtimes":{},"tools":{},"installers":{}}' > ~/.local/share/toto/state.json`)
+		})
+
+		It("installs runtime before dependent tool in parallel mode", func() {
+			By("Running toto apply on runtime-chain.cue with default parallelism")
+			_, err := testExec.Exec("toto", "apply", "~/dependency-test/runtime-chain.cue")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying go runtime is installed")
+			output, err := testExec.ExecBash("GOTOOLCHAIN=local ~/.local/share/toto/runtimes/go/1.23.5/bin/go version")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(ContainSubstring("go1.23"))
+
+			By("Verifying gopls is installed (depends on go runtime)")
+			output, err = testExec.ExecBash("~/go/bin/gopls version")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(ContainSubstring("golang.org/x/tools/gopls"))
+
+			By("Verifying state.json records both resources")
+			stateOutput, err := testExec.ExecBash("cat ~/.local/share/toto/state.json")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stateOutput).To(ContainSubstring(`"go"`))
+			Expect(stateOutput).To(ContainSubstring(`"gopls"`))
 		})
 	})
 

--- a/internal/installer/download/callback.go
+++ b/internal/installer/download/callback.go
@@ -1,0 +1,27 @@
+package download
+
+import "context"
+
+// OutputCallback is called for each line of command output.
+type OutputCallback func(line string)
+
+// Callback is a type constraint for callback functions that can be stored in context.
+type Callback interface {
+	ProgressCallback | OutputCallback
+}
+
+type callbackKey[T Callback] struct{}
+
+// WithCallback returns a context with the given callback.
+func WithCallback[T Callback](ctx context.Context, cb T) context.Context {
+	return context.WithValue(ctx, callbackKey[T]{}, cb)
+}
+
+// CallbackFromContext extracts the callback from context, or the zero value.
+func CallbackFromContext[T Callback](ctx context.Context) T {
+	if cb, ok := ctx.Value(callbackKey[T]{}).(T); ok {
+		return cb
+	}
+	var zero T
+	return zero
+}

--- a/internal/installer/download/callback_test.go
+++ b/internal/installer/download/callback_test.go
@@ -1,0 +1,118 @@
+package download
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCallbackFromContext_Progress(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(ctx context.Context) context.Context
+		wantNil bool
+	}{
+		{
+			name:    "returns nil when no callback set",
+			setup:   func(ctx context.Context) context.Context { return ctx },
+			wantNil: true,
+		},
+		{
+			name: "returns callback when set",
+			setup: func(ctx context.Context) context.Context {
+				return WithCallback(ctx, ProgressCallback(func(downloaded, total int64) {}))
+			},
+			wantNil: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := tt.setup(context.Background())
+			cb := CallbackFromContext[ProgressCallback](ctx)
+			if tt.wantNil {
+				assert.Nil(t, cb)
+			} else {
+				assert.NotNil(t, cb)
+			}
+		})
+	}
+}
+
+func TestCallbackFromContext_Output(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(ctx context.Context) context.Context
+		wantNil bool
+	}{
+		{
+			name:    "returns nil when no callback set",
+			setup:   func(ctx context.Context) context.Context { return ctx },
+			wantNil: true,
+		},
+		{
+			name: "returns callback when set",
+			setup: func(ctx context.Context) context.Context {
+				return WithCallback(ctx, OutputCallback(func(line string) {}))
+			},
+			wantNil: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := tt.setup(context.Background())
+			cb := CallbackFromContext[OutputCallback](ctx)
+			if tt.wantNil {
+				assert.Nil(t, cb)
+			} else {
+				assert.NotNil(t, cb)
+			}
+		})
+	}
+}
+
+func TestCallbackFromContext_ProgressInvocable(t *testing.T) {
+	var called bool
+	var gotDownloaded, gotTotal int64
+
+	ctx := WithCallback(context.Background(), ProgressCallback(func(downloaded, total int64) {
+		called = true
+		gotDownloaded = downloaded
+		gotTotal = total
+	}))
+
+	cb := CallbackFromContext[ProgressCallback](ctx)
+	assert.NotNil(t, cb)
+
+	cb(100, 200)
+	assert.True(t, called)
+	assert.Equal(t, int64(100), gotDownloaded)
+	assert.Equal(t, int64(200), gotTotal)
+}
+
+func TestCallbackFromContext_OutputInvocable(t *testing.T) {
+	var called bool
+	var gotLine string
+
+	ctx := WithCallback(context.Background(), OutputCallback(func(line string) {
+		called = true
+		gotLine = line
+	}))
+
+	cb := CallbackFromContext[OutputCallback](ctx)
+	assert.NotNil(t, cb)
+
+	cb("hello")
+	assert.True(t, called)
+	assert.Equal(t, "hello", gotLine)
+}
+
+func TestCallbackFromContext_TypeIsolation(t *testing.T) {
+	ctx := WithCallback(context.Background(), ProgressCallback(func(downloaded, total int64) {}))
+
+	// ProgressCallback is set, but OutputCallback should be nil
+	assert.NotNil(t, CallbackFromContext[ProgressCallback](ctx))
+	assert.Nil(t, CallbackFromContext[OutputCallback](ctx))
+}

--- a/internal/installer/executor/runtime_store.go
+++ b/internal/installer/executor/runtime_store.go
@@ -1,22 +1,23 @@
 package executor
 
 import (
+	"sync"
+
 	"github.com/terassyi/toto/internal/resource"
 	"github.com/terassyi/toto/internal/state"
 )
 
 // RuntimeStateStore adapts state.Store to the StateStore interface for Runtimes.
 type RuntimeStateStore struct {
+	mu    *sync.Mutex
 	store *state.Store[state.UserState]
-}
-
-// NewRuntimeStateStore creates a new RuntimeStateStore.
-func NewRuntimeStateStore(store *state.Store[state.UserState]) *RuntimeStateStore {
-	return &RuntimeStateStore{store: store}
 }
 
 // Load loads a runtime state by name.
 func (s *RuntimeStateStore) Load(name string) (*resource.RuntimeState, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	st, err := s.store.Load()
 	if err != nil {
 		return nil, false, err
@@ -27,6 +28,9 @@ func (s *RuntimeStateStore) Load(name string) (*resource.RuntimeState, bool, err
 
 // Save saves a runtime state.
 func (s *RuntimeStateStore) Save(name string, runtimeState *resource.RuntimeState) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	st, err := s.store.Load()
 	if err != nil {
 		return err
@@ -42,6 +46,9 @@ func (s *RuntimeStateStore) Save(name string, runtimeState *resource.RuntimeStat
 
 // Delete removes a runtime from state.
 func (s *RuntimeStateStore) Delete(name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	st, err := s.store.Load()
 	if err != nil {
 		return err

--- a/internal/installer/executor/store_factory.go
+++ b/internal/installer/executor/store_factory.go
@@ -1,0 +1,30 @@
+package executor
+
+import (
+	"sync"
+
+	"github.com/terassyi/toto/internal/state"
+)
+
+// StateStoreFactory creates StateStore instances that share a single mutex.
+// This ensures that ToolStateStore and RuntimeStateStore, which both
+// read/write the same state.json, are properly serialized.
+type StateStoreFactory struct {
+	mu    sync.Mutex
+	store *state.Store[state.UserState]
+}
+
+// NewStateStoreFactory creates a new StateStoreFactory.
+func NewStateStoreFactory(store *state.Store[state.UserState]) *StateStoreFactory {
+	return &StateStoreFactory{store: store}
+}
+
+// ToolStore creates a ToolStateStore with the shared mutex.
+func (f *StateStoreFactory) ToolStore() *ToolStateStore {
+	return &ToolStateStore{mu: &f.mu, store: f.store}
+}
+
+// RuntimeStore creates a RuntimeStateStore with the shared mutex.
+func (f *StateStoreFactory) RuntimeStore() *RuntimeStateStore {
+	return &RuntimeStateStore{mu: &f.mu, store: f.store}
+}

--- a/internal/installer/executor/store_test.go
+++ b/internal/installer/executor/store_test.go
@@ -1,0 +1,367 @@
+package executor
+
+import (
+	"fmt"
+	"os"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/toto/internal/state"
+	"pgregory.net/rapid"
+)
+
+// newLockedFactory creates a StateStoreFactory with Lock already acquired.
+func newLockedFactory(t *testing.T) *StateStoreFactory {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := state.NewStore[state.UserState](dir)
+	require.NoError(t, err)
+	require.NoError(t, store.Lock())
+	t.Cleanup(func() { _ = store.Unlock() })
+	return NewStateStoreFactory(store)
+}
+
+// newLockedFactoryRapid creates a StateStoreFactory for use inside rapid.Check.
+func newLockedFactoryRapid(t *rapid.T) *StateStoreFactory {
+	dir, err := os.MkdirTemp("", "store-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	store, err := state.NewStore[state.UserState](dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Lock(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Unlock() })
+	return NewStateStoreFactory(store)
+}
+
+// --- Integration Tests ---
+
+func TestToolStateStore_SaveAndLoad(t *testing.T) {
+	f := newLockedFactory(t)
+	ts := f.ToolStore()
+
+	toolState := &resource.ToolState{
+		InstallerRef: "download",
+		Version:      "14.1.1",
+		InstallPath:  "/tools/ripgrep/14.1.1",
+		BinPath:      "/bin/rg",
+	}
+
+	require.NoError(t, ts.Save("ripgrep", toolState))
+
+	loaded, exists, err := ts.Load("ripgrep")
+	require.NoError(t, err)
+	assert.True(t, exists)
+	assert.Equal(t, "14.1.1", loaded.Version)
+}
+
+func TestToolStateStore_Delete(t *testing.T) {
+	f := newLockedFactory(t)
+	ts := f.ToolStore()
+
+	require.NoError(t, ts.Save("ripgrep", &resource.ToolState{Version: "14.1.1"}))
+	require.NoError(t, ts.Delete("ripgrep"))
+
+	_, exists, err := ts.Load("ripgrep")
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestToolStateStore_LoadNotFound(t *testing.T) {
+	f := newLockedFactory(t)
+	ts := f.ToolStore()
+
+	_, exists, err := ts.Load("nonexistent")
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestRuntimeStateStore_SaveAndLoad(t *testing.T) {
+	f := newLockedFactory(t)
+	rs := f.RuntimeStore()
+
+	runtimeState := &resource.RuntimeState{
+		Version:     "1.23.0",
+		InstallPath: "/runtimes/go/1.23.0",
+		BinDir:      "/runtimes/go/1.23.0/bin",
+	}
+
+	require.NoError(t, rs.Save("go", runtimeState))
+
+	loaded, exists, err := rs.Load("go")
+	require.NoError(t, err)
+	assert.True(t, exists)
+	assert.Equal(t, "1.23.0", loaded.Version)
+}
+
+func TestRuntimeStateStore_Delete(t *testing.T) {
+	f := newLockedFactory(t)
+	rs := f.RuntimeStore()
+
+	require.NoError(t, rs.Save("go", &resource.RuntimeState{Version: "1.23.0"}))
+	require.NoError(t, rs.Delete("go"))
+
+	_, exists, err := rs.Load("go")
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+// --- Concurrency Integration Tests ---
+
+func TestToolStateStore_ConcurrentSave(t *testing.T) {
+	f := newLockedFactory(t)
+	ts := f.ToolStore()
+
+	const n = 20
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+
+	for i := range n {
+		wg.Go(func() {
+			name := fmt.Sprintf("tool-%d", i)
+			errs[i] = ts.Save(name, &resource.ToolState{
+				Version:     fmt.Sprintf("1.0.%d", i),
+				InstallPath: fmt.Sprintf("/tools/%s", name),
+				BinPath:     fmt.Sprintf("/bin/%s", name),
+			})
+		})
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "save failed for tool-%d", i)
+	}
+
+	for i := range n {
+		name := fmt.Sprintf("tool-%d", i)
+		loaded, exists, err := ts.Load(name)
+		require.NoError(t, err)
+		assert.True(t, exists, "tool %s missing", name)
+		assert.Equal(t, fmt.Sprintf("1.0.%d", i), loaded.Version)
+	}
+}
+
+func TestRuntimeStateStore_ConcurrentSave(t *testing.T) {
+	f := newLockedFactory(t)
+	rs := f.RuntimeStore()
+
+	const n = 10
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+
+	for i := range n {
+		wg.Go(func() {
+			name := fmt.Sprintf("runtime-%d", i)
+			errs[i] = rs.Save(name, &resource.RuntimeState{
+				Version:     fmt.Sprintf("1.%d.0", i),
+				InstallPath: fmt.Sprintf("/runtimes/%s", name),
+				BinDir:      fmt.Sprintf("/runtimes/%s/bin", name),
+			})
+		})
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "save failed for runtime-%d", i)
+	}
+
+	for i := range n {
+		name := fmt.Sprintf("runtime-%d", i)
+		loaded, exists, err := rs.Load(name)
+		require.NoError(t, err)
+		assert.True(t, exists, "runtime %s missing", name)
+		assert.Equal(t, fmt.Sprintf("1.%d.0", i), loaded.Version)
+	}
+}
+
+func TestToolAndRuntimeStateStore_ConcurrentMixed(t *testing.T) {
+	f := newLockedFactory(t)
+	ts := f.ToolStore()
+	rs := f.RuntimeStore()
+
+	const nTools = 10
+	const nRuntimes = 5
+	var wg sync.WaitGroup
+
+	toolErrs := make([]error, nTools)
+	for i := range nTools {
+		wg.Go(func() {
+			name := fmt.Sprintf("tool-%d", i)
+			toolErrs[i] = ts.Save(name, &resource.ToolState{
+				Version: fmt.Sprintf("1.0.%d", i),
+			})
+		})
+	}
+
+	runtimeErrs := make([]error, nRuntimes)
+	for i := range nRuntimes {
+		wg.Go(func() {
+			name := fmt.Sprintf("runtime-%d", i)
+			runtimeErrs[i] = rs.Save(name, &resource.RuntimeState{
+				Version: fmt.Sprintf("2.%d.0", i),
+			})
+		})
+	}
+
+	wg.Wait()
+
+	for i, err := range toolErrs {
+		require.NoError(t, err, "tool save failed for tool-%d", i)
+	}
+	for i, err := range runtimeErrs {
+		require.NoError(t, err, "runtime save failed for runtime-%d", i)
+	}
+
+	for i := range nTools {
+		name := fmt.Sprintf("tool-%d", i)
+		_, exists, err := ts.Load(name)
+		require.NoError(t, err)
+		assert.True(t, exists, "tool %s missing", name)
+	}
+
+	for i := range nRuntimes {
+		name := fmt.Sprintf("runtime-%d", i)
+		_, exists, err := rs.Load(name)
+		require.NoError(t, err)
+		assert.True(t, exists, "runtime %s missing", name)
+	}
+}
+
+// --- Property-Based Tests ---
+
+func TestToolStateStore_Property_ConcurrentSavePreservesAll(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		f := newLockedFactoryRapid(t)
+		ts := f.ToolStore()
+
+		n := rapid.IntRange(2, 15).Draw(t, "numTools")
+		type toolDef struct {
+			name    string
+			version string
+		}
+		tools := make([]toolDef, n)
+		for i := range n {
+			tools[i] = toolDef{
+				name:    fmt.Sprintf("tool-%d", i),
+				version: rapid.StringMatching(`[0-9]+\.[0-9]+\.[0-9]+`).Draw(t, fmt.Sprintf("version-%d", i)),
+			}
+		}
+
+		var wg sync.WaitGroup
+		for _, td := range tools {
+			wg.Go(func() {
+				if err := ts.Save(td.name, &resource.ToolState{Version: td.version}); err != nil {
+					t.Fatalf("save failed for %s: %v", td.name, err)
+				}
+			})
+		}
+		wg.Wait()
+
+		// Property: every tool must be present with its version
+		for _, td := range tools {
+			loaded, exists, err := ts.Load(td.name)
+			if err != nil {
+				t.Fatalf("load failed for %s: %v", td.name, err)
+			}
+			if !exists {
+				t.Fatalf("tool %s missing after concurrent save", td.name)
+			}
+			if loaded.Version != td.version {
+				t.Fatalf("tool %s: got version %q, want %q", td.name, loaded.Version, td.version)
+			}
+		}
+	})
+}
+
+func TestToolStateStore_Property_SaveDeleteConsistency(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		f := newLockedFactoryRapid(t)
+		ts := f.ToolStore()
+
+		n := rapid.IntRange(2, 10).Draw(t, "numTools")
+
+		// Save all tools first (sequential)
+		for i := range n {
+			name := fmt.Sprintf("tool-%d", i)
+			if err := ts.Save(name, &resource.ToolState{Version: fmt.Sprintf("1.0.%d", i)}); err != nil {
+				t.Fatalf("save failed for %s: %v", name, err)
+			}
+		}
+
+		// Randomly decide which tools to delete
+		deleteSet := make(map[string]bool)
+		for i := range n {
+			if rapid.Bool().Draw(t, fmt.Sprintf("delete-%d", i)) {
+				deleteSet[fmt.Sprintf("tool-%d", i)] = true
+			}
+		}
+
+		// Concurrent delete
+		var wg sync.WaitGroup
+		for name := range deleteSet {
+			wg.Go(func() {
+				if err := ts.Delete(name); err != nil {
+					t.Fatalf("delete failed for %s: %v", name, err)
+				}
+			})
+		}
+		wg.Wait()
+
+		// Property: deleted tools gone, others remain
+		for i := range n {
+			name := fmt.Sprintf("tool-%d", i)
+			_, exists, err := ts.Load(name)
+			if err != nil {
+				t.Fatalf("load failed for %s: %v", name, err)
+			}
+			if deleteSet[name] && exists {
+				t.Fatalf("tool %s should have been deleted", name)
+			}
+			if !deleteSet[name] && !exists {
+				t.Fatalf("tool %s should still exist", name)
+			}
+		}
+	})
+}
+
+func TestToolStateStore_Property_ConcurrentSameTool_LastWriteWins(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		f := newLockedFactoryRapid(t)
+		ts := f.ToolStore()
+
+		// Multiple goroutines write different versions to the same tool name
+		versions := rapid.SliceOfN(
+			rapid.StringMatching(`[0-9]+\.[0-9]+\.[0-9]+`),
+			2, 10,
+		).Draw(t, "versions")
+
+		var wg sync.WaitGroup
+		for _, v := range versions {
+			wg.Go(func() {
+				_ = ts.Save("contested", &resource.ToolState{Version: v})
+			})
+		}
+		wg.Wait()
+
+		// Property: final value must be one of the written versions
+		loaded, exists, err := ts.Load("contested")
+		if err != nil {
+			t.Fatalf("load failed: %v", err)
+		}
+		if !exists {
+			t.Fatal("contested tool missing")
+		}
+		if !slices.Contains(versions, loaded.Version) {
+			t.Fatalf("final version %q not in written versions %v", loaded.Version, versions)
+		}
+	})
+}

--- a/internal/installer/executor/tool_store.go
+++ b/internal/installer/executor/tool_store.go
@@ -1,22 +1,23 @@
 package executor
 
 import (
+	"sync"
+
 	"github.com/terassyi/toto/internal/resource"
 	"github.com/terassyi/toto/internal/state"
 )
 
 // ToolStateStore adapts state.Store to the StateStore interface for Tools.
 type ToolStateStore struct {
+	mu    *sync.Mutex
 	store *state.Store[state.UserState]
-}
-
-// NewToolStateStore creates a new ToolStateStore.
-func NewToolStateStore(store *state.Store[state.UserState]) *ToolStateStore {
-	return &ToolStateStore{store: store}
 }
 
 // Load loads a tool state by name.
 func (s *ToolStateStore) Load(name string) (*resource.ToolState, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	st, err := s.store.Load()
 	if err != nil {
 		return nil, false, err
@@ -27,6 +28,9 @@ func (s *ToolStateStore) Load(name string) (*resource.ToolState, bool, error) {
 
 // Save saves a tool state.
 func (s *ToolStateStore) Save(name string, toolState *resource.ToolState) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	st, err := s.store.Load()
 	if err != nil {
 		return err
@@ -42,6 +46,9 @@ func (s *ToolStateStore) Save(name string, toolState *resource.ToolState) error 
 
 // Delete removes a tool from state.
 func (s *ToolStateStore) Delete(name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	st, err := s.store.Load()
 	if err != nil {
 		return err

--- a/internal/installer/runtime/installer.go
+++ b/internal/installer/runtime/installer.go
@@ -81,7 +81,12 @@ func (i *Installer) installDownload(ctx context.Context, spec *resource.RuntimeS
 
 	urlFilename := filepath.Base(spec.Source.URL)
 	archivePath := filepath.Join(tmpDir, urlFilename)
-	_, err = i.downloader.DownloadWithProgress(ctx, spec.Source.URL, archivePath, i.progressCallback)
+	// Prefer context callback for parallel execution
+	progressCb := download.CallbackFromContext[download.ProgressCallback](ctx)
+	if progressCb == nil {
+		progressCb = i.progressCallback
+	}
+	_, err = i.downloader.DownloadWithProgress(ctx, spec.Source.URL, archivePath, progressCb)
 	if err != nil {
 		return nil, fmt.Errorf("failed to download: %w", err)
 	}

--- a/internal/ui/cmdview_test.go
+++ b/internal/ui/cmdview_test.go
@@ -1,0 +1,312 @@
+package ui
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/terassyi/toto/internal/resource"
+)
+
+func TestCommandView_StartTask(t *testing.T) {
+	var buf bytes.Buffer
+	cv := NewCommandView(&buf)
+
+	cv.StartTask("Tool/rg", resource.KindTool, "rg", "14.1.1", "download")
+
+	cv.mu.Lock()
+	task, ok := cv.tasks["Tool/rg"]
+	cv.mu.Unlock()
+
+	require.True(t, ok)
+	assert.Equal(t, resource.KindTool, task.kind)
+	assert.Equal(t, "rg", task.name)
+	assert.Equal(t, "14.1.1", task.version)
+	assert.Equal(t, "download", task.method)
+	assert.False(t, task.done)
+}
+
+func TestCommandView_AddOutput(t *testing.T) {
+	var buf bytes.Buffer
+	cv := NewCommandView(&buf)
+
+	cv.StartTask("Tool/gopls", resource.KindTool, "gopls", "0.17.0", "go install")
+	cv.AddOutput("Tool/gopls", "downloading golang.org/x/tools...")
+
+	assert.Equal(t, "downloading golang.org/x/tools...", cv.LastLog("Tool/gopls"))
+}
+
+func TestCommandView_AddOutput_IgnoresUnknownTask(t *testing.T) {
+	var buf bytes.Buffer
+	cv := NewCommandView(&buf)
+
+	// Should not panic
+	cv.AddOutput("Tool/nonexistent", "some output")
+}
+
+func TestCommandView_AddOutput_IgnoresDoneTask(t *testing.T) {
+	var buf bytes.Buffer
+	cv := NewCommandView(&buf)
+
+	cv.StartTask("Tool/rg", resource.KindTool, "rg", "1.0.0", "download")
+	cv.CompleteTask("Tool/rg")
+	cv.AddOutput("Tool/rg", "should be ignored")
+
+	assert.Empty(t, cv.LastLog("Tool/rg"))
+}
+
+func TestCommandView_LastLog(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(cv *CommandView)
+		key      string
+		expected string
+	}{
+		{
+			name: "returns last log",
+			setup: func(cv *CommandView) {
+				cv.StartTask("Tool/a", resource.KindTool, "a", "1.0", "go install")
+				cv.AddOutput("Tool/a", "line 1")
+				cv.AddOutput("Tool/a", "line 2")
+			},
+			key:      "Tool/a",
+			expected: "line 2",
+		},
+		{
+			name:     "returns empty for unknown task",
+			setup:    func(cv *CommandView) {},
+			key:      "Tool/unknown",
+			expected: "",
+		},
+		{
+			name: "returns empty after complete",
+			setup: func(cv *CommandView) {
+				cv.StartTask("Tool/b", resource.KindTool, "b", "1.0", "download")
+				cv.AddOutput("Tool/b", "some log")
+				cv.CompleteTask("Tool/b")
+			},
+			key:      "Tool/b",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			cv := NewCommandView(&buf)
+			tt.setup(cv)
+			assert.Equal(t, tt.expected, cv.LastLog(tt.key))
+		})
+	}
+}
+
+func TestCommandView_CompleteTask(t *testing.T) {
+	var buf bytes.Buffer
+	cv := NewCommandView(&buf)
+
+	cv.StartTask("Tool/rg", resource.KindTool, "rg", "1.0.0", "download")
+	cv.AddOutput("Tool/rg", "some log")
+	cv.CompleteTask("Tool/rg")
+
+	cv.mu.Lock()
+	task := cv.tasks["Tool/rg"]
+	cv.mu.Unlock()
+
+	assert.True(t, task.done)
+	assert.Empty(t, task.lastLog)
+	assert.NoError(t, task.err)
+}
+
+func TestCommandView_FailTask(t *testing.T) {
+	var buf bytes.Buffer
+	cv := NewCommandView(&buf)
+
+	cv.StartTask("Tool/rg", resource.KindTool, "rg", "1.0.0", "download")
+	testErr := assert.AnError
+	cv.FailTask("Tool/rg", testErr)
+
+	cv.mu.Lock()
+	task := cv.tasks["Tool/rg"]
+	cv.mu.Unlock()
+
+	assert.True(t, task.done)
+	assert.Equal(t, testErr, task.err)
+}
+
+func TestCommandView_PrintTaskStart(t *testing.T) {
+	var buf bytes.Buffer
+	cv := NewCommandView(&buf)
+
+	cv.StartTask("Tool/gopls", resource.KindTool, "gopls", "0.17.0", "go install")
+	cv.PrintTaskStart("Tool/gopls")
+
+	output := buf.String()
+	assert.Contains(t, output, "Commands:")
+	assert.Contains(t, output, "Tool/")
+	assert.Contains(t, output, "gopls")
+	assert.Contains(t, output, "0.17.0")
+	assert.Contains(t, output, "go install")
+}
+
+func TestCommandView_PrintTaskStart_HeaderOnce(t *testing.T) {
+	var buf bytes.Buffer
+	cv := NewCommandView(&buf)
+
+	cv.StartTask("Tool/a", resource.KindTool, "a", "1.0", "go install")
+	cv.StartTask("Tool/b", resource.KindTool, "b", "2.0", "go install")
+	cv.PrintTaskStart("Tool/a")
+	cv.PrintTaskStart("Tool/b")
+
+	output := buf.String()
+	// "Commands:" header should appear exactly once
+	count := 0
+	for i := 0; i+len("Commands:") <= len(output); i++ {
+		if output[i:i+len("Commands:")] == "Commands:" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "Commands: header should appear exactly once")
+}
+
+func TestCommandView_PrintTaskStart_NilTask(t *testing.T) {
+	var buf bytes.Buffer
+	cv := NewCommandView(&buf)
+
+	// Should not panic
+	cv.PrintTaskStart("Tool/nonexistent")
+	assert.Empty(t, buf.String())
+}
+
+func TestCommandView_PrintOutput(t *testing.T) {
+	var buf bytes.Buffer
+	cv := NewCommandView(&buf)
+
+	cv.PrintOutput("go: downloading golang.org/x/tools v0.28.0")
+
+	output := buf.String()
+	assert.Contains(t, output, "go: downloading golang.org/x/tools v0.28.0")
+	assert.Contains(t, output, "    ") // indented
+}
+
+func TestCommandView_PrintTaskComplete_Success(t *testing.T) {
+	var buf bytes.Buffer
+	cv := NewCommandView(&buf)
+
+	cv.StartTask("Tool/gopls", resource.KindTool, "gopls", "0.17.0", "go install")
+	cv.CompleteTask("Tool/gopls")
+	cv.PrintTaskComplete("Tool/gopls")
+
+	output := buf.String()
+	assert.Contains(t, output, "gopls")
+	assert.Contains(t, output, "done")
+}
+
+func TestCommandView_PrintTaskComplete_Error(t *testing.T) {
+	var buf bytes.Buffer
+	cv := NewCommandView(&buf)
+
+	cv.StartTask("Tool/gopls", resource.KindTool, "gopls", "0.17.0", "go install")
+	cv.FailTask("Tool/gopls", assert.AnError)
+	cv.PrintTaskComplete("Tool/gopls")
+
+	output := buf.String()
+	assert.Contains(t, output, "gopls")
+	assert.Contains(t, output, "failed")
+}
+
+func TestCommandView_PrintTaskComplete_NilTask(t *testing.T) {
+	var buf bytes.Buffer
+	cv := NewCommandView(&buf)
+
+	// Should not panic
+	cv.PrintTaskComplete("Tool/nonexistent")
+	assert.Empty(t, buf.String())
+}
+
+func TestTruncateLine(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		maxLen int
+		want   string
+	}{
+		{
+			name:   "short line",
+			input:  "hello",
+			maxLen: 10,
+			want:   "hello",
+		},
+		{
+			name:   "exact length",
+			input:  "hello",
+			maxLen: 5,
+			want:   "hello",
+		},
+		{
+			name:   "long line truncated",
+			input:  "this is a very long line that needs truncation",
+			maxLen: 20,
+			want:   "this is a very lo...",
+		},
+		{
+			name:   "trims whitespace",
+			input:  "  hello  ",
+			maxLen: 10,
+			want:   "hello",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateLine(tt.input, tt.maxLen)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCommandView_ConcurrentAccess(t *testing.T) {
+	var buf bytes.Buffer
+	cv := NewCommandView(&buf)
+
+	const n = 20
+	var wg sync.WaitGroup
+	wg.Add(n * 3)
+
+	// Concurrent StartTask + AddOutput + LastLog
+	for i := range n {
+		key := resourceKey(resource.KindTool, func() string {
+			return "tool" + string(rune('a'+i))
+		}())
+
+		go func(k string) {
+			defer wg.Done()
+			cv.StartTask(k, resource.KindTool, "tool", "1.0", "download")
+		}(key)
+
+		go func(k string) {
+			defer wg.Done()
+			cv.AddOutput(k, "some output")
+		}(key)
+
+		go func(k string) {
+			defer wg.Done()
+			_ = cv.LastLog(k)
+		}(key)
+	}
+
+	wg.Wait()
+
+	// Concurrent CompleteTask + FailTask
+	wg.Add(n)
+	for i := range n {
+		key := resourceKey(resource.KindTool, "tool"+string(rune('a'+i)))
+		go func(k string) {
+			defer wg.Done()
+			cv.CompleteTask(k)
+		}(key)
+	}
+
+	wg.Wait()
+}

--- a/internal/ui/progress_test.go
+++ b/internal/ui/progress_test.go
@@ -1,0 +1,397 @@
+package ui
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/terassyi/toto/internal/installer/engine"
+	"github.com/terassyi/toto/internal/resource"
+	"github.com/vbauerster/mpb/v8"
+)
+
+// newNonTTYProgressManager creates a ProgressManager that behaves as non-TTY for testing.
+func newNonTTYProgressManager(w *bytes.Buffer) *ProgressManager {
+	return &ProgressManager{
+		w:       w,
+		isTTY:   false,
+		bars:    make(map[string]*mpb.Bar),
+		cmdView: NewCommandView(w),
+	}
+}
+
+func TestProgressManager_HandleEvent_DownloadStart_NonTTY(t *testing.T) {
+	var buf bytes.Buffer
+	pm := newNonTTYProgressManager(&buf)
+
+	pm.HandleEvent(engine.Event{
+		Type:    engine.EventStart,
+		Kind:    resource.KindTool,
+		Name:    "rg",
+		Version: "14.1.1",
+		Action:  resource.ActionInstall,
+		Method:  "download",
+	}, &ApplyResults{})
+
+	output := buf.String()
+	assert.Contains(t, output, "Downloads:")
+	assert.Contains(t, output, "rg")
+	assert.Contains(t, output, "14.1.1")
+}
+
+func TestProgressManager_HandleEvent_DownloadHeaderOnce_NonTTY(t *testing.T) {
+	var buf bytes.Buffer
+	pm := newNonTTYProgressManager(&buf)
+	results := &ApplyResults{}
+
+	// Send 3 download start events
+	for _, name := range []string{"rg", "fd", "bat"} {
+		pm.HandleEvent(engine.Event{
+			Type:    engine.EventStart,
+			Kind:    resource.KindTool,
+			Name:    name,
+			Version: "1.0.0",
+			Action:  resource.ActionInstall,
+			Method:  "download",
+		}, results)
+	}
+
+	output := buf.String()
+	assert.Equal(t, 1, strings.Count(output, "Downloads:"), "Downloads: header should appear exactly once")
+}
+
+func TestProgressManager_HandleEvent_CommandLifecycle_NonTTY(t *testing.T) {
+	var buf bytes.Buffer
+	pm := newNonTTYProgressManager(&buf)
+	results := &ApplyResults{}
+
+	// Start
+	pm.HandleEvent(engine.Event{
+		Type:    engine.EventStart,
+		Kind:    resource.KindTool,
+		Name:    "gopls",
+		Version: "0.17.0",
+		Action:  resource.ActionInstall,
+		Method:  "go install",
+	}, results)
+
+	// Output
+	pm.HandleEvent(engine.Event{
+		Type:   engine.EventOutput,
+		Kind:   resource.KindTool,
+		Name:   "gopls",
+		Output: "go: downloading golang.org/x/tools v0.28.0",
+		Method: "go install",
+	}, results)
+
+	// Complete
+	pm.HandleEvent(engine.Event{
+		Type:    engine.EventComplete,
+		Kind:    resource.KindTool,
+		Name:    "gopls",
+		Version: "0.17.0",
+		Action:  resource.ActionInstall,
+		Method:  "go install",
+	}, results)
+
+	output := buf.String()
+	assert.Contains(t, output, "Commands:")
+	assert.Contains(t, output, "gopls")
+	assert.Contains(t, output, "go install")
+	assert.Contains(t, output, "go: downloading golang.org/x/tools v0.28.0")
+	assert.Contains(t, output, "done")
+	assert.Equal(t, 1, results.Installed)
+}
+
+func TestProgressManager_HandleEvent_CommandError_NonTTY(t *testing.T) {
+	var buf bytes.Buffer
+	pm := newNonTTYProgressManager(&buf)
+	results := &ApplyResults{}
+
+	pm.HandleEvent(engine.Event{
+		Type:   engine.EventStart,
+		Kind:   resource.KindTool,
+		Name:   "gopls",
+		Method: "go install",
+	}, results)
+
+	pm.HandleEvent(engine.Event{
+		Type:   engine.EventError,
+		Kind:   resource.KindTool,
+		Name:   "gopls",
+		Method: "go install",
+		Error:  fmt.Errorf("build failed"),
+	}, results)
+
+	output := buf.String()
+	assert.Contains(t, output, "failed")
+	assert.Equal(t, 1, results.Failed)
+}
+
+func TestProgressManager_HandleEvent_DownloadError_NonTTY(t *testing.T) {
+	var buf bytes.Buffer
+	pm := newNonTTYProgressManager(&buf)
+	results := &ApplyResults{}
+
+	pm.HandleEvent(engine.Event{
+		Type:   engine.EventStart,
+		Kind:   resource.KindTool,
+		Name:   "rg",
+		Method: "download",
+	}, results)
+
+	pm.HandleEvent(engine.Event{
+		Type:   engine.EventError,
+		Kind:   resource.KindTool,
+		Name:   "rg",
+		Method: "download",
+		Error:  fmt.Errorf("404 not found"),
+	}, results)
+
+	output := buf.String()
+	assert.Contains(t, output, "failed")
+	assert.Contains(t, output, "404 not found")
+	assert.Equal(t, 1, results.Failed)
+}
+
+func TestProgressManager_UpdateResults(t *testing.T) {
+	tests := []struct {
+		name      string
+		action    resource.ActionType
+		wantField string
+	}{
+		{"install", resource.ActionInstall, "Installed"},
+		{"reinstall", resource.ActionReinstall, "Installed"},
+		{"upgrade", resource.ActionUpgrade, "Upgraded"},
+		{"remove", resource.ActionRemove, "Removed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := &ApplyResults{}
+			updateResults(tt.action, results)
+			switch tt.wantField {
+			case "Installed":
+				assert.Equal(t, 1, results.Installed)
+			case "Upgraded":
+				assert.Equal(t, 1, results.Upgraded)
+			case "Removed":
+				assert.Equal(t, 1, results.Removed)
+			}
+		})
+	}
+}
+
+func TestProgressManager_HandleEvent_MixedDownloadAndCommand_NonTTY(t *testing.T) {
+	var buf bytes.Buffer
+	pm := newNonTTYProgressManager(&buf)
+	results := &ApplyResults{}
+
+	// Download tool
+	pm.HandleEvent(engine.Event{
+		Type:    engine.EventStart,
+		Kind:    resource.KindTool,
+		Name:    "rg",
+		Version: "14.1.1",
+		Action:  resource.ActionInstall,
+		Method:  "download",
+	}, results)
+
+	pm.HandleEvent(engine.Event{
+		Type:    engine.EventComplete,
+		Kind:    resource.KindTool,
+		Name:    "rg",
+		Version: "14.1.1",
+		Action:  resource.ActionInstall,
+		Method:  "download",
+	}, results)
+
+	// Delegation tool
+	pm.HandleEvent(engine.Event{
+		Type:    engine.EventStart,
+		Kind:    resource.KindTool,
+		Name:    "gopls",
+		Version: "0.17.0",
+		Action:  resource.ActionInstall,
+		Method:  "go install",
+	}, results)
+
+	pm.HandleEvent(engine.Event{
+		Type:    engine.EventComplete,
+		Kind:    resource.KindTool,
+		Name:    "gopls",
+		Version: "0.17.0",
+		Action:  resource.ActionInstall,
+		Method:  "go install",
+	}, results)
+
+	output := buf.String()
+	assert.Contains(t, output, "Downloads:")
+	assert.Contains(t, output, "Commands:")
+	assert.Equal(t, 2, results.Installed)
+}
+
+func TestProgressManager_IsDownloadMethod(t *testing.T) {
+	tests := []struct {
+		method string
+		want   bool
+	}{
+		{"download", true},
+		{"", true},
+		{"go install", false},
+		{"brew install", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			assert.Equal(t, tt.want, isDownloadMethod(tt.method))
+		})
+	}
+}
+
+func TestProgressManager_ResourceKey(t *testing.T) {
+	assert.Equal(t, "Tool/rg", resourceKey(resource.KindTool, "rg"))
+	assert.Equal(t, "Runtime/go", resourceKey(resource.KindRuntime, "go"))
+}
+
+func TestPrintApplySummary_NoChanges(t *testing.T) {
+	var buf bytes.Buffer
+	PrintApplySummary(&buf, &ApplyResults{})
+	output := buf.String()
+	assert.Contains(t, output, "No changes to apply")
+}
+
+func TestPrintApplySummary_WithResults(t *testing.T) {
+	var buf bytes.Buffer
+	PrintApplySummary(&buf, &ApplyResults{
+		Installed: 3,
+		Upgraded:  1,
+		Failed:    1,
+	})
+	output := buf.String()
+	assert.Contains(t, output, "Installed: 3")
+	assert.Contains(t, output, "Upgraded:  1")
+	assert.Contains(t, output, "Failed:    1")
+	assert.Contains(t, output, "completed with errors")
+}
+
+func TestPrintApplySummary_AllSuccess(t *testing.T) {
+	var buf bytes.Buffer
+	PrintApplySummary(&buf, &ApplyResults{
+		Installed: 2,
+	})
+	output := buf.String()
+	assert.Contains(t, output, "Apply complete!")
+}
+
+func TestProgressManager_ConcurrentHandleEvent_NonTTY(t *testing.T) {
+	var buf bytes.Buffer
+	pm := newNonTTYProgressManager(&buf)
+	results := &ApplyResults{}
+
+	const n = 10
+	var wg sync.WaitGroup
+	wg.Add(n)
+
+	for i := range n {
+		go func(idx int) {
+			defer wg.Done()
+			name := fmt.Sprintf("tool%d", idx)
+
+			pm.HandleEvent(engine.Event{
+				Type:    engine.EventStart,
+				Kind:    resource.KindTool,
+				Name:    name,
+				Version: "1.0.0",
+				Action:  resource.ActionInstall,
+				Method:  "download",
+			}, results)
+
+			pm.HandleEvent(engine.Event{
+				Type:    engine.EventComplete,
+				Kind:    resource.KindTool,
+				Name:    name,
+				Version: "1.0.0",
+				Action:  resource.ActionInstall,
+				Method:  "download",
+			}, results)
+		}(i)
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, n, results.Installed)
+	// Downloads: header should appear exactly once
+	assert.Equal(t, 1, strings.Count(buf.String(), "Downloads:"))
+}
+
+func TestProgressManager_ConcurrentMixedEvents_NonTTY(t *testing.T) {
+	var buf bytes.Buffer
+	pm := newNonTTYProgressManager(&buf)
+	results := &ApplyResults{}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Download events
+	go func() {
+		defer wg.Done()
+		for i := range 5 {
+			name := fmt.Sprintf("dl%d", i)
+			pm.HandleEvent(engine.Event{
+				Type:    engine.EventStart,
+				Kind:    resource.KindTool,
+				Name:    name,
+				Version: "1.0.0",
+				Action:  resource.ActionInstall,
+				Method:  "download",
+			}, results)
+			pm.HandleEvent(engine.Event{
+				Type:    engine.EventComplete,
+				Kind:    resource.KindTool,
+				Name:    name,
+				Version: "1.0.0",
+				Action:  resource.ActionInstall,
+				Method:  "download",
+			}, results)
+		}
+	}()
+
+	// Delegation events
+	go func() {
+		defer wg.Done()
+		for i := range 5 {
+			name := fmt.Sprintf("cmd%d", i)
+			pm.HandleEvent(engine.Event{
+				Type:    engine.EventStart,
+				Kind:    resource.KindTool,
+				Name:    name,
+				Version: "1.0.0",
+				Action:  resource.ActionInstall,
+				Method:  "go install",
+			}, results)
+			pm.HandleEvent(engine.Event{
+				Type:   engine.EventOutput,
+				Kind:   resource.KindTool,
+				Name:   name,
+				Output: "building...",
+				Method: "go install",
+			}, results)
+			pm.HandleEvent(engine.Event{
+				Type:    engine.EventComplete,
+				Kind:    resource.KindTool,
+				Name:    name,
+				Version: "1.0.0",
+				Action:  resource.ActionInstall,
+				Method:  "go install",
+			}, results)
+		}
+	}()
+
+	wg.Wait()
+
+	assert.Equal(t, 10, results.Installed)
+}

--- a/tests/engine_test.go
+++ b/tests/engine_test.go
@@ -4,9 +4,13 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,10 +23,12 @@ import (
 	"github.com/terassyi/toto/internal/state"
 )
 
-// mockToolInstaller is a mock implementation of engine.ToolInstaller.
+// mockToolInstaller is a thread-safe mock implementation of engine.ToolInstaller.
 type mockToolInstaller struct {
-	installed map[string]*resource.ToolState
-	removed   map[string]bool
+	mu          sync.Mutex
+	installed   map[string]*resource.ToolState
+	removed     map[string]bool
+	installFunc func(ctx context.Context, res *resource.Tool, name string) (*resource.ToolState, error)
 }
 
 func newMockToolInstaller() *mockToolInstaller {
@@ -32,7 +38,10 @@ func newMockToolInstaller() *mockToolInstaller {
 	}
 }
 
-func (m *mockToolInstaller) Install(_ context.Context, res *resource.Tool, name string) (*resource.ToolState, error) {
+func (m *mockToolInstaller) Install(ctx context.Context, res *resource.Tool, name string) (*resource.ToolState, error) {
+	if m.installFunc != nil {
+		return m.installFunc(ctx, res, name)
+	}
 	st := &resource.ToolState{
 		InstallerRef: res.ToolSpec.InstallerRef,
 		RuntimeRef:   res.ToolSpec.RuntimeRef,
@@ -40,13 +49,17 @@ func (m *mockToolInstaller) Install(_ context.Context, res *resource.Tool, name 
 		Version:      res.ToolSpec.Version,
 		BinPath:      filepath.Join("/mock/bin", name),
 	}
+	m.mu.Lock()
 	m.installed[name] = st
+	m.mu.Unlock()
 	return st, nil
 }
 
 func (m *mockToolInstaller) Remove(_ context.Context, _ *resource.ToolState, name string) error {
+	m.mu.Lock()
 	m.removed[name] = true
 	delete(m.installed, name)
+	m.mu.Unlock()
 	return nil
 }
 
@@ -56,12 +69,14 @@ func (m *mockToolInstaller) RegisterInstaller(_ string, _ *tool.InstallerInfo) {
 
 func (m *mockToolInstaller) SetProgressCallback(_ download.ProgressCallback) {}
 
-func (m *mockToolInstaller) SetOutputCallback(_ func(line string)) {}
+func (m *mockToolInstaller) SetOutputCallback(_ download.OutputCallback) {}
 
-// mockRuntimeInstaller is a mock implementation of engine.RuntimeInstaller.
+// mockRuntimeInstaller is a thread-safe mock implementation of engine.RuntimeInstaller.
 type mockRuntimeInstaller struct {
-	installed map[string]*resource.RuntimeState
-	removed   map[string]bool
+	mu          sync.Mutex
+	installed   map[string]*resource.RuntimeState
+	removed     map[string]bool
+	installFunc func(ctx context.Context, res *resource.Runtime, name string) (*resource.RuntimeState, error)
 }
 
 func newMockRuntimeInstaller() *mockRuntimeInstaller {
@@ -71,7 +86,10 @@ func newMockRuntimeInstaller() *mockRuntimeInstaller {
 	}
 }
 
-func (m *mockRuntimeInstaller) Install(_ context.Context, res *resource.Runtime, name string) (*resource.RuntimeState, error) {
+func (m *mockRuntimeInstaller) Install(ctx context.Context, res *resource.Runtime, name string) (*resource.RuntimeState, error) {
+	if m.installFunc != nil {
+		return m.installFunc(ctx, res, name)
+	}
 	// Resolve BinDir: use explicit BinDir, or fall back to ToolBinPath
 	binDir := res.RuntimeSpec.BinDir
 	if binDir == "" {
@@ -88,13 +106,17 @@ func (m *mockRuntimeInstaller) Install(_ context.Context, res *resource.Runtime,
 		Env:         res.RuntimeSpec.Env,
 		Commands:    res.RuntimeSpec.Commands,
 	}
+	m.mu.Lock()
 	m.installed[name] = st
+	m.mu.Unlock()
 	return st, nil
 }
 
 func (m *mockRuntimeInstaller) Remove(_ context.Context, _ *resource.RuntimeState, name string) error {
+	m.mu.Lock()
 	m.removed[name] = true
 	delete(m.installed, name)
+	m.mu.Unlock()
 	return nil
 }
 
@@ -1018,6 +1040,860 @@ goRuntime: {
 	assert.Contains(t, st.Runtimes, "go")
 	assert.Equal(t, "~/go/bin", st.Runtimes["go"].BinDir)
 	assert.Equal(t, "~/go/bin", st.Runtimes["go"].ToolBinPath)
+}
+
+// TestEngine_Apply_ToolProgressCallback tests that the engine injects per-node progress callbacks
+// into context and that those callbacks generate correct engine events with node-specific data.
+func TestEngine_Apply_ToolProgressCallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "config")
+	stateDir := filepath.Join(tmpDir, "state")
+	require.NoError(t, os.MkdirAll(configDir, 0755))
+
+	cueContent := `package toto
+
+ripgrep: {
+	apiVersion: "toto.terassyi.net/v1beta1"
+	kind: "Tool"
+	metadata: name: "ripgrep"
+	spec: {
+		installerRef: "download"
+		version: "14.0.0"
+		source: { url: "https://example.com/rg.tar.gz" }
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "tool.cue"), []byte(cueContent), 0644))
+
+	resources := loadResources(t, configDir)
+
+	store, err := state.NewStore[state.UserState](stateDir)
+	require.NoError(t, err)
+
+	mockTool := &mockToolInstaller{
+		installed: make(map[string]*resource.ToolState),
+		removed:   make(map[string]bool),
+		installFunc: func(ctx context.Context, res *resource.Tool, name string) (*resource.ToolState, error) {
+			// Extract per-node progress callback from context (same as real installer does)
+			progressCb := download.CallbackFromContext[download.ProgressCallback](ctx)
+			require.NotNil(t, progressCb, "progress callback should be injected into context by engine")
+
+			// Simulate download progress
+			progressCb(512, 1024)
+			progressCb(1024, 1024)
+
+			return &resource.ToolState{
+				InstallerRef: res.ToolSpec.InstallerRef,
+				Version:      res.ToolSpec.Version,
+				BinPath:      filepath.Join("/mock/bin", name),
+			}, nil
+		},
+	}
+
+	mockRuntime := newMockRuntimeInstaller()
+	eng := engine.NewEngine(mockTool, mockRuntime, store)
+
+	// Capture events to verify callback generates correct engine events
+	var mu sync.Mutex
+	var progressEvents []engine.Event
+	eng.SetEventHandler(func(event engine.Event) {
+		if event.Type == engine.EventProgress {
+			mu.Lock()
+			progressEvents = append(progressEvents, event)
+			mu.Unlock()
+		}
+	})
+
+	err = eng.Apply(context.Background(), resources)
+	require.NoError(t, err)
+
+	// Verify progress events were generated with correct node-specific data
+	mu.Lock()
+	defer mu.Unlock()
+
+	require.Len(t, progressEvents, 2)
+
+	assert.Equal(t, resource.KindTool, progressEvents[0].Kind)
+	assert.Equal(t, "ripgrep", progressEvents[0].Name)
+	assert.Equal(t, "14.0.0", progressEvents[0].Version)
+	assert.Equal(t, int64(512), progressEvents[0].Downloaded)
+	assert.Equal(t, int64(1024), progressEvents[0].Total)
+	assert.Equal(t, "download", progressEvents[0].Method)
+
+	assert.Equal(t, int64(1024), progressEvents[1].Downloaded)
+	assert.Equal(t, int64(1024), progressEvents[1].Total)
+}
+
+// TestEngine_Apply_ToolOutputCallback tests that the engine injects per-node output callbacks
+// for delegation-pattern tools via context.
+func TestEngine_Apply_ToolOutputCallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "config")
+	stateDir := filepath.Join(tmpDir, "state")
+	require.NoError(t, os.MkdirAll(configDir, 0755))
+
+	cueContent := `package toto
+
+jq: {
+	apiVersion: "toto.terassyi.net/v1beta1"
+	kind: "Tool"
+	metadata: name: "jq"
+	spec: {
+		installerRef: "download"
+		version: "1.7.1"
+		source: { url: "https://example.com/jq" }
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "tool.cue"), []byte(cueContent), 0644))
+
+	resources := loadResources(t, configDir)
+
+	store, err := state.NewStore[state.UserState](stateDir)
+	require.NoError(t, err)
+
+	mockTool := &mockToolInstaller{
+		installed: make(map[string]*resource.ToolState),
+		removed:   make(map[string]bool),
+		installFunc: func(ctx context.Context, res *resource.Tool, name string) (*resource.ToolState, error) {
+			// Extract per-node output callback from context
+			outputCb := download.CallbackFromContext[download.OutputCallback](ctx)
+			require.NotNil(t, outputCb, "output callback should be injected into context by engine")
+
+			// Simulate command output
+			outputCb("downloading jq...")
+			outputCb("installing jq to /usr/local/bin")
+
+			return &resource.ToolState{
+				InstallerRef: res.ToolSpec.InstallerRef,
+				Version:      res.ToolSpec.Version,
+				BinPath:      filepath.Join("/mock/bin", name),
+			}, nil
+		},
+	}
+
+	mockRuntime := newMockRuntimeInstaller()
+	eng := engine.NewEngine(mockTool, mockRuntime, store)
+
+	var mu sync.Mutex
+	var outputEvents []engine.Event
+	eng.SetEventHandler(func(event engine.Event) {
+		if event.Type == engine.EventOutput {
+			mu.Lock()
+			outputEvents = append(outputEvents, event)
+			mu.Unlock()
+		}
+	})
+
+	err = eng.Apply(context.Background(), resources)
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	require.Len(t, outputEvents, 2)
+
+	assert.Equal(t, resource.KindTool, outputEvents[0].Kind)
+	assert.Equal(t, "jq", outputEvents[0].Name)
+	assert.Equal(t, "1.7.1", outputEvents[0].Version)
+	assert.Equal(t, "downloading jq...", outputEvents[0].Output)
+
+	assert.Equal(t, "installing jq to /usr/local/bin", outputEvents[1].Output)
+}
+
+// TestEngine_Apply_RuntimeProgressCallback tests that the engine injects per-node progress
+// callbacks into context for runtime installations.
+func TestEngine_Apply_RuntimeProgressCallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "config")
+	stateDir := filepath.Join(tmpDir, "state")
+	require.NoError(t, os.MkdirAll(configDir, 0755))
+
+	cueContent := `package toto
+
+goRuntime: {
+	apiVersion: "toto.terassyi.net/v1beta1"
+	kind: "Runtime"
+	metadata: name: "go"
+	spec: {
+		installerRef: "download"
+		version: "1.25.5"
+		source: { url: "https://go.dev/dl/go1.25.5.linux-amd64.tar.gz" }
+		binaries: ["go", "gofmt"]
+		toolBinPath: "~/go/bin"
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "runtime.cue"), []byte(cueContent), 0644))
+
+	resources := loadResources(t, configDir)
+
+	store, err := state.NewStore[state.UserState](stateDir)
+	require.NoError(t, err)
+
+	mockRuntime := &mockRuntimeInstaller{
+		installed: make(map[string]*resource.RuntimeState),
+		removed:   make(map[string]bool),
+		installFunc: func(ctx context.Context, res *resource.Runtime, name string) (*resource.RuntimeState, error) {
+			// Extract per-node progress callback from context
+			progressCb := download.CallbackFromContext[download.ProgressCallback](ctx)
+			require.NotNil(t, progressCb, "progress callback should be injected into context by engine")
+
+			// Simulate download progress
+			progressCb(0, 50_000_000)
+			progressCb(25_000_000, 50_000_000)
+			progressCb(50_000_000, 50_000_000)
+
+			binDir := res.RuntimeSpec.BinDir
+			if binDir == "" {
+				binDir = res.RuntimeSpec.ToolBinPath
+			}
+			return &resource.RuntimeState{
+				Type:        res.RuntimeSpec.Type,
+				Version:     res.RuntimeSpec.Version,
+				InstallPath: filepath.Join("/mock/runtimes", name, res.RuntimeSpec.Version),
+				Binaries:    res.RuntimeSpec.Binaries,
+				BinDir:      binDir,
+				ToolBinPath: res.RuntimeSpec.ToolBinPath,
+			}, nil
+		},
+	}
+
+	mockTool := newMockToolInstaller()
+	eng := engine.NewEngine(mockTool, mockRuntime, store)
+
+	var mu sync.Mutex
+	var progressEvents []engine.Event
+	eng.SetEventHandler(func(event engine.Event) {
+		if event.Type == engine.EventProgress {
+			mu.Lock()
+			progressEvents = append(progressEvents, event)
+			mu.Unlock()
+		}
+	})
+
+	err = eng.Apply(context.Background(), resources)
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	require.Len(t, progressEvents, 3)
+
+	// All events should have correct runtime-specific metadata
+	for _, ev := range progressEvents {
+		assert.Equal(t, resource.KindRuntime, ev.Kind)
+		assert.Equal(t, "go", ev.Name)
+		assert.Equal(t, "1.25.5", ev.Version)
+	}
+
+	assert.Equal(t, int64(0), progressEvents[0].Downloaded)
+	assert.Equal(t, int64(50_000_000), progressEvents[0].Total)
+	assert.Equal(t, int64(25_000_000), progressEvents[1].Downloaded)
+	assert.Equal(t, int64(50_000_000), progressEvents[2].Downloaded)
+}
+
+// TestEngine_Apply_ParallelCallbackIsolation tests that parallel tool installations each receive
+// their own isolated callback that generates events with the correct tool name.
+func TestEngine_Apply_ParallelCallbackIsolation(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "config")
+	stateDir := filepath.Join(tmpDir, "state")
+	require.NoError(t, os.MkdirAll(configDir, 0755))
+
+	cueContent := `package toto
+
+ripgrep: {
+	apiVersion: "toto.terassyi.net/v1beta1"
+	kind: "Tool"
+	metadata: name: "ripgrep"
+	spec: {
+		installerRef: "download"
+		version: "14.0.0"
+		source: { url: "https://example.com/rg.tar.gz" }
+	}
+}
+
+fd: {
+	apiVersion: "toto.terassyi.net/v1beta1"
+	kind: "Tool"
+	metadata: name: "fd"
+	spec: {
+		installerRef: "download"
+		version: "9.0.0"
+		source: { url: "https://example.com/fd.tar.gz" }
+	}
+}
+
+bat: {
+	apiVersion: "toto.terassyi.net/v1beta1"
+	kind: "Tool"
+	metadata: name: "bat"
+	spec: {
+		installerRef: "download"
+		version: "0.24.0"
+		source: { url: "https://example.com/bat.tar.gz" }
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "tools.cue"), []byte(cueContent), 0644))
+
+	resources := loadResources(t, configDir)
+
+	store, err := state.NewStore[state.UserState](stateDir)
+	require.NoError(t, err)
+
+	mockTool := &mockToolInstaller{
+		installed: make(map[string]*resource.ToolState),
+		removed:   make(map[string]bool),
+		installFunc: func(ctx context.Context, res *resource.Tool, name string) (*resource.ToolState, error) {
+			progressCb := download.CallbackFromContext[download.ProgressCallback](ctx)
+			require.NotNil(t, progressCb)
+
+			// Each tool reports progress with different values
+			progressCb(100, 200) // Reports {100, 200} tagged with this tool's name
+
+			time.Sleep(20 * time.Millisecond) // Allow interleaving
+
+			progressCb(200, 200) // Reports {200, 200} tagged with this tool's name
+
+			return &resource.ToolState{
+				InstallerRef: res.ToolSpec.InstallerRef,
+				Version:      res.ToolSpec.Version,
+				BinPath:      filepath.Join("/mock/bin", name),
+			}, nil
+		},
+	}
+
+	mockRuntime := newMockRuntimeInstaller()
+	eng := engine.NewEngine(mockTool, mockRuntime, store)
+
+	var mu sync.Mutex
+	eventsByTool := make(map[string][]engine.Event)
+	eng.SetEventHandler(func(event engine.Event) {
+		if event.Type == engine.EventProgress {
+			mu.Lock()
+			eventsByTool[event.Name] = append(eventsByTool[event.Name], event)
+			mu.Unlock()
+		}
+	})
+
+	err = eng.Apply(context.Background(), resources)
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Each tool should have exactly 2 progress events
+	for _, toolName := range []string{"ripgrep", "fd", "bat"} {
+		events, ok := eventsByTool[toolName]
+		require.True(t, ok, "should have events for %s", toolName)
+		assert.Len(t, events, 2, "should have 2 progress events for %s", toolName)
+
+		// Verify all events are correctly tagged with the right tool name
+		for _, ev := range events {
+			assert.Equal(t, toolName, ev.Name, "event should be tagged with correct tool name")
+			assert.Equal(t, resource.KindTool, ev.Kind)
+		}
+	}
+
+	// Verify no cross-contamination: total of 6 events (2 per tool * 3 tools)
+	totalEvents := 0
+	for _, events := range eventsByTool {
+		totalEvents += len(events)
+	}
+	assert.Equal(t, 6, totalEvents)
+}
+
+// TestEngine_Apply_ParallelExecution tests that independent tools are installed concurrently.
+func TestEngine_Apply_ParallelExecution(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "config")
+	stateDir := filepath.Join(tmpDir, "state")
+	require.NoError(t, os.MkdirAll(configDir, 0755))
+
+	cueContent := `package toto
+
+ripgrep: {
+	apiVersion: "toto.terassyi.net/v1beta1"
+	kind: "Tool"
+	metadata: name: "ripgrep"
+	spec: {
+		installerRef: "download"
+		version: "14.0.0"
+		source: { url: "https://example.com/rg" }
+	}
+}
+
+fd: {
+	apiVersion: "toto.terassyi.net/v1beta1"
+	kind: "Tool"
+	metadata: name: "fd"
+	spec: {
+		installerRef: "download"
+		version: "9.0.0"
+		source: { url: "https://example.com/fd" }
+	}
+}
+
+bat: {
+	apiVersion: "toto.terassyi.net/v1beta1"
+	kind: "Tool"
+	metadata: name: "bat"
+	spec: {
+		installerRef: "download"
+		version: "0.24.0"
+		source: { url: "https://example.com/bat" }
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "tools.cue"), []byte(cueContent), 0644))
+
+	resources := loadResources(t, configDir)
+
+	store, err := state.NewStore[state.UserState](stateDir)
+	require.NoError(t, err)
+
+	var concurrentCount atomic.Int32
+	var maxConcurrent atomic.Int32
+
+	var mu sync.Mutex
+	installed := make(map[string]*resource.ToolState)
+
+	mockTool := &mockToolInstaller{
+		installed: make(map[string]*resource.ToolState),
+		removed:   make(map[string]bool),
+		installFunc: func(ctx context.Context, res *resource.Tool, name string) (*resource.ToolState, error) {
+			current := concurrentCount.Add(1)
+			defer concurrentCount.Add(-1)
+
+			for {
+				old := maxConcurrent.Load()
+				if current <= old || maxConcurrent.CompareAndSwap(old, current) {
+					break
+				}
+			}
+
+			time.Sleep(50 * time.Millisecond)
+
+			st := &resource.ToolState{
+				InstallerRef: res.ToolSpec.InstallerRef,
+				Version:      res.ToolSpec.Version,
+				BinPath:      filepath.Join("/mock/bin", name),
+			}
+			mu.Lock()
+			installed[name] = st
+			mu.Unlock()
+			return st, nil
+		},
+	}
+
+	mockRuntime := newMockRuntimeInstaller()
+	eng := engine.NewEngine(mockTool, mockRuntime, store)
+
+	err = eng.Apply(context.Background(), resources)
+	require.NoError(t, err)
+
+	// All tools should be installed
+	assert.Len(t, installed, 3)
+	assert.Contains(t, installed, "ripgrep")
+	assert.Contains(t, installed, "fd")
+	assert.Contains(t, installed, "bat")
+
+	// Verify parallelism occurred
+	assert.Greater(t, maxConcurrent.Load(), int32(1), "expected concurrent execution")
+
+	// Verify state
+	require.NoError(t, store.Lock())
+	st, err := store.Load()
+	require.NoError(t, err)
+	_ = store.Unlock()
+
+	assert.Len(t, st.Tools, 3)
+}
+
+// TestEngine_Apply_ParallelCancelOnError tests that a failure cancels other running tasks.
+func TestEngine_Apply_ParallelCancelOnError(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "config")
+	stateDir := filepath.Join(tmpDir, "state")
+	require.NoError(t, os.MkdirAll(configDir, 0755))
+
+	cueContent := `package toto
+
+ripgrep: {
+	apiVersion: "toto.terassyi.net/v1beta1"
+	kind: "Tool"
+	metadata: name: "ripgrep"
+	spec: {
+		installerRef: "download"
+		version: "14.0.0"
+		source: { url: "https://example.com/rg" }
+	}
+}
+
+fd: {
+	apiVersion: "toto.terassyi.net/v1beta1"
+	kind: "Tool"
+	metadata: name: "fd"
+	spec: {
+		installerRef: "download"
+		version: "9.0.0"
+		source: { url: "https://example.com/fd" }
+	}
+}
+
+bat: {
+	apiVersion: "toto.terassyi.net/v1beta1"
+	kind: "Tool"
+	metadata: name: "bat"
+	spec: {
+		installerRef: "download"
+		version: "0.24.0"
+		source: { url: "https://example.com/bat" }
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "tools.cue"), []byte(cueContent), 0644))
+
+	resources := loadResources(t, configDir)
+
+	store, err := state.NewStore[state.UserState](stateDir)
+	require.NoError(t, err)
+
+	var mu sync.Mutex
+	installed := make(map[string]bool)
+
+	mockTool := &mockToolInstaller{
+		installed: make(map[string]*resource.ToolState),
+		removed:   make(map[string]bool),
+		installFunc: func(ctx context.Context, res *resource.Tool, name string) (*resource.ToolState, error) {
+			if name == "fd" {
+				return nil, fmt.Errorf("simulated install failure for fd")
+			}
+
+			// Other tools wait to be cancelled
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(200 * time.Millisecond):
+			}
+
+			mu.Lock()
+			installed[name] = true
+			mu.Unlock()
+
+			return &resource.ToolState{
+				InstallerRef: res.ToolSpec.InstallerRef,
+				Version:      res.ToolSpec.Version,
+				BinPath:      filepath.Join("/mock/bin", name),
+			}, nil
+		},
+	}
+
+	mockRuntime := newMockRuntimeInstaller()
+	eng := engine.NewEngine(mockTool, mockRuntime, store)
+
+	err = eng.Apply(context.Background(), resources)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fd")
+}
+
+// TestEngine_Apply_ParallelismLimit tests that the parallelism limit is respected.
+func TestEngine_Apply_ParallelismLimit(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "config")
+	stateDir := filepath.Join(tmpDir, "state")
+	require.NoError(t, os.MkdirAll(configDir, 0755))
+
+	cueContent := `package toto
+`
+	toolDefs := []struct{ cueKey, name string }{
+		{"toolA", "tool-a"}, {"toolB", "tool-b"}, {"toolC", "tool-c"},
+		{"toolD", "tool-d"}, {"toolE", "tool-e"}, {"toolF", "tool-f"},
+	}
+	for _, td := range toolDefs {
+		cueContent += fmt.Sprintf(`
+%s: {
+	apiVersion: "toto.terassyi.net/v1beta1"
+	kind: "Tool"
+	metadata: name: "%s"
+	spec: {
+		installerRef: "download"
+		version: "1.0.0"
+		source: { url: "https://example.com/%s" }
+	}
+}
+`, td.cueKey, td.name, td.name)
+	}
+
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "tools.cue"), []byte(cueContent), 0644))
+
+	resources := loadResources(t, configDir)
+
+	store, err := state.NewStore[state.UserState](stateDir)
+	require.NoError(t, err)
+
+	var concurrentCount atomic.Int32
+	var maxConcurrent atomic.Int32
+
+	mockTool := &mockToolInstaller{
+		installed: make(map[string]*resource.ToolState),
+		removed:   make(map[string]bool),
+		installFunc: func(ctx context.Context, res *resource.Tool, name string) (*resource.ToolState, error) {
+			current := concurrentCount.Add(1)
+			defer concurrentCount.Add(-1)
+
+			for {
+				old := maxConcurrent.Load()
+				if current <= old || maxConcurrent.CompareAndSwap(old, current) {
+					break
+				}
+			}
+
+			time.Sleep(50 * time.Millisecond)
+
+			return &resource.ToolState{
+				InstallerRef: res.ToolSpec.InstallerRef,
+				Version:      res.ToolSpec.Version,
+				BinPath:      filepath.Join("/mock/bin", name),
+			}, nil
+		},
+	}
+
+	mockRuntime := newMockRuntimeInstaller()
+	eng := engine.NewEngine(mockTool, mockRuntime, store)
+	eng.SetParallelism(2)
+
+	err = eng.Apply(context.Background(), resources)
+	require.NoError(t, err)
+
+	assert.LessOrEqual(t, maxConcurrent.Load(), int32(2), "concurrent execution should not exceed parallelism limit")
+	assert.Greater(t, maxConcurrent.Load(), int32(0), "should have some concurrent execution")
+
+	// Verify state
+	require.NoError(t, store.Lock())
+	st, err := store.Load()
+	require.NoError(t, err)
+	_ = store.Unlock()
+
+	assert.Len(t, st.Tools, 6)
+}
+
+// TestEngine_Apply_RuntimeBeforeTool tests that Runtimes always execute before Tools.
+func TestEngine_Apply_RuntimeBeforeTool(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "config")
+	stateDir := filepath.Join(tmpDir, "state")
+	require.NoError(t, os.MkdirAll(configDir, 0755))
+
+	// Runtime and Tool with no dependency between them
+	cueContent := `package toto
+
+goRuntime: {
+	apiVersion: "toto.terassyi.net/v1beta1"
+	kind: "Runtime"
+	metadata: name: "go"
+	spec: {
+		installerRef: "download"
+		version: "1.25.5"
+		source: {
+			url: "https://go.dev/dl/go1.25.5.linux-amd64.tar.gz"
+		}
+		binaries: ["go", "gofmt"]
+		toolBinPath: "~/go/bin"
+	}
+}
+
+ripgrep: {
+	apiVersion: "toto.terassyi.net/v1beta1"
+	kind: "Tool"
+	metadata: name: "ripgrep"
+	spec: {
+		installerRef: "download"
+		version: "14.0.0"
+		source: { url: "https://example.com/rg" }
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "resources.cue"), []byte(cueContent), 0644))
+
+	resources := loadResources(t, configDir)
+
+	store, err := state.NewStore[state.UserState](stateDir)
+	require.NoError(t, err)
+
+	var mu sync.Mutex
+	var executionOrder []string
+
+	mockTool := &mockToolInstaller{
+		installed: make(map[string]*resource.ToolState),
+		removed:   make(map[string]bool),
+		installFunc: func(ctx context.Context, res *resource.Tool, name string) (*resource.ToolState, error) {
+			mu.Lock()
+			executionOrder = append(executionOrder, "Tool:"+name)
+			mu.Unlock()
+			return &resource.ToolState{
+				InstallerRef: res.ToolSpec.InstallerRef,
+				Version:      res.ToolSpec.Version,
+				BinPath:      filepath.Join("/mock/bin", name),
+			}, nil
+		},
+	}
+
+	mockRuntime := &mockRuntimeInstaller{
+		installed: make(map[string]*resource.RuntimeState),
+		removed:   make(map[string]bool),
+		installFunc: func(ctx context.Context, res *resource.Runtime, name string) (*resource.RuntimeState, error) {
+			mu.Lock()
+			executionOrder = append(executionOrder, "Runtime:"+name)
+			mu.Unlock()
+
+			binDir := res.RuntimeSpec.BinDir
+			if binDir == "" {
+				binDir = res.RuntimeSpec.ToolBinPath
+			}
+			return &resource.RuntimeState{
+				Type:        res.RuntimeSpec.Type,
+				Version:     res.RuntimeSpec.Version,
+				InstallPath: filepath.Join("/mock/runtimes", name, res.RuntimeSpec.Version),
+				Binaries:    res.RuntimeSpec.Binaries,
+				BinDir:      binDir,
+				ToolBinPath: res.RuntimeSpec.ToolBinPath,
+			}, nil
+		},
+	}
+
+	eng := engine.NewEngine(mockTool, mockRuntime, store)
+
+	err = eng.Apply(context.Background(), resources)
+	require.NoError(t, err)
+
+	// Find indices
+	goIndex := -1
+	rgIndex := -1
+	for i, item := range executionOrder {
+		switch item {
+		case "Runtime:go":
+			goIndex = i
+		case "Tool:ripgrep":
+			rgIndex = i
+		}
+	}
+
+	assert.NotEqual(t, -1, goIndex, "go runtime should be installed")
+	assert.NotEqual(t, -1, rgIndex, "ripgrep tool should be installed")
+	assert.Less(t, goIndex, rgIndex, "runtime must complete before tool even without dependency")
+}
+
+// TestEngine_Apply_ParallelRuntimeExecution tests that multiple runtimes are installed concurrently.
+func TestEngine_Apply_ParallelRuntimeExecution(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "config")
+	stateDir := filepath.Join(tmpDir, "state")
+	require.NoError(t, os.MkdirAll(configDir, 0755))
+
+	cueContent := `package toto
+
+goRuntime: {
+	apiVersion: "toto.terassyi.net/v1beta1"
+	kind: "Runtime"
+	metadata: name: "go"
+	spec: {
+		installerRef: "download"
+		version: "1.25.5"
+		source: { url: "https://go.dev/dl/go1.25.5.tar.gz" }
+		binaries: ["go", "gofmt"]
+		toolBinPath: "~/go/bin"
+	}
+}
+
+rustRuntime: {
+	apiVersion: "toto.terassyi.net/v1beta1"
+	kind: "Runtime"
+	metadata: name: "rust"
+	spec: {
+		installerRef: "download"
+		version: "1.80.0"
+		source: { url: "https://example.com/rust.tar.gz" }
+		binaries: ["rustc", "cargo"]
+		toolBinPath: "~/.cargo/bin"
+	}
+}
+
+nodeRuntime: {
+	apiVersion: "toto.terassyi.net/v1beta1"
+	kind: "Runtime"
+	metadata: name: "node"
+	spec: {
+		installerRef: "download"
+		version: "22.0.0"
+		source: { url: "https://example.com/node.tar.gz" }
+		binaries: ["node", "npm"]
+		toolBinPath: "~/.npm/bin"
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "runtimes.cue"), []byte(cueContent), 0644))
+
+	resources := loadResources(t, configDir)
+
+	store, err := state.NewStore[state.UserState](stateDir)
+	require.NoError(t, err)
+
+	var concurrentCount atomic.Int32
+	var maxConcurrent atomic.Int32
+
+	mockRuntime := &mockRuntimeInstaller{
+		installed: make(map[string]*resource.RuntimeState),
+		removed:   make(map[string]bool),
+		installFunc: func(ctx context.Context, res *resource.Runtime, name string) (*resource.RuntimeState, error) {
+			current := concurrentCount.Add(1)
+			defer concurrentCount.Add(-1)
+
+			for {
+				old := maxConcurrent.Load()
+				if current <= old || maxConcurrent.CompareAndSwap(old, current) {
+					break
+				}
+			}
+
+			time.Sleep(50 * time.Millisecond)
+
+			binDir := res.RuntimeSpec.BinDir
+			if binDir == "" {
+				binDir = res.RuntimeSpec.ToolBinPath
+			}
+			return &resource.RuntimeState{
+				Type:        res.RuntimeSpec.Type,
+				Version:     res.RuntimeSpec.Version,
+				InstallPath: filepath.Join("/mock/runtimes", name, res.RuntimeSpec.Version),
+				Binaries:    res.RuntimeSpec.Binaries,
+				BinDir:      binDir,
+				ToolBinPath: res.RuntimeSpec.ToolBinPath,
+			}, nil
+		},
+	}
+
+	mockTool := newMockToolInstaller()
+	eng := engine.NewEngine(mockTool, mockRuntime, store)
+
+	err = eng.Apply(context.Background(), resources)
+	require.NoError(t, err)
+
+	// All runtimes should be installed
+	assert.Greater(t, maxConcurrent.Load(), int32(1), "expected concurrent runtime execution")
+
+	// Verify state
+	require.NoError(t, store.Lock())
+	st, err := store.Load()
+	require.NoError(t, err)
+	_ = store.Unlock()
+
+	assert.Len(t, st.Runtimes, 3)
+	assert.Contains(t, st.Runtimes, "go")
+	assert.Contains(t, st.Runtimes, "rust")
+	assert.Contains(t, st.Runtimes, "node")
 }
 
 // TestEngine_Apply_RuntimeWithoutBinDir tests that BinDir defaults to ToolBinPath.


### PR DESCRIPTION
- Add parallel execution with semaphore-based concurrency control
- Add --parallel flag to 'toto apply' (default: 5, range: 1-20)
- Integrate delegation commands with mpb SpinnerBar (spinner + log)
- Fix non-TTY data race by protecting io.Writer under mutex
- Add 4 property-based tests (rapid) for engine safety
- Add unit tests for UI (cmdview, progress) with race detection
- Add e2e tests for --parallel flag and runtime+tool chains
- Add Mermaid diagrams to e2e/scenario.md
