### PR TITLE
e2e: extract version strings from CUE manifests as single source of truth

### DIFF
--- a/e2e/config/manifests/delegation.cue
+++ b/e2e/config/manifests/delegation.cue
@@ -1,6 +1,9 @@
 package toto
 
 // gopls - Go language server installed via go install (Runtime Delegation)
+
+_goplsVersion: "v0.21.0"
+
 gopls: {
 	apiVersion: "toto.terassyi.net/v1beta1"
 	kind:       "Tool"
@@ -8,6 +11,6 @@ gopls: {
 	spec: {
 		runtimeRef: "go"
 		package:    "golang.org/x/tools/gopls"
-		version:    "v0.21.0"
+		version:    _goplsVersion
 	}
 }

--- a/e2e/config/manifests/runtime.cue
+++ b/e2e/config/manifests/runtime.cue
@@ -3,13 +3,16 @@ package toto
 // Go runtime for E2E testing
 // Initially installs Go 1.25.6, then can be upgraded to 1.25.7
 // Uses _env for OS/arch portability
+
+_goVersion: "1.25.6"
+
 goRuntime: {
 	apiVersion: "toto.terassyi.net/v1beta1"
 	kind:       "Runtime"
 	metadata: name: "go"
 	spec: {
 		type:    "download"
-		version: "1.25.6"
+		version: _goVersion
 		source: {
 			url: "https://go.dev/dl/go\(spec.version).\(_env.os)-\(_env.arch).tar.gz"
 			checksum: {

--- a/e2e/config/manifests/runtime.cue.upgrade
+++ b/e2e/config/manifests/runtime.cue.upgrade
@@ -2,13 +2,16 @@ package toto
 
 // Go runtime upgraded to 1.25.7
 // Uses _env for OS/arch portability
+
+_goVersionUpgrade: "1.25.7"
+
 goRuntime: {
 	apiVersion: "toto.terassyi.net/v1beta1"
 	kind:       "Runtime"
 	metadata: name: "go"
 	spec: {
 		type:    "download"
-		version: "1.25.7"
+		version: _goVersionUpgrade
 		source: {
 			url: "https://go.dev/dl/go\(spec.version).\(_env.os)-\(_env.arch).tar.gz"
 			checksum: {

--- a/e2e/config/manifests/tools.cue
+++ b/e2e/config/manifests/tools.cue
@@ -1,13 +1,16 @@
 package toto
 
 // gh CLI tool - uses _env for OS/arch portability
+
+_ghVersion: "2.86.0"
+
 gh: {
 	apiVersion: "toto.terassyi.net/v1beta1"
 	kind:       "Tool"
 	metadata: name: "gh"
 	spec: {
 		installerRef: "download"
-		version:      "2.86.0"
+		version:      _ghVersion
 		source: {
 			if _env.os == "linux" {
 				url: "https://github.com/cli/cli/releases/download/v\(spec.version)/gh_\(spec.version)_linux_\(_env.arch).tar.gz"

--- a/e2e/config/registry/tools.cue
+++ b/e2e/config/registry/tools.cue
@@ -1,5 +1,9 @@
 package manifests
 
+_rgVersion: "15.1.0"
+_fdVersion: "v10.3.0"
+_jqVersion: "jq-1.8.1"
+
 // ripgrep - Install via aqua registry
 ripgrep: {
 	apiVersion: "toto.terassyi.net/v1beta1"
@@ -7,7 +11,7 @@ ripgrep: {
 	metadata: name: "rg"
 	spec: {
 		installerRef: "aqua"
-		version:      "15.1.0"
+		version:      _rgVersion
 		package:      "BurntSushi/ripgrep"
 	}
 }
@@ -19,7 +23,7 @@ fd: {
 	metadata: name: "fd"
 	spec: {
 		installerRef: "aqua"
-		version:      "v10.3.0"
+		version:      _fdVersion
 		package:      "sharkdp/fd"
 	}
 }
@@ -31,7 +35,7 @@ jq: {
 	metadata: name: "jq"
 	spec: {
 		installerRef: "aqua"
-		version:      "jq-1.8.1"
+		version:      _jqVersion
 		package:      "jqlang/jq"
 	}
 }

--- a/e2e/config/registry/tools.cue.old
+++ b/e2e/config/registry/tools.cue.old
@@ -1,5 +1,9 @@
 package manifests
 
+_rgVersionOld: "14.1.1"
+_fdVersionOld: "v10.2.0"
+_jqVersionOld: "jq-1.7.1"
+
 // ripgrep - Install via aqua registry (older version for upgrade test)
 ripgrep: {
 	apiVersion: "toto.terassyi.net/v1beta1"
@@ -7,7 +11,7 @@ ripgrep: {
 	metadata: name: "rg"
 	spec: {
 		installerRef: "aqua"
-		version:      "14.1.1"
+		version:      _rgVersionOld
 		package:      "BurntSushi/ripgrep"
 	}
 }
@@ -19,7 +23,7 @@ fd: {
 	metadata: name: "fd"
 	spec: {
 		installerRef: "aqua"
-		version:      "v10.2.0"
+		version:      _fdVersionOld
 		package:      "sharkdp/fd"
 	}
 }
@@ -31,7 +35,7 @@ jq: {
 	metadata: name: "jq"
 	spec: {
 		installerRef: "aqua"
-		version:      "jq-1.7.1"
+		version:      _jqVersionOld
 		package:      "jqlang/jq"
 	}
 }

--- a/e2e/dependency_test.go
+++ b/e2e/dependency_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -61,17 +62,17 @@ func dependencyTests() {
 			By("Verifying rg works")
 			output, err = testExec.ExecBash("~/.local/bin/rg --version")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("ripgrep 14.1.1"))
+			Expect(output).To(ContainSubstring("ripgrep " + versions.DepRgVersion))
 
 			By("Verifying fd works")
 			output, err = testExec.ExecBash("~/.local/bin/fd --version")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("fd 10.2.0"))
+			Expect(output).To(ContainSubstring("fd " + versions.DepFdVersion))
 
 			By("Verifying bat works")
 			output, err = testExec.ExecBash("~/.local/bin/bat --version")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("bat 0.26.1"))
+			Expect(output).To(ContainSubstring("bat " + versions.DepBatVersion))
 		})
 
 		It("is idempotent - second apply reports no changes", func() {
@@ -102,17 +103,17 @@ func dependencyTests() {
 			By("Verifying rg works")
 			rgOut, err := testExec.ExecBash("~/.local/bin/rg --version")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(rgOut).To(ContainSubstring("ripgrep 14.1.1"))
+			Expect(rgOut).To(ContainSubstring("ripgrep " + versions.DepRgVersion))
 
 			By("Verifying fd works")
 			fdOut, err := testExec.ExecBash("~/.local/bin/fd --version")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(fdOut).To(ContainSubstring("fd 10.2.0"))
+			Expect(fdOut).To(ContainSubstring("fd " + versions.DepFdVersion))
 
 			By("Verifying bat works")
 			batOut, err := testExec.ExecBash("~/.local/bin/bat --version")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(batOut).To(ContainSubstring("bat 0.26.1"))
+			Expect(batOut).To(ContainSubstring("bat " + versions.DepBatVersion))
 
 			By("Verifying non-TTY output has Commands: header exactly once")
 			Expect(strings.Count(output, "Commands:")).To(Equal(1))
@@ -153,9 +154,9 @@ func dependencyTests() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying go runtime is installed")
-			output, err := testExec.ExecBash("GOTOOLCHAIN=local ~/.local/share/toto/runtimes/go/1.23.5/bin/go version")
+			output, err := testExec.ExecBash(fmt.Sprintf("GOTOOLCHAIN=local ~/.local/share/toto/runtimes/go/%s/bin/go version", versions.DepGoVersion))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("go1.23"))
+			Expect(output).To(ContainSubstring("go" + versions.DepGoVersion))
 
 			By("Verifying gopls is installed (depends on go runtime)")
 			output, err = testExec.ExecBash("~/go/bin/gopls version")
@@ -196,7 +197,7 @@ func dependencyTests() {
 			By("Verifying jq is installed and works")
 			output, err := testExec.ExecBash("~/.local/bin/jq --version")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("jq-1.7"))
+			Expect(output).To(ContainSubstring("jq-" + versions.DepJqVersion))
 		})
 	})
 
@@ -223,11 +224,11 @@ func dependencyTests() {
 			_, err := testExec.Exec("toto", "apply", "~/dependency-test/runtime-chain.cue")
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Verifying go runtime 1.23.5 is installed in expected location")
+			By(fmt.Sprintf("Verifying go runtime %s is installed in expected location", versions.DepGoVersion))
 			// Set GOTOOLCHAIN=local to prevent auto-upgrade to newer Go version
-			output, err := testExec.ExecBash("GOTOOLCHAIN=local ~/.local/share/toto/runtimes/go/1.23.5/bin/go version")
+			output, err := testExec.ExecBash(fmt.Sprintf("GOTOOLCHAIN=local ~/.local/share/toto/runtimes/go/%s/bin/go version", versions.DepGoVersion))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("go1.23"))
+			Expect(output).To(ContainSubstring("go" + versions.DepGoVersion))
 
 			By("Verifying gopls is installed")
 			output, err = testExec.ExecBash("~/go/bin/gopls version")

--- a/e2e/registry_test.go
+++ b/e2e/registry_test.go
@@ -3,6 +3,8 @@
 package e2e
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -72,7 +74,7 @@ func registryTests() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking ripgrep version output")
-			Expect(output).To(ContainSubstring("ripgrep 15.1.0"))
+			Expect(output).To(ContainSubstring("ripgrep " + versions.RegRgVersion))
 		})
 
 		It("installs fd via aqua registry", func() {
@@ -85,7 +87,7 @@ func registryTests() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking fd version output")
-			Expect(output).To(ContainSubstring("fd 10.3.0"))
+			Expect(output).To(ContainSubstring("fd " + versions.RegFdVersion))
 		})
 
 		It("installs jq via aqua registry", func() {
@@ -98,7 +100,7 @@ func registryTests() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking jq version output")
-			Expect(output).To(ContainSubstring("jq-1.8.1"))
+			Expect(output).To(ContainSubstring(versions.RegJqVersion))
 		})
 
 		It("OS/arch is correctly resolved", func() {
@@ -168,23 +170,23 @@ func registryTests() {
 			By("Checking ripgrep still works")
 			output, err := testExec.ExecBash("~/.local/bin/rg --version")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("ripgrep 15.1.0"))
+			Expect(output).To(ContainSubstring("ripgrep " + versions.RegRgVersion))
 
 			By("Checking fd still works")
 			output, err = testExec.ExecBash("~/.local/bin/fd --version")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("fd 10.3.0"))
+			Expect(output).To(ContainSubstring("fd " + versions.RegFdVersion))
 
 			By("Checking jq still works")
 			output, err = testExec.ExecBash("~/.local/bin/jq --version")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("jq-1.8.1"))
+			Expect(output).To(ContainSubstring(versions.RegJqVersion))
 		})
 	})
 
 	Context("Version Upgrade", func() {
 		It("downgrades to older version", func() {
-			By("Swapping manifest to older version (15.1.0 -> 14.1.1, etc)")
+			By(fmt.Sprintf("Swapping manifest to older version (%s -> %s, etc)", versions.RegRgVersion, versions.RegRgVersionOld))
 			_, err := testExec.ExecBash("mv ~/manifests/registry/tools.cue ~/manifests/registry/tools.cue.new")
 			Expect(err).NotTo(HaveOccurred())
 			_, err = testExec.ExecBash("mv ~/manifests/registry/tools.cue.old ~/manifests/registry/tools.cue")
@@ -196,20 +198,20 @@ func registryTests() {
 		})
 
 		It("verifies older versions are installed", func() {
-			By("Checking ripgrep downgraded to 14.1.1")
+			By("Checking ripgrep downgraded to " + versions.RegRgVersionOld)
 			output, err := testExec.ExecBash("~/.local/bin/rg --version")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("ripgrep 14.1.1"))
+			Expect(output).To(ContainSubstring("ripgrep " + versions.RegRgVersionOld))
 
-			By("Checking fd downgraded to 10.2.0")
+			By("Checking fd downgraded to " + versions.RegFdVersionOld)
 			output, err = testExec.ExecBash("~/.local/bin/fd --version")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("fd 10.2.0"))
+			Expect(output).To(ContainSubstring("fd " + versions.RegFdVersionOld))
 
-			By("Checking jq downgraded to 1.7.1")
+			By("Checking jq downgraded to " + versions.RegJqVersionOld)
 			output, err = testExec.ExecBash("~/.local/bin/jq --version")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("jq-1.7.1"))
+			Expect(output).To(ContainSubstring(versions.RegJqVersionOld))
 		})
 
 		It("upgrades back to newer version", func() {
@@ -225,20 +227,20 @@ func registryTests() {
 		})
 
 		It("verifies newer versions are installed after upgrade", func() {
-			By("Checking ripgrep upgraded to 15.1.0")
+			By("Checking ripgrep upgraded to " + versions.RegRgVersion)
 			output, err := testExec.ExecBash("~/.local/bin/rg --version")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("ripgrep 15.1.0"))
+			Expect(output).To(ContainSubstring("ripgrep " + versions.RegRgVersion))
 
-			By("Checking fd upgraded to 10.3.0")
+			By("Checking fd upgraded to " + versions.RegFdVersion)
 			output, err = testExec.ExecBash("~/.local/bin/fd --version")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("fd 10.3.0"))
+			Expect(output).To(ContainSubstring("fd " + versions.RegFdVersion))
 
-			By("Checking jq upgraded to 1.8.1")
+			By("Checking jq upgraded to " + versions.RegJqVersion)
 			output, err = testExec.ExecBash("~/.local/bin/jq --version")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("jq-1.8.1"))
+			Expect(output).To(ContainSubstring(versions.RegJqVersion))
 		})
 
 		It("is idempotent after version changes", func() {

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -22,6 +22,9 @@ var _ = BeforeSuite(func() {
 		Skip(err.Error())
 	}
 	Expect(testExec.Setup()).To(Succeed())
+
+	versions, err = loadVersions()
+	Expect(err).NotTo(HaveOccurred(), "failed to load versions from CUE manifests")
 })
 
 var _ = AfterSuite(func() {

--- a/e2e/versions_test.go
+++ b/e2e/versions_test.go
@@ -1,0 +1,173 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/terassyi/toto/internal/config"
+	"github.com/terassyi/toto/internal/resource"
+)
+
+// e2eVersions holds version strings extracted from CUE manifests.
+// This is the single source of truth for version assertions in E2E tests.
+type e2eVersions struct {
+	// Basic manifests (e2e/config/manifests/)
+	GoVersion        string // runtime.cue → Runtime/go
+	GoVersionUpgrade string // runtime.cue.upgrade → Runtime/go
+	GhVersion        string // tools.cue → Tool/gh
+	GoplsVersion     string // delegation.cue → Tool/gopls
+
+	// Dependency test manifests (e2e/config/dependency-test/)
+	DepGoVersion  string // runtime-chain.cue → Runtime/go (1.23.5)
+	DepRgVersion  string // parallel.cue → Tool/rg
+	DepFdVersion  string // parallel.cue → Tool/fd
+	DepBatVersion string // parallel.cue → Tool/bat
+	DepJqVersion  string // toolref.cue → Tool/jq
+
+	// Registry manifests (e2e/config/registry/)
+	RegRgVersion    string // tools.cue → Tool/rg (newer)
+	RegFdVersion    string // tools.cue → Tool/fd (newer)
+	RegJqVersion    string // tools.cue → Tool/jq (newer)
+	RegRgVersionOld string // tools.cue.old → Tool/rg (older)
+	RegFdVersionOld string // tools.cue.old → Tool/fd (older)
+	RegJqVersionOld string // tools.cue.old → Tool/jq (older)
+}
+
+// versions is the global version holder, populated in BeforeSuite.
+var versions *e2eVersions
+
+// loadVersions loads version strings from CUE manifests.
+func loadVersions() (*e2eVersions, error) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return nil, fmt.Errorf("failed to get current file path")
+	}
+	e2eDir := filepath.Dir(filename)
+	manifestsDir := filepath.Join(e2eDir, "config", "manifests")
+	depTestDir := filepath.Join(e2eDir, "config", "dependency-test")
+	registryDir := filepath.Join(e2eDir, "config", "registry")
+
+	loader := config.NewLoader(nil)
+	v := &e2eVersions{}
+
+	// Basic manifests
+	if ver, err := loadVersion(loader, filepath.Join(manifestsDir, "runtime.cue"), resource.KindRuntime, "go"); err != nil {
+		return nil, fmt.Errorf("runtime.cue: %w", err)
+	} else {
+		v.GoVersion = ver
+	}
+
+	if ver, err := loadVersion(loader, filepath.Join(manifestsDir, "runtime.cue.upgrade"), resource.KindRuntime, "go"); err != nil {
+		return nil, fmt.Errorf("runtime.cue.upgrade: %w", err)
+	} else {
+		v.GoVersionUpgrade = ver
+	}
+
+	if ver, err := loadVersion(loader, filepath.Join(manifestsDir, "tools.cue"), resource.KindTool, "gh"); err != nil {
+		return nil, fmt.Errorf("tools.cue: %w", err)
+	} else {
+		v.GhVersion = ver
+	}
+
+	if ver, err := loadVersion(loader, filepath.Join(manifestsDir, "delegation.cue"), resource.KindTool, "gopls"); err != nil {
+		return nil, fmt.Errorf("delegation.cue: %w", err)
+	} else {
+		v.GoplsVersion = ver
+	}
+
+	// Dependency test manifests
+	if ver, err := loadVersion(loader, filepath.Join(depTestDir, "runtime-chain.cue"), resource.KindRuntime, "go"); err != nil {
+		return nil, fmt.Errorf("runtime-chain.cue: %w", err)
+	} else {
+		v.DepGoVersion = ver
+	}
+
+	if ver, err := loadVersion(loader, filepath.Join(depTestDir, "parallel.cue"), resource.KindTool, "rg"); err != nil {
+		return nil, fmt.Errorf("parallel.cue rg: %w", err)
+	} else {
+		v.DepRgVersion = ver
+	}
+
+	if ver, err := loadVersion(loader, filepath.Join(depTestDir, "parallel.cue"), resource.KindTool, "fd"); err != nil {
+		return nil, fmt.Errorf("parallel.cue fd: %w", err)
+	} else {
+		v.DepFdVersion = ver
+	}
+
+	if ver, err := loadVersion(loader, filepath.Join(depTestDir, "parallel.cue"), resource.KindTool, "bat"); err != nil {
+		return nil, fmt.Errorf("parallel.cue bat: %w", err)
+	} else {
+		v.DepBatVersion = ver
+	}
+
+	if ver, err := loadVersion(loader, filepath.Join(depTestDir, "toolref.cue"), resource.KindTool, "jq"); err != nil {
+		return nil, fmt.Errorf("toolref.cue jq: %w", err)
+	} else {
+		v.DepJqVersion = ver
+	}
+
+	// Registry manifests
+	if ver, err := loadVersion(loader, filepath.Join(registryDir, "tools.cue"), resource.KindTool, "rg"); err != nil {
+		return nil, fmt.Errorf("registry tools.cue rg: %w", err)
+	} else {
+		v.RegRgVersion = ver
+	}
+
+	if ver, err := loadVersion(loader, filepath.Join(registryDir, "tools.cue"), resource.KindTool, "fd"); err != nil {
+		return nil, fmt.Errorf("registry tools.cue fd: %w", err)
+	} else {
+		v.RegFdVersion = strings.TrimPrefix(ver, "v")
+	}
+
+	if ver, err := loadVersion(loader, filepath.Join(registryDir, "tools.cue"), resource.KindTool, "jq"); err != nil {
+		return nil, fmt.Errorf("registry tools.cue jq: %w", err)
+	} else {
+		v.RegJqVersion = ver
+	}
+
+	if ver, err := loadVersion(loader, filepath.Join(registryDir, "tools.cue.old"), resource.KindTool, "rg"); err != nil {
+		return nil, fmt.Errorf("registry tools.cue.old rg: %w", err)
+	} else {
+		v.RegRgVersionOld = ver
+	}
+
+	if ver, err := loadVersion(loader, filepath.Join(registryDir, "tools.cue.old"), resource.KindTool, "fd"); err != nil {
+		return nil, fmt.Errorf("registry tools.cue.old fd: %w", err)
+	} else {
+		v.RegFdVersionOld = strings.TrimPrefix(ver, "v")
+	}
+
+	if ver, err := loadVersion(loader, filepath.Join(registryDir, "tools.cue.old"), resource.KindTool, "jq"); err != nil {
+		return nil, fmt.Errorf("registry tools.cue.old jq: %w", err)
+	} else {
+		v.RegJqVersionOld = ver
+	}
+
+	return v, nil
+}
+
+// loadVersion loads a single CUE file and extracts the version of the named resource.
+func loadVersion(loader *config.Loader, path string, kind resource.Kind, name string) (string, error) {
+	resources, err := loader.LoadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to load %s: %w", path, err)
+	}
+
+	for _, res := range resources {
+		if res.Kind() != kind || res.Name() != name {
+			continue
+		}
+		switch r := res.(type) {
+		case *resource.Runtime:
+			return r.RuntimeSpec.Version, nil
+		case *resource.Tool:
+			return r.ToolSpec.Version, nil
+		}
+	}
+
+	return "", fmt.Errorf("%s %q not found in %s", kind, name, filepath.Base(path))
+}


### PR DESCRIPTION
- Add e2e/versions_test.go: loads versions from CUE using config.Loader
- Add _xxxVersion variables to CUE manifests for consistency
- Replace all hardcoded version strings in test files with versions.*
- Load versions in BeforeSuite via loadVersions()
- Update e2e/README.md with version management documentation

Version updates now only require changing CUE manifest variables.
No Go test code changes needed.
