### PR TITLE
feat: add toto env command for shell environment export

### DIFF
--- a/cmd/toto/env.go
+++ b/cmd/toto/env.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/terassyi/toto/internal/config"
+	"github.com/terassyi/toto/internal/env"
+	"github.com/terassyi/toto/internal/path"
+	"github.com/terassyi/toto/internal/state"
+)
+
+var (
+	envShell  string
+	envExport bool
+)
+
+var envCmd = &cobra.Command{
+	Use:   "env",
+	Short: "Output environment variables for shell configuration",
+	Long: `Output environment variable statements for installed runtimes.
+
+Stdout mode (default):
+  eval "$(toto env)"
+
+File export mode:
+  toto env --export
+  source ~/.config/toto/env.sh
+
+Shell types:
+  --shell posix   POSIX-compatible (bash, zsh) [default]
+  --shell fish    fish shell`,
+	RunE: runEnv,
+}
+
+func init() {
+	envCmd.Flags().StringVar(&envShell, "shell", "posix", "Shell type (posix, fish)")
+	envCmd.Flags().BoolVar(&envExport, "export", false, "Write to file instead of stdout")
+}
+
+func runEnv(cmd *cobra.Command, _ []string) error {
+	// Parse shell type
+	shellType, err := env.ParseShellType(envShell)
+	if err != nil {
+		return err
+	}
+
+	// Load config
+	cfg, err := config.LoadConfig(config.DefaultConfigDir)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	// Create paths
+	paths, err := path.NewFromConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to create paths: %w", err)
+	}
+
+	// Load state
+	store, err := state.NewStore[state.UserState](paths.UserDataDir())
+	if err != nil {
+		return fmt.Errorf("failed to create state store: %w", err)
+	}
+
+	if err := store.Lock(); err != nil {
+		return fmt.Errorf("failed to lock state: %w", err)
+	}
+	defer func() { _ = store.Unlock() }()
+
+	userState, err := store.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load state: %w", err)
+	}
+
+	// Generate env output
+	formatter := env.NewFormatter(shellType)
+	lines := env.Generate(userState.Runtimes, paths.UserBinDir(), formatter)
+	output := strings.Join(lines, "\n")
+	if len(lines) > 0 {
+		output += "\n"
+	}
+
+	// Export to file or print to stdout
+	if envExport {
+		return writeEnvFile(cmd, output, paths.EnvDir(), formatter.Ext())
+	}
+
+	fmt.Fprint(cmd.OutOrStdout(), output)
+	return nil
+}
+
+func writeEnvFile(cmd *cobra.Command, content, envDir, ext string) error {
+	if err := os.MkdirAll(envDir, 0755); err != nil {
+		return fmt.Errorf("failed to create env dir: %w", err)
+	}
+
+	filePath := filepath.Join(envDir, "env"+ext)
+
+	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+		return fmt.Errorf("failed to write env file: %w", err)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Wrote %s\n", filePath)
+	return nil
+}

--- a/cmd/toto/init.go
+++ b/cmd/toto/init.go
@@ -131,6 +131,7 @@ func runInit(cmd *cobra.Command, _ []string) error {
 		{filepath.Join(paths.UserDataDir(), "tools"), "tools"},
 		{filepath.Join(paths.UserDataDir(), "runtimes"), "runtimes"},
 		{paths.UserBinDir(), "bin"},
+		{paths.EnvDir(), "env"},
 	}
 
 	for _, dir := range dirs {

--- a/cmd/toto/root.go
+++ b/cmd/toto/root.go
@@ -34,5 +34,6 @@ func init() {
 		validateCmd,
 		planCmd,
 		doctorCmd,
+		envCmd,
 	)
 }

--- a/e2e/scenario.md
+++ b/e2e/scenario.md
@@ -15,7 +15,7 @@ This document describes the scenarios verified by toto's E2E tests.
 
 | Suite | Tests | Description |
 |-------|-------|-------------|
-| toto on Ubuntu | 30 | Basic commands, installation, idempotency, doctor, runtime upgrade, resource removal |
+| toto on Ubuntu | 33 | Basic commands, installation, env export, idempotency, doctor, runtime upgrade, resource removal |
 | Aqua Registry | 10 | Registry initialization, tool installation via aqua registry, OS/arch resolution |
 | Dependency Resolution | 15 | Circular dependency detection, parallel installation, --parallel flag, dependency chains, toolRef chain |
 
@@ -28,13 +28,14 @@ flowchart TD
         S1_1["1.1 Basic Commands<br/>version / init / validate / plan"]
         S1_2["1.2 Apply<br/>Runtime(go 1.25.5) + Tool(gh) + Tool(gopls)"]
         S1_3["1.3-1.5 Verify<br/>directories / symlinks / state.json"]
+        S1_5a["1.5a Environment Export<br/>toto env / --shell fish / --export"]
         S1_6["1.6 Idempotency<br/>total_actions=0"]
         S1_7["1.7 Delegation<br/>gopls via go install"]
         S1_8["1.8 Doctor<br/>unmanaged tool detection"]
         S1_9["1.9 Runtime Upgrade<br/>go 1.25.5 → 1.25.6 + taint"]
         S1_10["1.10 Resource Removal<br/>dependency guard + tool/runtime removal"]
 
-        S1_1 --> S1_2 --> S1_3 --> S1_6 --> S1_7 --> S1_8 --> S1_9 --> S1_10
+        S1_1 --> S1_2 --> S1_3 --> S1_5a --> S1_6 --> S1_7 --> S1_8 --> S1_9 --> S1_10
     end
 
     subgraph S2["2. Aqua Registry"]
@@ -169,6 +170,30 @@ graph LR
   - gh tool version: "2.86.0"
   - gopls runtimeRef: "go"
   - gopls package: "golang.org/x/tools/gopls"
+
+### 1.5a Environment Export
+
+#### POSIX Output (`toto env`)
+1. Run `toto env`
+2. Verify:
+   - Output contains `export GOROOT=`
+   - Output contains `export GOBIN=`
+   - Output contains `go/bin` and `.local/bin` in PATH
+   - Output is eval-safe and PATH works: `eval '<output>' && GOTOOLCHAIN=local go version` succeeds
+
+#### Fish Output (`toto env --shell fish`)
+1. Run `toto env --shell fish`
+2. Verify:
+   - Output contains `set -gx GOROOT`
+   - Output contains `fish_add_path`
+
+#### File Export (`toto env --export`)
+1. Run `toto env --export`
+2. Verify:
+   - Output mentions `env.sh` file
+   - File `~/.config/toto/env.sh` exists
+   - File contains `export GOROOT=`
+   - File contains `export PATH=`
 
 ### 1.6 Idempotency
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,12 +17,14 @@ const (
 	DefaultConfigDir = "~/.config/toto"
 	DefaultDataDir   = "~/.local/share/toto"
 	DefaultBinDir    = "~/.local/bin"
+	DefaultEnvDir    = "~/.config/toto"
 )
 
 // Config represents toto configuration.
 type Config struct {
 	DataDir string `json:"dataDir"`
 	BinDir  string `json:"binDir"`
+	EnvDir  string `json:"envDir"`
 }
 
 // DefaultConfig returns the default configuration.
@@ -30,6 +32,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		DataDir: DefaultDataDir,
 		BinDir:  DefaultBinDir,
+		EnvDir:  DefaultEnvDir,
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -110,6 +110,7 @@ func TestConfig_ToCue(t *testing.T) {
 	cfg := &Config{
 		DataDir: "~/my-data",
 		BinDir:  "~/my-bin",
+		EnvDir:  "~/my-env",
 	}
 
 	cueBytes, err := cfg.ToCue()
@@ -122,6 +123,8 @@ func TestConfig_ToCue(t *testing.T) {
 	assert.Contains(t, cueContent, "~/my-data")
 	assert.Contains(t, cueContent, "binDir")
 	assert.Contains(t, cueContent, "~/my-bin")
+	assert.Contains(t, cueContent, "envDir")
+	assert.Contains(t, cueContent, "~/my-env")
 }
 
 func TestConfig_ToCue_RoundTrip(t *testing.T) {
@@ -142,4 +145,5 @@ func TestConfig_ToCue_RoundTrip(t *testing.T) {
 
 	assert.Equal(t, cfg.DataDir, loadedCfg.DataDir)
 	assert.Equal(t, cfg.BinDir, loadedCfg.BinDir)
+	assert.Equal(t, cfg.EnvDir, loadedCfg.EnvDir)
 }

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -1,0 +1,86 @@
+package env
+
+import (
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/terassyi/toto/internal/resource"
+)
+
+// Generate produces environment variable statements for the given runtimes.
+// It collects env vars from each runtime and builds a PATH statement
+// with BinDir, ToolBinPath from runtimes plus the user bin directory.
+func Generate(runtimes map[string]*resource.RuntimeState, userBinDir string, f Formatter) []string {
+	var lines []string
+	var pathDirs []string
+
+	// Add user bin dir first (highest priority in PATH)
+	pathDirs = append(pathDirs, toShellPath(userBinDir))
+
+	// Sort runtime names for deterministic output
+	names := make([]string, 0, len(runtimes))
+	for name := range runtimes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	// Process each runtime in sorted order
+	for _, name := range names {
+		rs := runtimes[name]
+
+		// Sort env keys for deterministic output
+		keys := make([]string, 0, len(rs.Env))
+		for key := range rs.Env {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+
+		for _, key := range keys {
+			lines = append(lines, f.ExportVar(key, toShellPath(rs.Env[key])))
+		}
+
+		// Collect PATH directories
+		if rs.BinDir != "" {
+			pathDirs = append(pathDirs, toShellPath(rs.BinDir))
+		}
+		if rs.ToolBinPath != "" && rs.ToolBinPath != rs.BinDir {
+			pathDirs = append(pathDirs, toShellPath(rs.ToolBinPath))
+		}
+	}
+
+	// Deduplicate and add PATH statement
+	pathDirs = dedupStrings(pathDirs)
+	if len(pathDirs) > 0 {
+		lines = append(lines, f.ExportPath(pathDirs))
+	}
+
+	return lines
+}
+
+// toShellPath converts an absolute path under $HOME to $HOME/... form for shell portability.
+// e.g., "/home/user/go/bin" → "$HOME/go/bin"
+// Paths not under $HOME are returned as-is.
+func toShellPath(p string) string {
+	home, _ := os.UserHomeDir()
+	if home != "" && strings.HasPrefix(p, home+"/") {
+		return shellHome + "/" + p[len(home)+1:]
+	}
+	if p == home {
+		return shellHome
+	}
+	return p
+}
+
+// dedupStrings removes duplicate strings while preserving order.
+func dedupStrings(ss []string) []string {
+	seen := make(map[string]bool, len(ss))
+	result := make([]string, 0, len(ss))
+	for _, s := range ss {
+		if !seen[s] {
+			seen[s] = true
+			result = append(result, s)
+		}
+	}
+	return result
+}

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -1,0 +1,236 @@
+package env
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/terassyi/toto/internal/resource"
+)
+
+func TestGenerate(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	userBinDir := home + "/.local/bin"
+
+	tests := []struct {
+		name            string
+		runtimes        map[string]*resource.RuntimeState
+		shell           ShellType
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{
+			name:     "no runtimes - posix",
+			runtimes: map[string]*resource.RuntimeState{},
+			shell:    ShellPosix,
+			wantContains: []string{
+				`export PATH="$HOME/.local/bin:$PATH"`,
+			},
+		},
+		{
+			name:     "no runtimes - fish",
+			runtimes: map[string]*resource.RuntimeState{},
+			shell:    ShellFish,
+			wantContains: []string{
+				`fish_add_path "$HOME/.local/bin"`,
+			},
+		},
+		{
+			name: "go runtime - posix",
+			runtimes: map[string]*resource.RuntimeState{
+				"go": {
+					Version:     "1.25.6",
+					BinDir:      home + "/go/bin",
+					ToolBinPath: home + "/go/bin",
+					Env: map[string]string{
+						"GOROOT": home + "/.local/share/toto/runtimes/go/1.25.6",
+						"GOBIN":  home + "/go/bin",
+					},
+				},
+			},
+			shell: ShellPosix,
+			wantContains: []string{
+				`export GOROOT="$HOME/.local/share/toto/runtimes/go/1.25.6"`,
+				`export GOBIN="$HOME/go/bin"`,
+				`$HOME/.local/bin`,
+				`$HOME/go/bin`,
+				`export PATH=`,
+			},
+		},
+		{
+			name: "go runtime - fish",
+			runtimes: map[string]*resource.RuntimeState{
+				"go": {
+					Version:     "1.25.6",
+					BinDir:      home + "/go/bin",
+					ToolBinPath: home + "/go/bin",
+					Env: map[string]string{
+						"GOROOT": home + "/.local/share/toto/runtimes/go/1.25.6",
+					},
+				},
+			},
+			shell: ShellFish,
+			wantContains: []string{
+				`set -gx GOROOT "$HOME/.local/share/toto/runtimes/go/1.25.6"`,
+				`fish_add_path`,
+				`$HOME/go/bin`,
+			},
+		},
+		{
+			name: "multiple runtimes with deduplicated PATH",
+			runtimes: map[string]*resource.RuntimeState{
+				"go": {
+					Version:     "1.25.6",
+					BinDir:      home + "/go/bin",
+					ToolBinPath: home + "/go/bin",
+					Env: map[string]string{
+						"GOROOT": home + "/.local/share/toto/runtimes/go/1.25.6",
+					},
+				},
+				"rust": {
+					Version:     "1.80.0",
+					BinDir:      home + "/.cargo/bin",
+					ToolBinPath: home + "/.cargo/bin",
+					Env: map[string]string{
+						"CARGO_HOME":  home + "/.cargo",
+						"RUSTUP_HOME": home + "/.rustup",
+					},
+				},
+			},
+			shell: ShellPosix,
+			wantContains: []string{
+				`export GOROOT=`,
+				`export CARGO_HOME=`,
+				`export RUSTUP_HOME=`,
+				`$HOME/go/bin`,
+				`$HOME/.cargo/bin`,
+			},
+		},
+		{
+			name: "BinDir different from ToolBinPath",
+			runtimes: map[string]*resource.RuntimeState{
+				"go": {
+					Version:     "1.25.6",
+					BinDir:      home + "/.local/share/toto/runtimes/go/1.25.6/bin",
+					ToolBinPath: home + "/go/bin",
+					Env:         map[string]string{},
+				},
+			},
+			shell: ShellPosix,
+			wantContains: []string{
+				`$HOME/.local/share/toto/runtimes/go/1.25.6/bin`,
+				`$HOME/go/bin`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := NewFormatter(tt.shell)
+			lines := Generate(tt.runtimes, userBinDir, f)
+			output := joinLines(lines)
+
+			for _, want := range tt.wantContains {
+				assert.Contains(t, output, want)
+			}
+			for _, notWant := range tt.wantNotContains {
+				assert.NotContains(t, output, notWant)
+			}
+		})
+	}
+}
+
+func TestToShellPath(t *testing.T) {
+	home, _ := os.UserHomeDir()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "path under home",
+			input: home + "/go/bin",
+			want:  "$HOME/go/bin",
+		},
+		{
+			name:  "home directory itself",
+			input: home,
+			want:  "$HOME",
+		},
+		{
+			name:  "path not under home",
+			input: "/opt/local/bin",
+			want:  "/opt/local/bin",
+		},
+		{
+			name:  "empty path",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "nested path under home",
+			input: home + "/.local/share/toto/runtimes/go/1.25.6",
+			want:  "$HOME/.local/share/toto/runtimes/go/1.25.6",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toShellPath(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDedupStrings(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  []string
+	}{
+		{
+			name:  "no duplicates",
+			input: []string{"a", "b", "c"},
+			want:  []string{"a", "b", "c"},
+		},
+		{
+			name:  "with duplicates preserves order",
+			input: []string{"a", "b", "a", "c", "b"},
+			want:  []string{"a", "b", "c"},
+		},
+		{
+			name:  "all same",
+			input: []string{"a", "a", "a"},
+			want:  []string{"a"},
+		},
+		{
+			name:  "empty",
+			input: []string{},
+			want:  []string{},
+		},
+		{
+			name:  "nil",
+			input: nil,
+			want:  []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dedupStrings(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func joinLines(lines []string) string {
+	var b strings.Builder
+	for _, l := range lines {
+		b.WriteString(l)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}

--- a/internal/env/shell.go
+++ b/internal/env/shell.go
@@ -1,0 +1,84 @@
+package env
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Shell variable references and commands used in generated output.
+const (
+	shellHome   = "$HOME"
+	shellPath   = "$PATH"
+	fishAddPath = "fish_add_path"
+)
+
+// ShellType represents a shell syntax type.
+type ShellType string
+
+const (
+	// ShellPosix represents POSIX-compatible shells (bash, zsh, sh).
+	ShellPosix ShellType = "posix"
+	// ShellFish represents the fish shell.
+	ShellFish ShellType = "fish"
+)
+
+// ParseShellType parses a string into a ShellType.
+func ParseShellType(s string) (ShellType, error) {
+	switch s {
+	case "posix", "bash", "sh", "zsh", "":
+		return ShellPosix, nil
+	case "fish":
+		return ShellFish, nil
+	default:
+		return "", fmt.Errorf("unsupported shell type: %q (supported: posix, fish)", s)
+	}
+}
+
+// Formatter provides shell-specific formatting for environment variable statements.
+type Formatter interface {
+	// ExportVar formats a single environment variable export statement.
+	ExportVar(key, value string) string
+	// ExportPath formats a PATH export statement with the given directories prepended.
+	ExportPath(dirs []string) string
+	// Ext returns the file extension for this shell type (e.g., ".sh", ".fish").
+	// The format matches filepath.Ext() convention (dot-prefixed).
+	Ext() string
+}
+
+// NewFormatter returns a Formatter for the given ShellType.
+func NewFormatter(st ShellType) Formatter {
+	switch st {
+	case ShellFish:
+		return fishFormatter{}
+	default:
+		return posixFormatter{}
+	}
+}
+
+type posixFormatter struct{}
+
+func (posixFormatter) ExportVar(key, value string) string {
+	return fmt.Sprintf("export %s=%q", key, value)
+}
+
+func (posixFormatter) ExportPath(dirs []string) string {
+	return fmt.Sprintf("export PATH=%q", strings.Join(dirs, ":")+":"+shellPath)
+}
+
+func (posixFormatter) Ext() string { return ".sh" }
+
+type fishFormatter struct{}
+
+func (fishFormatter) ExportVar(key, value string) string {
+	return fmt.Sprintf("set -gx %s %q", key, value)
+}
+
+func (fishFormatter) ExportPath(dirs []string) string {
+	quoted := make([]string, len(dirs))
+	for i, d := range dirs {
+		quoted[i] = fmt.Sprintf("%q", d)
+	}
+	return fmt.Sprintf("%s %s", fishAddPath, strings.Join(quoted, " "))
+}
+
+func (fishFormatter) Ext() string { return ".fish" }

--- a/internal/env/shell_test.go
+++ b/internal/env/shell_test.go
@@ -1,0 +1,128 @@
+package env
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseShellType(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    ShellType
+		wantErr bool
+	}{
+		{
+			name:  "posix",
+			input: "posix",
+			want:  ShellPosix,
+		},
+		{
+			name:  "fish",
+			input: "fish",
+			want:  ShellFish,
+		},
+		{
+			name:  "empty defaults to posix",
+			input: "",
+			want:  ShellPosix,
+		},
+		{
+			name:  "bash maps to posix",
+			input: "bash",
+			want:  ShellPosix,
+		},
+		{
+			name:  "sh maps to posix",
+			input: "sh",
+			want:  ShellPosix,
+		},
+		{
+			name:  "zsh maps to posix",
+			input: "zsh",
+			want:  ShellPosix,
+		},
+		{
+			name:    "unsupported shell",
+			input:   "powershell",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseShellType(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "unsupported shell type")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPosixFormatter(t *testing.T) {
+	f := posixFormatter{}
+
+	t.Run("ExportVar", func(t *testing.T) {
+		got := f.ExportVar("GOROOT", "$HOME/.local/share/toto/runtimes/go/1.25.6")
+		assert.Equal(t, `export GOROOT="$HOME/.local/share/toto/runtimes/go/1.25.6"`, got)
+	})
+
+	t.Run("ExportPath", func(t *testing.T) {
+		got := f.ExportPath([]string{"$HOME/.local/bin", "$HOME/go/bin"})
+		assert.Equal(t, `export PATH="$HOME/.local/bin:$HOME/go/bin:$PATH"`, got)
+	})
+
+	t.Run("Ext", func(t *testing.T) {
+		assert.Equal(t, ".sh", f.Ext())
+	})
+}
+
+func TestFishFormatter(t *testing.T) {
+	f := fishFormatter{}
+
+	t.Run("ExportVar", func(t *testing.T) {
+		got := f.ExportVar("GOROOT", "$HOME/.local/share/toto/runtimes/go/1.25.6")
+		assert.Equal(t, `set -gx GOROOT "$HOME/.local/share/toto/runtimes/go/1.25.6"`, got)
+	})
+
+	t.Run("ExportPath", func(t *testing.T) {
+		got := f.ExportPath([]string{"$HOME/.local/bin", "$HOME/go/bin"})
+		assert.Equal(t, `fish_add_path "$HOME/.local/bin" "$HOME/go/bin"`, got)
+	})
+
+	t.Run("Ext", func(t *testing.T) {
+		assert.Equal(t, ".fish", f.Ext())
+	})
+}
+
+func TestNewFormatter(t *testing.T) {
+	tests := []struct {
+		name      string
+		shellType ShellType
+		wantType  string
+	}{
+		{
+			name:      "posix",
+			shellType: ShellPosix,
+			wantType:  ".sh",
+		},
+		{
+			name:      "fish",
+			shellType: ShellFish,
+			wantType:  ".fish",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := NewFormatter(tt.shellType)
+			assert.Equal(t, tt.wantType, f.Ext())
+		})
+	}
+}

--- a/internal/path/path.go
+++ b/internal/path/path.go
@@ -25,6 +25,7 @@ type Paths struct {
 	userDataDir   string
 	userBinDir    string
 	userCacheDir  string
+	envDir        string
 	systemDataDir string
 }
 
@@ -88,6 +89,11 @@ func (p *Paths) UserCacheDir() string {
 	return p.userCacheDir
 }
 
+// EnvDir returns the directory for env export files.
+func (p *Paths) EnvDir() string {
+	return p.envDir
+}
+
 // SystemDataDir returns the system data directory.
 func (p *Paths) SystemDataDir() string {
 	return p.systemDataDir
@@ -146,6 +152,11 @@ func NewFromConfig(cfg *config.Config) (*Paths, error) {
 		return nil, err
 	}
 
+	envDir, err := Expand(cfg.EnvDir)
+	if err != nil {
+		return nil, err
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil, err
@@ -155,6 +166,7 @@ func NewFromConfig(cfg *config.Config) (*Paths, error) {
 		userDataDir:   dataDir,
 		userBinDir:    binDir,
 		userCacheDir:  filepath.Join(home, defaultUserCacheSuffix),
+		envDir:        envDir,
 		systemDataDir: DefaultSystemDataDir,
 	}, nil
 }

--- a/tests/env_test.go
+++ b/tests/env_test.go
@@ -1,0 +1,90 @@
+//go:build integration
+
+package tests
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/terassyi/toto/internal/env"
+	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/toto/internal/state"
+)
+
+func TestEnv_GenerateFromState(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	// Create temp directory with state.json
+	tmpDir := t.TempDir()
+	dataDir := filepath.Join(tmpDir, "data")
+	require.NoError(t, os.MkdirAll(dataDir, 0755))
+
+	userState := &state.UserState{
+		Version: "1",
+		Runtimes: map[string]*resource.RuntimeState{
+			"go": {
+				Type:        resource.InstallTypeDownload,
+				Version:     "1.25.6",
+				InstallPath: filepath.Join(home, ".local/share/toto/runtimes/go/1.25.6"),
+				BinDir:      filepath.Join(home, "go/bin"),
+				ToolBinPath: filepath.Join(home, "go/bin"),
+				Env: map[string]string{
+					"GOROOT": filepath.Join(home, ".local/share/toto/runtimes/go/1.25.6"),
+					"GOBIN":  filepath.Join(home, "go/bin"),
+				},
+			},
+		},
+		Tools: make(map[string]*resource.ToolState),
+	}
+
+	// Write state.json and load it back via state.Store
+	data, err := json.MarshalIndent(userState, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "state.json"), data, 0644))
+
+	store, err := state.NewStore[state.UserState](dataDir)
+	require.NoError(t, err)
+	require.NoError(t, store.Lock())
+	defer func() { _ = store.Unlock() }()
+
+	loaded, err := store.Load()
+	require.NoError(t, err)
+
+	// Generate from loaded state
+	userBinDir := filepath.Join(home, ".local/bin")
+
+	t.Run("posix", func(t *testing.T) {
+		f := env.NewFormatter(env.ShellPosix)
+		lines := env.Generate(loaded.Runtimes, userBinDir, f)
+		assert.NotEmpty(t, lines)
+
+		output := joinLines(lines)
+		assert.Contains(t, output, `export GOROOT=`)
+		assert.Contains(t, output, `export GOBIN=`)
+		assert.Contains(t, output, `export PATH=`)
+	})
+
+	t.Run("fish", func(t *testing.T) {
+		f := env.NewFormatter(env.ShellFish)
+		lines := env.Generate(loaded.Runtimes, userBinDir, f)
+		assert.NotEmpty(t, lines)
+
+		output := joinLines(lines)
+		assert.Contains(t, output, `set -gx GOROOT`)
+		assert.Contains(t, output, `fish_add_path`)
+	})
+}
+
+func joinLines(lines []string) string {
+	result := ""
+	for _, l := range lines {
+		result += l + "\n"
+	}
+	return result
+}


### PR DESCRIPTION
Add `toto env` command that outputs shell environment variable
statements for installed runtimes.

- Two modes: stdout (eval "$(toto env)") and --export (file write)
- --shell flag supports posix (bash/sh/zsh) and fish
- Deterministic output with sorted runtime/env keys
- Converts absolute paths to $HOME/... for portability
- --export writes to configurable envDir (default ~/.config/toto)
- Unit tests (100% coverage on internal/env), integration, and E2E tests
