### PR TITLE
rename: toto -> tomei

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,6 @@
 {
   "instructions": [
-    "E2E tests MUST ALWAYS be run in containers using 'make test-e2e'. NEVER use TOTO_E2E_NATIVE=true or run e2e tests natively.",
-    "Before running 'make test-e2e', always run 'docker rm -f toto-e2e-ubuntu' first to clean up existing containers."
+    "E2E tests MUST ALWAYS be run in containers using 'make test-e2e'. NEVER use TOMEI_E2E_NATIVE=true or run e2e tests natively.",
+    "Before running 'make test-e2e', always run 'docker rm -f tomei-e2e-ubuntu' first to clean up existing containers."
   ]
 }

--- a/.github/actions/build-tomei/action.yaml
+++ b/.github/actions/build-tomei/action.yaml
@@ -1,5 +1,5 @@
-name: Build toto and E2E test binaries
-description: Build toto binary, e2e test binary, and ginkgo CLI for the current platform
+name: Build tomei and E2E test binaries
+description: Build tomei binary, e2e test binary, and ginkgo CLI for the current platform
 
 inputs:
   os:
@@ -22,9 +22,9 @@ runs:
       shell: bash
       run: go mod download
 
-    - name: Build toto binary
+    - name: Build tomei binary
       shell: bash
-      run: go build -o dist/toto ./cmd/toto
+      run: go build -o dist/tomei ./cmd/tomei
 
     - name: Build e2e test binary
       shell: bash

--- a/.github/actions/e2e-test/action.yaml
+++ b/.github/actions/e2e-test/action.yaml
@@ -23,14 +23,14 @@ runs:
       if: inputs.mode == 'native'
       shell: bash
       run: |
-        chmod +x dist/toto dist/e2e.test dist/ginkgo
+        chmod +x dist/tomei dist/e2e.test dist/ginkgo
 
     - name: E2E Test (Native Mode)
       if: inputs.mode == 'native'
       shell: bash
       run: |
-        TOTO_E2E_NATIVE=true \
-        TOTO_E2E_BINARY="$(pwd)/dist/toto" \
+        TOMEI_E2E_NATIVE=true \
+        TOMEI_E2E_BINARY="$(pwd)/dist/tomei" \
           ./dist/ginkgo -v ./dist/e2e.test
 
     # Container mode: setup-go is safe (tests run inside Docker, no PATH conflict)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Build E2E binaries
-        uses: ./.github/actions/build-toto
+        uses: ./.github/actions/build-tomei
         with:
           os: ${{ matrix.os }}
           arch: ${{ matrix.arch }}

--- a/.gitignore
+++ b/.gitignore
@@ -29,11 +29,11 @@ Thumbs.db
 
 # Build artifacts
 bin/
-/toto
-/e2e/toto
+/tomei
+/e2e/tomei
 
 # Local state (for testing)
-.toto/
+.tomei/
 state.json
 
 # Property-based test artifacts (rapid library)

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: build test test-integration test-e2e test-all test-cover lint fmt clean help docker-build docker-run
 
-BINARY_NAME := toto
+BINARY_NAME := tomei
 BUILD_DIR := bin
-IMAGE_NAME := toto-dev
+IMAGE_NAME := tomei-dev
 
 # Version info
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -14,7 +14,7 @@ LDFLAGS := -X main.version=$(VERSION) \
            -X main.buildDate=$(BUILD_DATE)
 
 build: ## Build the binary
-	go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/toto
+	go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/tomei
 
 test: ## Run unit tests
 	go test -v -race ./internal/... ./cmd/...
@@ -42,7 +42,7 @@ fmt: ## Format code
 clean: ## Clean build artifacts
 	rm -rf $(BUILD_DIR)
 	rm -f coverage.out coverage.html
-	rm -f toto
+	rm -f tomei
 	$(MAKE) -C e2e clean
 
 help: ## Show this help

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-toto
+tomei
 Copyright 2024-2025 terassyi
 
 This project includes code derived from the following projects:

--- a/cmd/tomei/apply.go
+++ b/cmd/tomei/apply.go
@@ -8,19 +8,19 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"github.com/terassyi/toto/internal/config"
-	"github.com/terassyi/toto/internal/github"
-	"github.com/terassyi/toto/internal/installer/download"
-	"github.com/terassyi/toto/internal/installer/engine"
-	"github.com/terassyi/toto/internal/installer/place"
-	"github.com/terassyi/toto/internal/installer/repository"
-	"github.com/terassyi/toto/internal/installer/runtime"
-	"github.com/terassyi/toto/internal/installer/tool"
-	"github.com/terassyi/toto/internal/path"
-	"github.com/terassyi/toto/internal/registry/aqua"
-	"github.com/terassyi/toto/internal/resource"
-	"github.com/terassyi/toto/internal/state"
-	"github.com/terassyi/toto/internal/ui"
+	"github.com/terassyi/tomei/internal/config"
+	"github.com/terassyi/tomei/internal/github"
+	"github.com/terassyi/tomei/internal/installer/download"
+	"github.com/terassyi/tomei/internal/installer/engine"
+	"github.com/terassyi/tomei/internal/installer/place"
+	"github.com/terassyi/tomei/internal/installer/repository"
+	"github.com/terassyi/tomei/internal/installer/runtime"
+	"github.com/terassyi/tomei/internal/installer/tool"
+	"github.com/terassyi/tomei/internal/path"
+	"github.com/terassyi/tomei/internal/registry/aqua"
+	"github.com/terassyi/tomei/internal/resource"
+	"github.com/terassyi/tomei/internal/state"
+	"github.com/terassyi/tomei/internal/ui"
 )
 
 // applyConfig holds configuration for the apply command.
@@ -39,12 +39,12 @@ var applyCmd = &cobra.Command{
 	Long: `Apply the configuration to install, upgrade, or remove resources.
 
 For user-level resources (Runtime, Tool, ToolSet):
-  toto apply .
-  toto apply tools.cue runtime.cue
-  toto apply ~/.config/toto/
+  tomei apply .
+  tomei apply tools.cue runtime.cue
+  tomei apply ~/.config/toto/
 
 For system-level resources (SystemPackageRepository, SystemPackageSet):
-  sudo toto apply --system .`,
+  sudo tomei apply --system .`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: runApply,
 }

--- a/cmd/tomei/doctor.go
+++ b/cmd/tomei/doctor.go
@@ -8,11 +8,11 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
-	"github.com/terassyi/toto/internal/config"
-	"github.com/terassyi/toto/internal/doctor"
-	"github.com/terassyi/toto/internal/path"
-	"github.com/terassyi/toto/internal/state"
-	"github.com/terassyi/toto/internal/ui"
+	"github.com/terassyi/tomei/internal/config"
+	"github.com/terassyi/tomei/internal/doctor"
+	"github.com/terassyi/tomei/internal/path"
+	"github.com/terassyi/tomei/internal/state"
+	"github.com/terassyi/tomei/internal/ui"
 )
 
 var doctorNoColor bool
@@ -24,7 +24,7 @@ var doctorCmd = &cobra.Command{
 
 Checks for:
   - Unmanaged tools in runtime bin paths (~/go/bin, ~/.cargo/bin)
-  - Conflicts between toto-managed and unmanaged tools
+  - Conflicts between tomei-managed and unmanaged tools
   - State file integrity`,
 	RunE: runDoctor,
 }

--- a/cmd/tomei/env.go
+++ b/cmd/tomei/env.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/terassyi/toto/internal/config"
-	"github.com/terassyi/toto/internal/env"
-	"github.com/terassyi/toto/internal/path"
-	"github.com/terassyi/toto/internal/state"
+	"github.com/terassyi/tomei/internal/config"
+	"github.com/terassyi/tomei/internal/env"
+	"github.com/terassyi/tomei/internal/path"
+	"github.com/terassyi/tomei/internal/state"
 )
 
 var (
@@ -25,10 +25,10 @@ var envCmd = &cobra.Command{
 	Long: `Output environment variable statements for installed runtimes.
 
 Stdout mode (default):
-  eval "$(toto env)"
+  eval "$(tomei env)"
 
 File export mode:
-  toto env --export
+  tomei env --export
   source ~/.config/toto/env.sh
 
 Shell types:

--- a/cmd/tomei/init.go
+++ b/cmd/tomei/init.go
@@ -12,24 +12,24 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"github.com/terassyi/toto/internal/config"
-	"github.com/terassyi/toto/internal/github"
-	"github.com/terassyi/toto/internal/path"
-	"github.com/terassyi/toto/internal/registry/aqua"
-	"github.com/terassyi/toto/internal/state"
-	"github.com/terassyi/toto/internal/ui"
+	"github.com/terassyi/tomei/internal/config"
+	"github.com/terassyi/tomei/internal/github"
+	"github.com/terassyi/tomei/internal/path"
+	"github.com/terassyi/tomei/internal/registry/aqua"
+	"github.com/terassyi/tomei/internal/state"
+	"github.com/terassyi/tomei/internal/ui"
 )
 
 var initCmd = &cobra.Command{
 	Use:   "init",
-	Short: "Initialize toto directories and state",
-	Long: `Initialize toto directories and state file.
+	Short: "Initialize tomei directories and state",
+	Long: `Initialize tomei directories and state file.
 
 Creates the following directories:
-  - Config directory (~/.config/toto/)
-  - Data directory (~/.local/share/toto/)
-  - Tools directory (~/.local/share/toto/tools/)
-  - Runtimes directory (~/.local/share/toto/runtimes/)
+  - Config directory (~/.config/tomei/)
+  - Data directory (~/.local/share/tomei/)
+  - Tools directory (~/.local/share/tomei/tools/)
+  - Runtimes directory (~/.local/share/tomei/runtimes/)
   - Bin directory (~/.local/bin/)
 
 Also initializes an empty state.json file.
@@ -58,10 +58,10 @@ func runInit(cmd *cobra.Command, _ []string) error {
 
 	style := ui.NewStyle()
 
-	cmd.Println("Initializing toto...")
+	cmd.Println("Initializing tomei...")
 	cmd.Println()
 
-	// Get config directory (fixed to ~/.config/toto)
+	// Get config directory (fixed to ~/.config/tomei)
 	cfgDir, err := path.Expand(config.DefaultConfigDir)
 	if err != nil {
 		return fmt.Errorf("failed to expand config directory: %w", err)
@@ -188,7 +188,7 @@ func runInit(cmd *cobra.Command, _ []string) error {
 	style.Header.Fprintln(cmd.OutOrStdout(), "Next steps:")
 	cmd.Printf("  %s Add %s to your PATH\n", style.Step.Sprint("1."), style.Path.Sprint(paths.UserBinDir()))
 	cmd.Printf("  %s Create manifest files (tools.cue, runtime.cue)\n", style.Step.Sprint("2."))
-	cmd.Printf("  %s Run '%s' to install\n", style.Step.Sprint("3."), style.Path.Sprint("toto apply ."))
+	cmd.Printf("  %s Run '%s' to install\n", style.Step.Sprint("3."), style.Path.Sprint("tomei apply ."))
 
 	return nil
 }

--- a/cmd/tomei/main.go
+++ b/cmd/tomei/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/terassyi/toto/internal/errors"
+	"github.com/terassyi/tomei/internal/errors"
 )
 
 var (

--- a/cmd/tomei/plan.go
+++ b/cmd/tomei/plan.go
@@ -9,13 +9,13 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
-	"github.com/terassyi/toto/internal/config"
-	"github.com/terassyi/toto/internal/github"
-	"github.com/terassyi/toto/internal/graph"
-	"github.com/terassyi/toto/internal/path"
-	"github.com/terassyi/toto/internal/registry/aqua"
-	"github.com/terassyi/toto/internal/resource"
-	"github.com/terassyi/toto/internal/state"
+	"github.com/terassyi/tomei/internal/config"
+	"github.com/terassyi/tomei/internal/github"
+	"github.com/terassyi/tomei/internal/graph"
+	"github.com/terassyi/tomei/internal/path"
+	"github.com/terassyi/tomei/internal/registry/aqua"
+	"github.com/terassyi/tomei/internal/resource"
+	"github.com/terassyi/tomei/internal/state"
 )
 
 var planCmd = &cobra.Command{

--- a/cmd/tomei/root.go
+++ b/cmd/tomei/root.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/spf13/cobra"
-	statecmd "github.com/terassyi/toto/cmd/toto/state"
+	statecmd "github.com/terassyi/tomei/cmd/tomei/state"
 )
 
 var (
@@ -10,15 +10,15 @@ var (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "toto",
+	Use:   "tomei",
 	Short: "Declarative development environment setup tool",
-	Long: `Toto is a declarative development environment setup tool.
+	Long: `Tomei is a declarative development environment setup tool.
 It manages tools, language runtimes, and system packages
 using a Kubernetes-like Spec/State reconciliation pattern.
 
 Commands are separated by privilege level:
-  toto apply              Apply user-level resources (Runtime, Tool)
-  sudo toto apply --system  Apply system-level resources (SystemPackage)`,
+  tomei apply              Apply user-level resources (Runtime, Tool)
+  sudo tomei apply --system  Apply system-level resources (SystemPackage)`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 }

--- a/cmd/tomei/state/diff.go
+++ b/cmd/tomei/state/diff.go
@@ -8,10 +8,10 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
-	"github.com/terassyi/toto/internal/config"
-	"github.com/terassyi/toto/internal/path"
-	internalstate "github.com/terassyi/toto/internal/state"
-	"github.com/terassyi/toto/internal/ui"
+	"github.com/terassyi/tomei/internal/config"
+	"github.com/terassyi/tomei/internal/path"
+	internalstate "github.com/terassyi/tomei/internal/state"
+	"github.com/terassyi/tomei/internal/ui"
 )
 
 var (
@@ -24,7 +24,7 @@ var diffCmd = &cobra.Command{
 	Short: "Show changes since last apply",
 	Long: `Compare current state with the backup created before the last apply.
 
-A backup is automatically created at the start of each "toto apply".
+A backup is automatically created at the start of each "tomei apply".
 This command shows what changed during the most recent apply.`,
 	RunE: runDiff,
 }
@@ -69,7 +69,7 @@ func runDiff(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to load backup state: %w", err)
 	}
 	if backup == nil {
-		cmd.Println("No backup found. Run 'toto apply' first.")
+		cmd.Println("No backup found. Run 'tomei apply' first.")
 		return nil
 	}
 

--- a/cmd/tomei/state/state.go
+++ b/cmd/tomei/state/state.go
@@ -6,7 +6,7 @@ import "github.com/spf13/cobra"
 var Cmd = &cobra.Command{
 	Use:   "state",
 	Short: "Manage state",
-	Long:  "Commands for inspecting and managing toto state.",
+	Long:  "Commands for inspecting and managing tomei state.",
 }
 
 func init() {

--- a/cmd/tomei/uninit.go
+++ b/cmd/tomei/uninit.go
@@ -10,20 +10,20 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"github.com/terassyi/toto/internal/config"
-	"github.com/terassyi/toto/internal/path"
-	"github.com/terassyi/toto/internal/ui"
+	"github.com/terassyi/tomei/internal/config"
+	"github.com/terassyi/tomei/internal/path"
+	"github.com/terassyi/tomei/internal/ui"
 )
 
 var uninitCmd = &cobra.Command{
 	Use:   "uninit",
-	Short: "Remove toto directories and state",
-	Long: `Remove toto directories, state files, and managed symlinks.
+	Short: "Remove tomei directories and state",
+	Long: `Remove tomei directories, state files, and managed symlinks.
 
 This command removes:
   - Config directory (~/.config/toto/)
-  - Data directory (~/.local/share/toto/)
-  - Symlinks in bin directory (~/.local/bin/) that point to toto-managed tools
+  - Data directory (~/.local/share/tomei/)
+  - Symlinks in bin directory (~/.local/bin/) that point to tomei-managed tools
 
 The bin directory itself is preserved as it may contain non-toto files.
 
@@ -72,7 +72,7 @@ func runUninit(cmd *cobra.Command, _ []string) error {
 
 	if ctx == nil {
 		// Not initialized
-		cmd.Println("toto is not initialized. Nothing to remove.")
+		cmd.Println("tomei is not initialized. Nothing to remove.")
 		return nil
 	}
 
@@ -271,7 +271,7 @@ func findManagedSymlinks(binDir, dataDir string) ([]string, error) {
 			target = filepath.Join(binDir, target)
 		}
 
-		// Check if target points to toto-managed directory
+		// Check if target points to tomei-managed directory
 		if strings.HasPrefix(target, dataDir) {
 			symlinks = append(symlinks, linkPath)
 		}

--- a/cmd/tomei/validate.go
+++ b/cmd/tomei/validate.go
@@ -6,10 +6,10 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
-	"github.com/terassyi/toto/internal/config"
-	"github.com/terassyi/toto/internal/graph"
-	"github.com/terassyi/toto/internal/resource"
-	"github.com/terassyi/toto/internal/ui"
+	"github.com/terassyi/tomei/internal/config"
+	"github.com/terassyi/tomei/internal/graph"
+	"github.com/terassyi/tomei/internal/resource"
+	"github.com/terassyi/tomei/internal/ui"
 )
 
 var validateNoColor bool

--- a/cmd/tomei/version.go
+++ b/cmd/tomei/version.go
@@ -37,7 +37,7 @@ var versionCmd = &cobra.Command{
 			enc.SetIndent("", "  ")
 			return enc.Encode(info)
 		default:
-			cmd.Printf("toto version %s\n", info.Version)
+			cmd.Printf("tomei version %s\n", info.Version)
 			cmd.Printf("  commit:    %s\n", info.Commit)
 			cmd.Printf("  built:     %s\n", info.BuildDate)
 			cmd.Printf("  go:        %s\n", info.GoVersion)

--- a/docs/design.en.md
+++ b/docs/design.en.md
@@ -1,4 +1,4 @@
-# Toto Design Document v2
+# Tomei Design Document v2
 
 **Version:** 2.0  
 **Date:** 2025-01-28
@@ -7,11 +7,11 @@
 
 ## 1. Overview
 
-Toto is a declarative development environment setup tool. It adopts Kubernetes' Spec/State reconciliation pattern to manage local tools, runtimes, and system packages.
+Tomei is a declarative development environment setup tool. It adopts Kubernetes' Spec/State reconciliation pattern to manage local tools, runtimes, and system packages.
 
 ### Design Philosophy
 
-- **Declarative Management**: Define desired state, toto realizes it
+- **Declarative Management**: Define desired state, tomei realizes it
 - **No Sandboxing**: Directly set up the real environment without virtualization or containers
 - **Type Safety with CUE**: Schema validation and flexible configuration
 - **Simplicity**: Leverage existing tools (apt, go install) without nix-level complexity
@@ -20,7 +20,7 @@ Toto is a declarative development environment setup tool. It adopts Kubernetes' 
 
 ## 2. Installer Patterns
 
-Toto supports two installer patterns.
+Tomei supports two installer patterns.
 
 ### 2.1 Delegation Pattern
 
@@ -35,11 +35,11 @@ Examples:
 └── npm install -g <package>
 ```
 
-Toto instructs "what to install", while external tools perform the actual processing.
+Tomei instructs "what to install", while external tools perform the actual processing.
 
 ### 2.2 Download Pattern
 
-Toto directly downloads and places files.
+Tomei directly downloads and places files.
 
 ```
 Examples:
@@ -48,7 +48,7 @@ Examples:
 └── Aqua registry format tools
 ```
 
-Toto handles checksum verification, extraction, and symlink creation.
+Tomei handles checksum verification, extraction, and symlink creation.
 
 ---
 
@@ -57,13 +57,13 @@ Toto handles checksum verification, extraction, and symlink creation.
 ### 3.1 Classification by Privilege
 
 ```
-User Privilege (toto apply):
+User Privilege (tomei apply):
 ├── Installer  - User-level installer definition (aqua, go, cargo, npm, brew)
 ├── Runtime    - Language runtimes (Go, Rust, Node)
 ├── Tool       - Individual tools
 └── ToolSet    - Set of multiple tools
 
-System Privilege (sudo toto apply --system):
+System Privilege (sudo tomei apply --system):
 ├── SystemInstaller         - Package manager definition (apt)
 ├── SystemPackageRepository - Third-party repositories
 └── SystemPackageSet        - Package sets
@@ -73,10 +73,10 @@ System Privilege (sudo toto apply --system):
 
 #### SystemInstaller
 
-Package manager definition. apt is provided as a builtin CUE manifest by toto.
+Package manager definition. apt is provided as a builtin CUE manifest by tomei.
 
 ```cue
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "SystemInstaller"
 metadata: name: "apt"
 spec: {
@@ -96,7 +96,7 @@ spec: {
 Third-party repository definition.
 
 ```cue
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "SystemPackageRepository"
 metadata: name: "docker"
 spec: {
@@ -119,7 +119,7 @@ spec: {
 Set of packages.
 
 ```cue
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "SystemPackageSet"
 metadata: name: "docker"
 spec: {
@@ -131,11 +131,11 @@ spec: {
 
 #### Installer
 
-User-level installer definition. toto provides builtin installers: aqua, go, cargo, npm, brew.
+User-level installer definition. tomei provides builtin installers: aqua, go, cargo, npm, brew.
 
 ```cue
 // Download Pattern (aqua) - Downloads directly from GitHub Releases, etc.
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Installer"
 metadata: name: "aqua"
 spec: {
@@ -143,7 +143,7 @@ spec: {
 }
 
 // Delegation Pattern (binstall) - depends on Tool
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Installer"
 metadata: name: "binstall"
 spec: {
@@ -157,7 +157,7 @@ spec: {
 }
 
 // Delegation Pattern (brew) - No Runtime dependency, self-install via bootstrap
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Installer"
 metadata: name: "brew"
 spec: {
@@ -182,7 +182,7 @@ Language runtimes. Supports two installation patterns:
 **Download Pattern** - Downloads and extracts tarball directly (e.g., Go):
 
 ```cue
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Runtime"
 metadata: name: "go"
 spec: {
@@ -209,7 +209,7 @@ spec: {
 **Delegation Pattern** - Executes installer script (e.g., Rust via rustup):
 
 ```cue
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Runtime"
 metadata: name: "rust"
 spec: {
@@ -242,16 +242,16 @@ spec: {
 
 | Aspect | Download Pattern | Delegation Pattern |
 |--------|------------------|-------------------|
-| Installation | toto downloads & extracts tarball | External script installs (e.g., rustup) |
+| Installation | tomei downloads & extracts tarball | External script installs (e.g., rustup) |
 | Source | `source.url` with checksum | `commands.install` script |
 | Binary location | Extracted to `dataDir/runtimes/` | Managed by external tool (e.g., `~/.cargo/bin`) |
-| Symlinks | Created by toto from extract dir | Not needed (binaries already in toolBinPath) |
-| Version management | toto manages versions | External tool manages (e.g., rustup) |
+| Symlinks | Created by tomei from extract dir | Not needed (binaries already in toolBinPath) |
+| Version management | tomei manages versions | External tool manages (e.g., rustup) |
 
 #### Tool (Individual)
 
 ```cue
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Tool"
 metadata: name: "ripgrep"
 spec: {
@@ -271,7 +271,7 @@ Set of multiple tools. Eliminates redundancy.
 
 ```cue
 // Download Pattern
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "ToolSet"
 metadata: name: "cli-tools"
 spec: {
@@ -284,7 +284,7 @@ spec: {
 }
 
 // Install via Runtime (no Installer needed)
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "ToolSet"
 metadata: name: "go-tools"
 spec: {
@@ -304,44 +304,44 @@ spec: {
 
 ```bash
 # User privilege (Runtime, Tool)
-toto apply
+tomei apply
 
 # System privilege (SystemPackage*)
-sudo toto apply --system
+sudo tomei apply --system
 ```
 
-Execution order: `sudo toto apply --system` → `toto apply`
+Execution order: `sudo tomei apply --system` → `tomei apply`
 
 ### 4.2 Command List
 
 ```bash
-toto init        # Initialize (config.cue, directories, state.json)
-toto validate    # CUE syntax + circular reference check
-toto plan        # validate + show execution plan
-toto apply       # plan + execute
-toto env         # Output environment variables (for eval)
-toto doctor      # detect unmanaged tools, conflicts
+tomei init        # Initialize (config.cue, directories, state.json)
+tomei validate    # CUE syntax + circular reference check
+tomei plan        # validate + show execution plan
+tomei apply       # plan + execute
+tomei env         # Output environment variables (for eval)
+tomei doctor      # detect unmanaged tools, conflicts
 
-toto version     # show version
+tomei version     # show version
 ```
 
-### 4.3 toto init
+### 4.3 tomei init
 
 Initialize the environment.
 
 ```bash
 # Interactive initialization (prompts to create config.cue if missing)
-toto init
+tomei init
 
 # Skip prompts and initialize
-toto init --yes
+tomei init --yes
 
 # Force reinitialization (resets state.json)
-toto init --force
+tomei init --force
 ```
 
 Execution steps:
-1. Create `~/.config/toto/` directory
+1. Create `~/.config/tomei/` directory
 2. If `config.cue` doesn't exist, create with default values (interactive or `--yes`)
 3. Load path settings from `config.cue`
 4. Create data directory (`dataDir`)
@@ -349,13 +349,13 @@ Execution steps:
 6. Create bin directory (`binDir`)
 7. Initialize `dataDir/state.json`
 
-### 4.4 toto env
+### 4.4 tomei env
 
 Outputs environment variables defined in Runtime's `env` field.
 
 ```bash
-$ toto env
-export GOROOT="$HOME/.local/share/toto/runtimes/go/1.25.1"
+$ tomei env
+export GOROOT="$HOME/.local/share/tomei/runtimes/go/1.25.1"
 export GOBIN="$HOME/go/bin"
 export CARGO_HOME="$HOME/.cargo"
 export RUSTUP_HOME="$HOME/.rustup"
@@ -367,12 +367,12 @@ export PATH="$HOME/.local/bin:$HOME/go/bin:$HOME/.cargo/bin:$PATH"
 Add the following to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.):
 
 ```bash
-eval "$(toto env)"
+eval "$(tomei env)"
 ```
 
-**Note:** During `toto apply`, delegation commands are automatically executed with the `env` field's environment variables set by toto. Therefore, `toto env` is for the user's shell environment.
+**Note:** During `tomei apply`, delegation commands are automatically executed with the `env` field's environment variables set by tomei. Therefore, `tomei env` is for the user's shell environment.
 
-**PATH propagation for toolRef:** When an Installer has a `toolRef` (e.g., Installer/binstall depends on Tool/cargo-binstall), toto automatically prepends the referenced Tool's bin directory to PATH when executing delegation commands. This applies to both Tool installation commands (e.g., `cargo binstall ripgrep`) and InstallerRepository commands (e.g., `helm repo add`). This ensures that delegation commands can find their dependent tool binaries even when the user's shell PATH does not include the tool's bin directory.
+**PATH propagation for toolRef:** When an Installer has a `toolRef` (e.g., Installer/binstall depends on Tool/cargo-binstall), tomei automatically prepends the referenced Tool's bin directory to PATH when executing delegation commands. This applies to both Tool installation commands (e.g., `cargo binstall ripgrep`) and InstallerRepository commands (e.g., `helm repo add`). This ensures that delegation commands can find their dependent tool binaries even when the user's shell PATH does not include the tool's bin directory.
 
 ---
 
@@ -382,12 +382,12 @@ eval "$(toto env)"
 
 ```
 User State:
-~/.local/share/toto/
+~/.local/share/tomei/
 ├── state.lock  (write PID, for flock)
 └── state.json  (state data)
 
 System State:
-/var/lib/toto/
+/var/lib/tomei/
 ├── state.lock
 └── state.json
 ```
@@ -397,7 +397,7 @@ System State:
 - Uses **flock (advisory lock)**
 - Acquires flock on state.lock
 - Writes own PID on successful acquisition
-- Prevents concurrent execution between toto processes
+- Prevents concurrent execution between tomei processes
 - Cannot prevent manual editing (vim, etc.) - nature of advisory locks
 
 ### 5.3 Write Flow
@@ -424,12 +424,12 @@ System State:
       "type": "download",
       "version": "1.25.1",
       "digest": "sha256:abc123...",
-      "installPath": "~/.local/share/toto/runtimes/go/1.25.1",
+      "installPath": "~/.local/share/tomei/runtimes/go/1.25.1",
       "binaries": ["go", "gofmt"],
-      "binDir": "~/.local/share/toto/runtimes/go/1.25.1/bin",
+      "binDir": "~/.local/share/tomei/runtimes/go/1.25.1/bin",
       "toolBinPath": "~/go/bin",
       "env": {
-        "GOROOT": "~/.local/share/toto/runtimes/go/1.25.1",
+        "GOROOT": "~/.local/share/tomei/runtimes/go/1.25.1",
         "GOBIN": "~/go/bin"
       },
       "updatedAt": "2025-01-28T12:00:00Z"
@@ -460,7 +460,7 @@ System State:
       "installerRef": "aqua",
       "version": "14.0.0",
       "digest": "sha256:def456...",
-      "installPath": "~/.local/share/toto/tools/ripgrep/14.0.0",
+      "installPath": "~/.local/share/tomei/tools/ripgrep/14.0.0",
       "binPath": "~/.local/bin/rg",
       "source": {
         "url": "https://github.com/BurntSushi/ripgrep/releases/...",
@@ -503,8 +503,8 @@ System State:
         "keyDigest": "sha256:..."
       },
       "installedFiles": [
-        "/etc/apt/keyrings/toto-docker.asc",
-        "/etc/apt/sources.list.d/toto-docker.list"
+        "/etc/apt/keyrings/tomei-docker.asc",
+        "/etc/apt/sources.list.d/tomei-docker.list"
       ],
       "updatedAt": "2025-01-28T12:00:00Z"
     }
@@ -582,7 +582,7 @@ spec: {
 }
 
 // 4. ripgrep Tool (installed via binstall installer)
-// When executing the install command, toto prepends cargo-binstall's bin directory to PATH.
+// When executing the install command, tomei prepends cargo-binstall's bin directory to PATH.
 kind: "Tool"
 metadata: name: "ripgrep"
 spec: {
@@ -652,7 +652,7 @@ Normal case:                   Cycle case:
                                  C → A where A is gray → back edge → Cycle!
 ```
 
-Detected early with `toto validate`, error message shows the cycle path.
+Detected early with `tomei validate`, error message shows the cycle path.
 
 ### 6.5 Topological Sort
 
@@ -712,12 +712,12 @@ Future improvement: batch state updates after layer completion.
 ### 6.7 Execution Order Summary
 
 ```
-System Privilege (sudo toto apply --system):
+System Privilege (sudo tomei apply --system):
   Layer 0: SystemInstaller
   Layer 1: SystemPackageRepository
   Layer 2: SystemPackageSet
 
-User Privilege (toto apply):
+User Privilege (tomei apply):
   Determined by DAG topological sort:
   - Runtime (no dependencies)
   - Installer (depends on Runtime or Tool)
@@ -749,7 +749,7 @@ node update → Tools installed via npm install -g
 
 ---
 
-## 8. toto doctor
+## 8. tomei doctor
 
 Detection of unmanaged tools and conflict detection.
 
@@ -768,7 +768,7 @@ Common:
 ### 8.2 Example Output
 
 ```
-$ toto doctor
+$ tomei doctor
 
 [go] ~/go/bin/
   gopls        unmanaged
@@ -778,7 +778,7 @@ $ toto doctor
   cargo-edit   unmanaged
 
 [Conflicts]
-  gopls: found in both ~/.local/bin (toto) and ~/go/bin (unmanaged)
+  gopls: found in both ~/.local/bin (tomei) and ~/go/bin (unmanaged)
          PATH resolves to: ~/go/bin/gopls
 
 [Suggestions]
@@ -795,7 +795,7 @@ $ toto doctor
 
 ```cue
 #Resource: {
-    apiVersion: "toto.terassyi.net/v1beta1"
+    apiVersion: "tomei.terassyi.net/v1beta1"
     kind: string
     metadata: {
         name: string
@@ -818,7 +818,7 @@ $ toto doctor
 ### 9.3 Environment Variable Injection
 
 ```cue
-// Automatically injected by toto
+// Automatically injected by tomei
 _env: {
     os: "linux" | "darwin"
     arch: "amd64" | "arm64"
@@ -850,7 +850,7 @@ overlays/darwin/tools.cue
 overlays/headless/tools.cue
 ```
 
-Leverages CUE's automatic merge feature for same package. toto selects and loads files based on environment.
+Leverages CUE's automatic merge feature for same package. tomei selects and loads files based on environment.
 
 ### 9.6 Exclusion Expression
 
@@ -897,7 +897,7 @@ Mode:
 ```
 ├── Tool (Download Pattern) with checksum verification
 ├── Aqua Registry integration (package resolution, --sync)
-├── Install tools with toto apply
+├── Install tools with tomei apply
 ├── Symlink to ~/.local/bin
 └── Update state.json
 ```
@@ -908,7 +908,7 @@ Mode:
 ├── Runtime (Go, Rust, Node.js)
 ├── Tool Runtime Delegation (go install, cargo install, npm install -g)
 ├── Taint Logic (runtime upgrade triggers tool reinstall)
-├── toto doctor (unmanaged tool detection, conflict detection)
+├── tomei doctor (unmanaged tool detection, conflict detection)
 └── Removal dependency guard (reject runtime removal if dependent tools remain)
 ```
 
@@ -932,7 +932,7 @@ Mode:
 ### Phase 6: Userland Commands (Completed)
 
 ```
-└── toto env — export runtime environment variables for shell (eval $(toto env))
+└── tomei env — export runtime environment variables for shell (eval $(tomei env))
 ```
 
 ### Phase 7: Runtime Delegation & Version Resolution (Completed)
@@ -965,7 +965,7 @@ Mode:
 ├── SystemInstaller (apt builtin)
 ├── SystemPackageRepository
 ├── SystemPackageSet
-└── toto apply --system
+└── tomei apply --system
 ```
 
 ---
@@ -973,7 +973,7 @@ Mode:
 ## 12. Directory Structure
 
 ```
-~/.config/toto/           # Config directory (fixed)
+~/.config/tomei/           # Config directory (fixed)
 ├── config.cue            # Path settings (required)
 ├── tools.cue             # Tool definitions
 ├── runtimes.cue          # Runtime definitions
@@ -986,7 +986,7 @@ Mode:
     ├── repos.cue
     └── packages.cue
 
-~/.local/share/toto/      # Data directory (configurable via config.cue)
+~/.local/share/tomei/      # Data directory (configurable via config.cue)
 ├── state.lock
 ├── state.json
 ├── runtimes/
@@ -996,21 +996,21 @@ Mode:
 
 ~/.local/bin/             # Symlink destination (configurable via config.cue)
 
-/var/lib/toto/            # System State
+/var/lib/tomei/            # System State
 ├── state.lock
 └── state.json
 ```
 
 ### 12.1 config.cue
 
-Path settings file. Fixed at `~/.config/toto/config.cue`.
+Path settings file. Fixed at `~/.config/tomei/config.cue`.
 
 ```cue
-package toto
+package tomei
 
 config: {
     // Data directory (storage for tools, runtimes, state.json)
-    dataDir: "~/.local/share/toto"
+    dataDir: "~/.local/share/tomei"
     
     // Symlink destination
     binDir: "~/.local/bin"
@@ -1018,10 +1018,10 @@ config: {
 ```
 
 Default values:
-- `dataDir`: `~/.local/share/toto`
+- `dataDir`: `~/.local/share/tomei`
 - `binDir`: `~/.local/bin`
 
-When `config.cue` doesn't exist, `toto init` will interactively create it with default values.
+When `config.cue` doesn't exist, `tomei init` will interactively create it with default values.
 
 ---
 
@@ -1157,11 +1157,11 @@ func (m *mockToolInstaller) Install(ctx context.Context, res *resource.Tool, nam
 - Full system test in Docker container
 - Real downloads and installations
 - Actual binary execution verification
-- Tests `toto apply` command end-to-end
+- Tests `tomei apply` command end-to-end
 
 **Requirements:**
 - Runs in isolated Docker container
-- Requires `TOTO_E2E_CONTAINER` environment variable
+- Requires `TOMEI_E2E_CONTAINER` environment variable
 - linux/amd64 only
 - Network access for real downloads
 
@@ -1205,7 +1205,7 @@ cd e2e && make test
 A repository that provides tool metadata (URL patterns, architecture-specific filenames, etc.) like aqua registry. Similar role to SystemPackageRepository.
 
 ```cue
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "InstallerRepository"
 metadata: name: "aqua-registry"
 spec: {
@@ -1223,7 +1223,7 @@ This simplifies Tool definitions:
 
 ```cue
 // With InstallerRepository, source is not needed
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Tool"
 metadata: name: "ripgrep"
 spec: {
@@ -1247,7 +1247,7 @@ spec: {
     type: "download"
     auth: {
         tokenEnvVar: "GITHUB_TOKEN"  // get from environment variable
-        // or tokenFile: "~/.config/toto/github-token"
+        // or tokenFile: "~/.config/tomei/github-token"
     }
 }
 ```
@@ -1260,7 +1260,7 @@ metadata: name: "github"
 spec: {
     type: "token"
     envVar: "GITHUB_TOKEN"
-    // or file: "~/.config/toto/github-token"
+    // or file: "~/.config/tomei/github-token"
     // or secretRef: "..." (integration with external secret management)
 }
 
@@ -1284,7 +1284,7 @@ spec: {
 ### 16.1 Auto-update latest-specified tools on `--sync`
 
 **Overview:**
-When running `toto apply --sync`, if the aqua-registry ref is updated, tools specified with `latest` should have their latest version re-fetched and automatically reinstalled if different from the installed version.
+When running `tomei apply --sync`, if the aqua-registry ref is updated, tools specified with `latest` should have their latest version re-fetched and automatically reinstalled if different from the installed version.
 
 **Current Behavior:**
 - `--sync` only updates `registry.aqua.ref` in state.json
@@ -1292,7 +1292,7 @@ When running `toto apply --sync`, if the aqua-registry ref is updated, tools spe
 - Subsequent applies compare against the state version, so changes in the latest version are not detected
 
 **Expected Behavior:**
-1. Run `toto apply --sync`
+1. Run `tomei apply --sync`
 2. Fetch the latest aqua-registry ref
 3. If ref changed, update state
 4. For tools specified with `latest`:

--- a/docs/design.ja.md
+++ b/docs/design.ja.md
@@ -1,4 +1,4 @@
-# Toto 設計ドキュメント v2
+# Tomei 設計ドキュメント v2
 
 **Version:** 2.0  
 **Date:** 2025-01-28
@@ -7,11 +7,11 @@
 
 ## 1. 概要
 
-Toto は宣言的な開発環境セットアップツール。Kubernetes の Spec/State reconciliation パターンを採用し、ローカル環境のツール、ランタイム、システムパッケージを管理する。
+Tomei は宣言的な開発環境セットアップツール。Kubernetes の Spec/State reconciliation パターンを採用し、ローカル環境のツール、ランタイム、システムパッケージを管理する。
 
 ### 設計哲学
 
-- **宣言的管理**: 望む状態を定義し、toto が実現する
+- **宣言的管理**: 望む状態を定義し、tomei が実現する
 - **サンドボックス不使用**: 仮想化やコンテナを使わず、実環境を直接セットアップ
 - **CUE による型安全**: スキーマ検証と柔軟な設定
 - **シンプルさ**: nix ほど複雑にせず、既存ツール (apt, go install) を活用
@@ -20,7 +20,7 @@ Toto は宣言的な開発環境セットアップツール。Kubernetes の Spe
 
 ## 2. インストーラパターン
 
-toto は2つのインストーラパターンをサポートする。
+tomei は2つのインストーラパターンをサポートする。
 
 ### 2.1 Delegation Pattern
 
@@ -35,11 +35,11 @@ toto は2つのインストーラパターンをサポートする。
 └── npm install -g <package>
 ```
 
-toto は「何をインストールするか」を指示し、実際の処理は外部ツールが行う。
+tomei は「何をインストールするか」を指示し、実際の処理は外部ツールが行う。
 
 ### 2.2 Download Pattern
 
-toto が直接ダウンロードして配置するパターン。
+tomei が直接ダウンロードして配置するパターン。
 
 ```
 例:
@@ -48,7 +48,7 @@ toto が直接ダウンロードして配置するパターン。
 └── Aqua registry 形式のツール
 ```
 
-チェックサム検証、展開、symlink 作成まで toto が担当。
+チェックサム検証、展開、symlink 作成まで tomei が担当。
 
 ---
 
@@ -57,13 +57,13 @@ toto が直接ダウンロードして配置するパターン。
 ### 3.1 権限による分類
 
 ```
-User 権限 (toto apply):
+User 権限 (tomei apply):
 ├── Installer  - ユーザー権限インストーラ定義 (aqua, go, cargo, npm, brew)
 ├── Runtime    - 言語ランタイム (Go, Rust, Node)
 ├── Tool       - 単体ツール
 └── ToolSet    - 複数ツールのセット
 
-System 権限 (sudo toto apply --system):
+System 権限 (sudo tomei apply --system):
 ├── SystemInstaller         - パッケージマネージャ定義 (apt)
 ├── SystemPackageRepository - サードパーティリポジトリ
 └── SystemPackageSet        - パッケージセット
@@ -73,10 +73,10 @@ System 権限 (sudo toto apply --system):
 
 #### SystemInstaller
 
-パッケージマネージャの定義。apt は toto が builtin として CUE マニフェストを提供。
+パッケージマネージャの定義。apt は tomei が builtin として CUE マニフェストを提供。
 
 ```cue
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "SystemInstaller"
 metadata: name: "apt"
 spec: {
@@ -96,7 +96,7 @@ spec: {
 サードパーティリポジトリの定義。
 
 ```cue
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "SystemPackageRepository"
 metadata: name: "docker"
 spec: {
@@ -119,7 +119,7 @@ spec: {
 パッケージのセット。
 
 ```cue
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "SystemPackageSet"
 metadata: name: "docker"
 spec: {
@@ -137,7 +137,7 @@ spec: {
 
 ```cue
 // Download Pattern (aqua) - GitHub Releases 等から直接ダウンロード
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Installer"
 metadata: name: "aqua"
 spec: {
@@ -145,7 +145,7 @@ spec: {
 }
 
 // Delegation Pattern (binstall) - Tool に依存
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Installer"
 metadata: name: "binstall"
 spec: {
@@ -159,7 +159,7 @@ spec: {
 }
 
 // Delegation Pattern (brew) - Runtime 不要、bootstrap で自己インストール
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Installer"
 metadata: name: "brew"
 spec: {
@@ -183,10 +183,10 @@ spec: {
 
 ##### Download Pattern
 
-toto が直接 tarball をダウンロードして展開するパターン。Go などの tarball 配布に適用。
+tomei が直接 tarball をダウンロードして展開するパターン。Go などの tarball 配布に適用。
 
 ```cue
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Runtime"
 metadata: name: "go"
 spec: {
@@ -215,7 +215,7 @@ spec: {
 外部スクリプトやインストーラに処理を委譲するパターン。rustup や nvm のようなインストーラスクリプトを使用するランタイムに適用。
 
 ```cue
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Runtime"
 metadata: name: "rust"
 spec: {
@@ -248,13 +248,13 @@ spec: {
 
 | パターン | 説明 | 例 |
 |---------|------|-----|
-| Download | toto が tarball をダウンロード・展開 | Go, Node (tarball) |
+| Download | tomei が tarball をダウンロード・展開 | Go, Node (tarball) |
 | Delegation | 外部スクリプト/インストーラに委譲 | Rust (rustup), Node (nvm) |
 
 #### Tool (単体)
 
 ```cue
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Tool"
 metadata: name: "ripgrep"
 spec: {
@@ -274,7 +274,7 @@ spec: {
 
 ```cue
 // Download Pattern
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "ToolSet"
 metadata: name: "cli-tools"
 spec: {
@@ -287,7 +287,7 @@ spec: {
 }
 
 // Runtime 経由でインストール (Installer 不要)
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "ToolSet"
 metadata: name: "go-tools"
 spec: {
@@ -307,44 +307,44 @@ spec: {
 
 ```bash
 # User 権限 (Runtime, Tool)
-toto apply
+tomei apply
 
 # System 権限 (SystemPackage*)
-sudo toto apply --system
+sudo tomei apply --system
 ```
 
-実行順序: `sudo toto apply --system` → `toto apply`
+実行順序: `sudo tomei apply --system` → `tomei apply`
 
 ### 4.2 コマンド一覧
 
 ```bash
-toto init        # 初期化 (config.cue, ディレクトリ, state.json)
-toto validate    # CUE 構文 + 循環参照チェック
-toto plan        # validate + 実行計画表示
-toto apply       # plan + 実行
-toto env         # 環境変数を出力 (eval 用)
-toto doctor      # 未管理ツール検知、競合検知
+tomei init        # 初期化 (config.cue, ディレクトリ, state.json)
+tomei validate    # CUE 構文 + 循環参照チェック
+tomei plan        # validate + 実行計画表示
+tomei apply       # plan + 実行
+tomei env         # 環境変数を出力 (eval 用)
+tomei doctor      # 未管理ツール検知、競合検知
 
-toto version     # バージョン表示
+tomei version     # バージョン表示
 ```
 
-### 4.3 toto init
+### 4.3 tomei init
 
 環境の初期化を行う。
 
 ```bash
 # 対話的に初期化 (config.cue がなければ作成確認)
-toto init
+tomei init
 
 # 対話スキップで初期化
-toto init --yes
+tomei init --yes
 
 # 強制的に再初期化 (state.json をリセット)
-toto init --force
+tomei init --force
 ```
 
 実行内容:
-1. `~/.config/toto/` ディレクトリ作成
+1. `~/.config/tomei/` ディレクトリ作成
 2. `config.cue` が存在しない場合、デフォルト値で作成（対話確認または `--yes`）
 3. `config.cue` からパス設定を読み込み
 4. データディレクトリ (`dataDir`) 作成
@@ -352,13 +352,13 @@ toto init --force
 6. bin ディレクトリ (`binDir`) 作成
 7. `dataDir/state.json` 初期化
 
-### 4.4 toto env
+### 4.4 tomei env
 
 Runtime の `env` フィールドで定義された環境変数を出力する。
 
 ```bash
-$ toto env
-export GOROOT="$HOME/.local/share/toto/runtimes/go/1.25.1"
+$ tomei env
+export GOROOT="$HOME/.local/share/tomei/runtimes/go/1.25.1"
 export GOBIN="$HOME/go/bin"
 export CARGO_HOME="$HOME/.cargo"
 export RUSTUP_HOME="$HOME/.rustup"
@@ -370,12 +370,12 @@ export PATH="$HOME/.local/bin:$HOME/go/bin:$HOME/.cargo/bin:$PATH"
 シェルの profile (`~/.bashrc`, `~/.zshrc` など) に以下を追加:
 
 ```bash
-eval "$(toto env)"
+eval "$(tomei env)"
 ```
 
-**Note:** `toto apply` 時の delegation コマンド実行では、toto が自動的に `env` フィールドの環境変数をセットしてコマンドを実行する。そのため `toto env` はユーザーのシェル環境用。
+**Note:** `tomei apply` 時の delegation コマンド実行では、tomei が自動的に `env` フィールドの環境変数をセットしてコマンドを実行する。そのため `tomei env` はユーザーのシェル環境用。
 
-**toolRef の PATH 伝搬:** Installer が `toolRef` を持つ場合（例: Installer/binstall が Tool/cargo-binstall に依存）、toto は delegation コマンド実行時に参照先 Tool の bin ディレクトリを自動的に PATH に追加する。これは Tool のインストールコマンド（例: `cargo binstall ripgrep`）と InstallerRepository のコマンド（例: `helm repo add`）の両方に適用される。ユーザーのシェル PATH に Tool の bin ディレクトリが含まれていなくても、delegation コマンドが依存する Tool バイナリを見つけられる。
+**toolRef の PATH 伝搬:** Installer が `toolRef` を持つ場合（例: Installer/binstall が Tool/cargo-binstall に依存）、tomei は delegation コマンド実行時に参照先 Tool の bin ディレクトリを自動的に PATH に追加する。これは Tool のインストールコマンド（例: `cargo binstall ripgrep`）と InstallerRepository のコマンド（例: `helm repo add`）の両方に適用される。ユーザーのシェル PATH に Tool の bin ディレクトリが含まれていなくても、delegation コマンドが依存する Tool バイナリを見つけられる。
 
 ---
 
@@ -385,12 +385,12 @@ eval "$(toto env)"
 
 ```
 User State:
-~/.local/share/toto/
+~/.local/share/tomei/
 ├── state.lock  (PID を書き込み、flock 用)
 └── state.json  (状態データ)
 
 System State:
-/var/lib/toto/
+/var/lib/tomei/
 ├── state.lock
 └── state.json
 ```
@@ -400,7 +400,7 @@ System State:
 - **flock (advisory lock)** を使用
 - state.lock に対して flock を取得
 - 取得成功時に自身の PID を書き込む
-- toto 同士の同時実行を防止
+- tomei 同士の同時実行を防止
 - 手動編集 (vim 等) は防げない (advisory lock の性質)
 
 ### 5.3 書き込みフロー
@@ -427,11 +427,11 @@ System State:
       "pattern": "download",
       "version": "1.25.1",
       "digest": "sha256:abc123...",
-      "installPath": "~/.local/share/toto/runtimes/go/1.25.1",
+      "installPath": "~/.local/share/tomei/runtimes/go/1.25.1",
       "binaries": ["go", "gofmt"],
       "toolBinPath": "~/go/bin",
       "env": {
-        "GOROOT": "~/.local/share/toto/runtimes/go/1.25.1"
+        "GOROOT": "~/.local/share/tomei/runtimes/go/1.25.1"
       },
       "updatedAt": "2025-01-28T12:00:00Z"
     },
@@ -461,7 +461,7 @@ System State:
       "installerRef": "aqua",
       "version": "14.0.0",
       "digest": "sha256:def456...",
-      "installPath": "~/.local/share/toto/tools/ripgrep/14.0.0",
+      "installPath": "~/.local/share/tomei/tools/ripgrep/14.0.0",
       "binPath": "~/.local/bin/rg",
       "source": {
         "url": "https://github.com/BurntSushi/ripgrep/releases/...",
@@ -504,8 +504,8 @@ System State:
         "keyDigest": "sha256:..."
       },
       "installedFiles": [
-        "/etc/apt/keyrings/toto-docker.asc",
-        "/etc/apt/sources.list.d/toto-docker.list"
+        "/etc/apt/keyrings/tomei-docker.asc",
+        "/etc/apt/sources.list.d/tomei-docker.list"
       ],
       "updatedAt": "2025-01-28T12:00:00Z"
     }
@@ -583,7 +583,7 @@ spec: {
 }
 
 // 4. ripgrep Tool (binstall installer でインストール)
-// install コマンド実行時、toto が cargo-binstall の bin ディレクトリを PATH に追加する。
+// install コマンド実行時、tomei が cargo-binstall の bin ディレクトリを PATH に追加する。
 kind: "Tool"
 metadata: name: "ripgrep"
 spec: {
@@ -653,7 +653,7 @@ spec: {
                                 C → A で A がグレー → back edge → 循環!
 ```
 
-`toto validate` で事前に検出し、エラーメッセージで循環パスを表示。
+`tomei validate` で事前に検出し、エラーメッセージで循環パスを表示。
 
 ### 6.5 トポロジカルソート
 
@@ -713,12 +713,12 @@ Layer 3: [Tool/ripgrep]         ← Installer/binstall に依存
 ### 6.7 実行順序まとめ
 
 ```
-System 権限 (sudo toto apply --system):
+System 権限 (sudo tomei apply --system):
   Layer 0: SystemInstaller
   Layer 1: SystemPackageRepository
   Layer 2: SystemPackageSet
 
-User 権限 (toto apply):
+User 権限 (tomei apply):
   DAG トポロジカルソートで決定:
   - Runtime (依存なし)
   - Installer (Runtime または Tool に依存)
@@ -750,7 +750,7 @@ node 更新 → npm install -g でインストールした Tool
 
 ---
 
-## 8. toto doctor
+## 8. tomei doctor
 
 未管理ツールの検出と競合検知。
 
@@ -769,7 +769,7 @@ Runtime 別:
 ### 8.2 出力例
 
 ```
-$ toto doctor
+$ tomei doctor
 
 [go] ~/go/bin/
   gopls        unmanaged
@@ -779,7 +779,7 @@ $ toto doctor
   cargo-edit   unmanaged
 
 [Conflicts]
-  gopls: found in both ~/.local/bin (toto) and ~/go/bin (unmanaged)
+  gopls: found in both ~/.local/bin (tomei) and ~/go/bin (unmanaged)
          PATH resolves to: ~/go/bin/gopls
 
 [Suggestions]
@@ -796,7 +796,7 @@ $ toto doctor
 
 ```cue
 #Resource: {
-    apiVersion: "toto.terassyi.net/v1beta1"
+    apiVersion: "tomei.terassyi.net/v1beta1"
     kind: string
     metadata: {
         name: string
@@ -819,7 +819,7 @@ $ toto doctor
 ### 9.3 環境変数の注入
 
 ```cue
-// toto が自動注入
+// tomei が自動注入
 _env: {
     os: "linux" | "darwin"
     arch: "amd64" | "arm64"
@@ -851,7 +851,7 @@ overlays/darwin/tools.cue
 overlays/headless/tools.cue
 ```
 
-CUE の同一パッケージ自動マージ機能を活用。toto が環境に応じてファイルを選択してロード。
+CUE の同一パッケージ自動マージ機能を活用。tomei が環境に応じてファイルを選択してロード。
 
 ### 9.6 除外の表現
 
@@ -898,7 +898,7 @@ Mode:
 ```
 ├── Tool (Download Pattern) チェックサム検証付き
 ├── Aqua Registry 統合 (パッケージ解決、--sync)
-├── toto apply でツールインストール
+├── tomei apply でツールインストール
 ├── ~/.local/bin への symlink
 └── state.json の更新
 ```
@@ -909,7 +909,7 @@ Mode:
 ├── Runtime (Go, Rust, Node.js)
 ├── Tool の Runtime Delegation (go install, cargo install, npm install -g)
 ├── Taint Logic (ランタイムアップグレード時にツール再インストール)
-├── toto doctor (未管理ツール検出、コンフリクト検出)
+├── tomei doctor (未管理ツール検出、コンフリクト検出)
 └── 削除時の依存ガード (依存ツールが残っている場合ランタイム削除を拒否)
 ```
 
@@ -933,7 +933,7 @@ Mode:
 ### Phase 6: ユーザランドコマンド (完了)
 
 ```
-└── toto env — ランタイムの環境変数をシェルにエクスポート (eval $(toto env))
+└── tomei env — ランタイムの環境変数をシェルにエクスポート (eval $(tomei env))
 ```
 
 ### Phase 7: Runtime Delegation & バージョン解決 (完了)
@@ -966,7 +966,7 @@ Mode:
 ├── SystemInstaller (apt builtin)
 ├── SystemPackageRepository
 ├── SystemPackageSet
-└── toto apply --system
+└── tomei apply --system
 ```
 
 ---
@@ -974,7 +974,7 @@ Mode:
 ## 12. ディレクトリ構成
 
 ```
-~/.config/toto/           # 設定ディレクトリ (固定)
+~/.config/tomei/           # 設定ディレクトリ (固定)
 ├── config.cue            # パス設定 (必須)
 ├── tools.cue             # ツール定義
 ├── runtimes.cue          # ランタイム定義
@@ -987,7 +987,7 @@ Mode:
     ├── repos.cue
     └── packages.cue
 
-~/.local/share/toto/      # データディレクトリ (config.cue で変更可)
+~/.local/share/tomei/      # データディレクトリ (config.cue で変更可)
 ├── state.lock
 ├── state.json
 ├── runtimes/
@@ -997,21 +997,21 @@ Mode:
 
 ~/.local/bin/             # symlink 配置先 (config.cue で変更可)
 
-/var/lib/toto/            # System State
+/var/lib/tomei/            # System State
 ├── state.lock
 └── state.json
 ```
 
 ### 12.1 config.cue
 
-パス設定ファイル。`~/.config/toto/config.cue` に固定。
+パス設定ファイル。`~/.config/tomei/config.cue` に固定。
 
 ```cue
-package toto
+package tomei
 
 config: {
     // データディレクトリ (tools, runtimes, state.json の保存先)
-    dataDir: "~/.local/share/toto"
+    dataDir: "~/.local/share/tomei"
     
     // symlink 配置先
     binDir: "~/.local/bin"
@@ -1019,10 +1019,10 @@ config: {
 ```
 
 デフォルト値:
-- `dataDir`: `~/.local/share/toto`
+- `dataDir`: `~/.local/share/tomei`
 - `binDir`: `~/.local/bin`
 
-`toto init` で config.cue が存在しない場合、対話的にデフォルト値で作成する。
+`tomei init` で config.cue が存在しない場合、対話的にデフォルト値で作成する。
 
 ---
 
@@ -1158,11 +1158,11 @@ func (m *mockToolInstaller) Install(ctx context.Context, res *resource.Tool, nam
 - Docker コンテナ内でのフルシステムテスト
 - 実際のダウンロードとインストール
 - 実際のバイナリ実行検証
-- `toto apply` コマンドのエンドツーエンドテスト
+- `tomei apply` コマンドのエンドツーエンドテスト
 
 **要件:**
 - 分離された Docker コンテナ内で実行
-- `TOTO_E2E_CONTAINER` 環境変数が必要
+- `TOMEI_E2E_CONTAINER` 環境変数が必要
 - linux/amd64 のみ
 - 実際のダウンロードのためネットワークアクセスあり
 
@@ -1206,7 +1206,7 @@ cd e2e && make test
 aqua registry のように、ツールのメタデータ（URL パターン、アーキテクチャ別ファイル名など）を提供するリポジトリ。SystemPackageRepository と同様の役割。
 
 ```cue
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "InstallerRepository"
 metadata: name: "aqua-registry"
 spec: {
@@ -1224,7 +1224,7 @@ spec: {
 
 ```cue
 // InstallerRepository があれば source 不要
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Tool"
 metadata: name: "ripgrep"
 spec: {
@@ -1248,7 +1248,7 @@ spec: {
     pattern: "download"
     auth: {
         tokenEnvVar: "GITHUB_TOKEN"  // 環境変数から取得
-        // or tokenFile: "~/.config/toto/github-token"
+        // or tokenFile: "~/.config/tomei/github-token"
     }
 }
 ```
@@ -1261,7 +1261,7 @@ metadata: name: "github"
 spec: {
     type: "token"
     envVar: "GITHUB_TOKEN"
-    // or file: "~/.config/toto/github-token"
+    // or file: "~/.config/tomei/github-token"
     // or secretRef: "..." (外部シークレット管理との連携)
 }
 
@@ -1285,7 +1285,7 @@ spec: {
 ### 16.1 `--sync` 時の latest 指定ツール自動更新
 
 **概要:**
-`toto apply --sync` 実行時、aqua-registry の ref が更新された場合、`latest` 指定のツールについて最新バージョンを再取得し、インストール済みバージョンと異なれば自動的に再インストールする機能。
+`tomei apply --sync` 実行時、aqua-registry の ref が更新された場合、`latest` 指定のツールについて最新バージョンを再取得し、インストール済みバージョンと異なれば自動的に再インストールする機能。
 
 **現状:**
 - `--sync` は state.json の `registry.aqua.ref` を更新するのみ
@@ -1293,7 +1293,7 @@ spec: {
 - 2回目以降の apply では state のバージョンと比較するため、最新バージョンが変わっても検知しない
 
 **期待される動作:**
-1. `toto apply --sync` 実行
+1. `tomei apply --sync` 実行
 2. aqua-registry の最新 ref を取得
 3. ref が変わっていたら state を更新
 4. `latest` 指定のツールについて：

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -1,5 +1,5 @@
-CONTAINER_NAME := toto-e2e-ubuntu
-IMAGE_NAME := toto-ubuntu:test
+CONTAINER_NAME := tomei-e2e-ubuntu
+IMAGE_NAME := tomei-ubuntu:test
 
 # Allow overriding GOARCH via environment variable (default: host architecture)
 GOOS ?= linux
@@ -7,8 +7,8 @@ GOARCH ?= $(shell go env GOARCH)
 
 .PHONY: build up down test clean help
 
-build: ## Build toto binary and Docker image
-	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o toto ../cmd/toto
+build: ## Build tomei binary and Docker image
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o tomei ../cmd/tomei
 	docker build -t $(IMAGE_NAME) -f containers/ubuntu/Dockerfile .
 
 up: ## Start the test container
@@ -18,16 +18,16 @@ down: ## Stop and remove the test container
 	-docker rm -f $(CONTAINER_NAME) 2>/dev/null || true
 
 test: ## Run E2E tests with Ginkgo (container mode)
-	TOTO_E2E_CONTAINER=$(CONTAINER_NAME) go test -tags=e2e -v ./... -ginkgo.v
+	TOMEI_E2E_CONTAINER=$(CONTAINER_NAME) go test -tags=e2e -v ./... -ginkgo.v
 
-test-native: ## Run E2E tests natively (requires TOTO_E2E_BINARY)
-	TOTO_E2E_NATIVE=true go test -tags=e2e -v ./... -ginkgo.v
+test-native: ## Run E2E tests natively (requires TOMEI_E2E_BINARY)
+	TOMEI_E2E_NATIVE=true go test -tags=e2e -v ./... -ginkgo.v
 
 exec: ## Exec into the test container
 	docker exec -it $(CONTAINER_NAME) bash
 
 clean: down ## Clean up build artifacts and Docker image
-	rm -f toto
+	rm -f tomei
 	-docker rmi $(IMAGE_NAME) 2>/dev/null || true
 
 help: ## Show this help

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,6 +1,6 @@
 # E2E Tests
 
-End-to-end tests for toto using Ginkgo BDD framework.
+End-to-end tests for tomei using Ginkgo BDD framework.
 Tests run in Docker containers (default) or natively on supported platforms.
 
 ## Requirements
@@ -21,7 +21,7 @@ make test-e2e
 All tests run within a single `Ordered` Describe block to guarantee execution order:
 
 ```
-toto E2E
+tomei E2E
 ├── Basic             # init, validate, plan, apply, runtime/tool install, upgrade, doctor
 ├── ToolSet           # ToolSet expansion and installation via runtime delegation
 ├── Aqua Registry     # Registry-based tool install, version upgrade/downgrade

--- a/e2e/basic_test.go
+++ b/e2e/basic_test.go
@@ -13,27 +13,27 @@ func basicTests() {
 
 	Context("Basic Commands", func() {
 		It("displays version information", func() {
-			By("Running toto version command")
-			output, err := testExec.Exec("toto", "version")
+			By("Running tomei version command")
+			output, err := testExec.Exec("tomei", "version")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking output contains version string")
-			Expect(output).To(ContainSubstring("toto version"))
+			Expect(output).To(ContainSubstring("tomei version"))
 		})
 
-		It("initializes environment with toto init", func() {
-			By("Running toto init --yes --force to create config.cue and directories")
-			output, err := testExec.Exec("toto", "init", "--yes", "--force")
+		It("initializes environment with tomei init", func() {
+			By("Running tomei init --yes --force to create config.cue and directories")
+			output, err := testExec.Exec("tomei", "init", "--yes", "--force")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).To(ContainSubstring("Initialization complete"))
 
 			By("Verifying config.cue was created")
-			output, err = testExec.ExecBash("cat ~/.config/toto/config.cue")
+			output, err = testExec.ExecBash("cat ~/.config/tomei/config.cue")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("package toto"))
+			Expect(output).To(ContainSubstring("package tomei"))
 
 			By("Verifying data directory was created")
-			_, err = testExec.ExecBash("ls -d ~/.local/share/toto")
+			_, err = testExec.ExecBash("ls -d ~/.local/share/tomei")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying bin directory was created")
@@ -41,14 +41,14 @@ func basicTests() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying state.json was created")
-			output, err = testExec.ExecBash("cat ~/.local/share/toto/state.json")
+			output, err = testExec.ExecBash("cat ~/.local/share/tomei/state.json")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).To(ContainSubstring(`"version"`))
 		})
 
 		It("validates CUE configuration", func() {
-			By("Running toto validate command")
-			output, err := testExec.Exec("toto", "validate", "~/manifests/")
+			By("Running tomei validate command")
+			output, err := testExec.Exec("tomei", "validate", "~/manifests/")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking validation succeeded")
@@ -65,8 +65,8 @@ func basicTests() {
 		})
 
 		It("shows planned changes", func() {
-			By("Running toto plan command")
-			output, err := testExec.Exec("toto", "plan", "~/manifests/")
+			By("Running tomei plan command")
+			output, err := testExec.Exec("tomei", "plan", "~/manifests/")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking plan shows resources")
@@ -77,8 +77,8 @@ func basicTests() {
 
 	Context("Runtime and Tool Installation", func() {
 		It("downloads and installs Runtime and Tools", func() {
-			By("Running toto apply command")
-			_, err := testExec.Exec("toto", "apply", "~/manifests/")
+			By("Running tomei apply command")
+			_, err := testExec.Exec("tomei", "apply", "~/manifests/")
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -86,7 +86,7 @@ func basicTests() {
 	Context("Runtime Installation Verification", func() {
 		It("places runtime in runtimes directory", func() {
 			By("Listing runtimes directory")
-			output, err := testExec.ExecBash(fmt.Sprintf("ls ~/.local/share/toto/runtimes/go/%s/", versions.GoVersion))
+			output, err := testExec.ExecBash(fmt.Sprintf("ls ~/.local/share/tomei/runtimes/go/%s/", versions.GoVersion))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking bin directory exists")
@@ -133,7 +133,7 @@ func basicTests() {
 	Context("Tool Installation - Download Pattern", func() {
 		It("places tool binary in tools directory", func() {
 			By("Listing tools directory")
-			output, err := testExec.ExecBash(fmt.Sprintf("ls ~/.local/share/toto/tools/gh/%s/", versions.GhVersion))
+			output, err := testExec.ExecBash(fmt.Sprintf("ls ~/.local/share/tomei/tools/gh/%s/", versions.GhVersion))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking gh binary exists")
@@ -162,7 +162,7 @@ func basicTests() {
 	Context("Runtime Delegation", func() {
 		It("installed tool via runtime delegation (go install) in first apply", func() {
 			By("Verifying gopls was already installed")
-			// gopls was installed during the first toto apply along with go runtime and gh
+			// gopls was installed during the first tomei apply along with go runtime and gh
 			// This test verifies the installation results
 		})
 
@@ -189,7 +189,7 @@ func basicTests() {
 	Context("State Management", func() {
 		It("updates state.json with runtime and tool info", func() {
 			By("Reading state.json")
-			output, err := testExec.ExecBash("cat ~/.local/share/toto/state.json")
+			output, err := testExec.ExecBash("cat ~/.local/share/tomei/state.json")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking runtimes section exists")
@@ -211,7 +211,7 @@ func basicTests() {
 
 		It("updates state.json with gopls tool info", func() {
 			By("Reading state.json")
-			output, err := testExec.ExecBash("cat ~/.local/share/toto/state.json")
+			output, err := testExec.ExecBash("cat ~/.local/share/tomei/state.json")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking gopls is in tools section")
@@ -229,8 +229,8 @@ func basicTests() {
 
 	Context("Environment Export", func() {
 		It("outputs posix environment variables for installed runtimes", func() {
-			By("Running toto env")
-			output, err := testExec.Exec("toto", "env")
+			By("Running tomei env")
+			output, err := testExec.Exec("tomei", "env")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking GOROOT export")
@@ -249,8 +249,8 @@ func basicTests() {
 		})
 
 		It("outputs fish environment variables", func() {
-			By("Running toto env --shell fish")
-			output, err := testExec.Exec("toto", "env", "--shell", "fish")
+			By("Running tomei env --shell fish")
+			output, err := testExec.Exec("tomei", "env", "--shell", "fish")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking fish-style GOROOT export")
@@ -261,15 +261,15 @@ func basicTests() {
 		})
 
 		It("exports env file with --export flag", func() {
-			By("Running toto env --export")
-			output, err := testExec.Exec("toto", "env", "--export")
+			By("Running tomei env --export")
+			output, err := testExec.Exec("tomei", "env", "--export")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking output confirms file was written")
 			Expect(output).To(ContainSubstring("env.sh"))
 
 			By("Verifying env file exists and contains exports")
-			content, err := testExec.ExecBash("cat ~/.config/toto/env.sh")
+			content, err := testExec.ExecBash("cat ~/.config/tomei/env.sh")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(content).To(ContainSubstring(`export GOROOT=`))
 			Expect(content).To(ContainSubstring(`export PATH=`))
@@ -278,16 +278,16 @@ func basicTests() {
 
 	Context("Idempotency", func() {
 		It("is idempotent on subsequent applies", func() {
-			By("Running toto apply again")
-			_, err := testExec.Exec("toto", "apply", "~/manifests/")
+			By("Running tomei apply again")
+			_, err := testExec.Exec("tomei", "apply", "~/manifests/")
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("does not re-download on multiple applies", func() {
-			By("Running toto apply two more times")
-			_, err := testExec.Exec("toto", "apply", "~/manifests/")
+			By("Running tomei apply two more times")
+			_, err := testExec.Exec("tomei", "apply", "~/manifests/")
 			Expect(err).NotTo(HaveOccurred())
-			_, err = testExec.Exec("toto", "apply", "~/manifests/")
+			_, err = testExec.Exec("tomei", "apply", "~/manifests/")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking go still works")
@@ -302,8 +302,8 @@ func basicTests() {
 		})
 
 		It("is idempotent for runtime delegation tools", func() {
-			By("Running toto apply again")
-			_, err := testExec.Exec("toto", "apply", "~/manifests/")
+			By("Running tomei apply again")
+			_, err := testExec.Exec("tomei", "apply", "~/manifests/")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking gopls still works")
@@ -318,10 +318,10 @@ func basicTests() {
 			By("Cleaning up any unmanaged tools from previous tests")
 			// Remove tools that may have been installed by dependency tests
 			_, _ = testExec.ExecBash("rm -f ~/.local/bin/rg ~/.local/bin/fd ~/.local/bin/bat ~/.local/bin/jq")
-			_, _ = testExec.ExecBash("rm -rf ~/.local/share/toto/tools/rg ~/.local/share/toto/tools/fd ~/.local/share/toto/tools/bat ~/.local/share/toto/tools/jq")
+			_, _ = testExec.ExecBash("rm -rf ~/.local/share/tomei/tools/rg ~/.local/share/tomei/tools/fd ~/.local/share/tomei/tools/bat ~/.local/share/tomei/tools/jq")
 
-			By("Running toto doctor command")
-			output, err := testExec.Exec("toto", "doctor")
+			By("Running tomei doctor command")
+			output, err := testExec.Exec("tomei", "doctor")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking doctor reports healthy environment")
@@ -329,13 +329,13 @@ func basicTests() {
 		})
 
 		It("detects unmanaged tools in runtime bin path", func() {
-			By("Installing an unmanaged tool via go install using toto-managed go runtime")
-			// Use the toto-managed go binary from ~/go/bin with proper GOBIN set
-			_, err := testExec.ExecBash(fmt.Sprintf("export GOROOT=$HOME/.local/share/toto/runtimes/go/%s && export GOBIN=$HOME/go/bin && ~/go/bin/go install golang.org/x/tools/cmd/goimports@latest", versions.GoVersion))
+			By("Installing an unmanaged tool via go install using tomei-managed go runtime")
+			// Use the tomei-managed go binary from ~/go/bin with proper GOBIN set
+			_, err := testExec.ExecBash(fmt.Sprintf("export GOROOT=$HOME/.local/share/tomei/runtimes/go/%s && export GOBIN=$HOME/go/bin && ~/go/bin/go install golang.org/x/tools/cmd/goimports@latest", versions.GoVersion))
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Running toto doctor command")
-			output, err := testExec.Exec("toto", "doctor")
+			By("Running tomei doctor command")
+			output, err := testExec.Exec("tomei", "doctor")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking doctor detects unmanaged tool")
@@ -352,14 +352,14 @@ func basicTests() {
 		It("shows upgrade plan before applying", func() {
 			By(fmt.Sprintf("Swapping runtime config to upgraded version (%s -> %s)", versions.GoVersion, versions.GoVersionUpgrade))
 			// Move current runtime.cue aside and replace with upgrade version
-			// runtime.cue.upgrade has .upgrade extension so it's not loaded by toto until renamed
+			// runtime.cue.upgrade has .upgrade extension so it's not loaded by tomei until renamed
 			_, err := testExec.ExecBash("mv ~/manifests/runtime.cue ~/manifests/runtime.cue.old")
 			Expect(err).NotTo(HaveOccurred())
 			_, err = testExec.ExecBash("mv ~/manifests/runtime.cue.upgrade ~/manifests/runtime.cue")
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Running toto plan to see changes")
-			output, err := testExec.Exec("toto", "plan", "~/manifests/")
+			By("Running tomei plan to see changes")
+			output, err := testExec.Exec("tomei", "plan", "~/manifests/")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking plan shows runtime in execution order")
@@ -368,8 +368,8 @@ func basicTests() {
 		})
 
 		It("upgrades runtime to newer version", func() {
-			By("Running toto apply with upgraded config")
-			_, err := testExec.Exec("toto", "apply", "~/manifests/")
+			By("Running tomei apply with upgraded config")
+			_, err := testExec.Exec("tomei", "apply", "~/manifests/")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying new runtime version is installed")
@@ -378,7 +378,7 @@ func basicTests() {
 			Expect(output).To(ContainSubstring("go" + versions.GoVersionUpgrade))
 
 			By("Verifying new runtime is in correct location")
-			_, err = testExec.ExecBash(fmt.Sprintf("ls ~/.local/share/toto/runtimes/go/%s/bin/go", versions.GoVersionUpgrade))
+			_, err = testExec.ExecBash(fmt.Sprintf("ls ~/.local/share/tomei/runtimes/go/%s/bin/go", versions.GoVersionUpgrade))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying symlink points to new version")
@@ -400,7 +400,7 @@ func basicTests() {
 
 		It("updates state.json with new runtime version", func() {
 			By("Reading state.json")
-			output, err := testExec.ExecBash("cat ~/.local/share/toto/state.json")
+			output, err := testExec.ExecBash("cat ~/.local/share/tomei/state.json")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking go runtime version is updated to " + versions.GoVersionUpgrade)
@@ -408,8 +408,8 @@ func basicTests() {
 		})
 
 		It("is idempotent after runtime upgrade", func() {
-			By("Running toto apply again")
-			_, err := testExec.Exec("toto", "apply", "~/manifests/")
+			By("Running tomei apply again")
+			_, err := testExec.Exec("tomei", "apply", "~/manifests/")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying runtime still works")
@@ -431,8 +431,8 @@ func basicTests() {
 			_, err := testExec.ExecBash("mv ~/manifests/runtime.cue ~/manifests/runtime.cue.hidden")
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Running toto apply — should fail because gopls depends on go runtime")
-			output, err := testExec.Exec("toto", "apply", "~/manifests/")
+			By("Running tomei apply — should fail because gopls depends on go runtime")
+			output, err := testExec.Exec("tomei", "apply", "~/manifests/")
 			Expect(err).To(HaveOccurred())
 			Expect(output).To(ContainSubstring("cannot remove runtime"))
 			Expect(output).To(ContainSubstring("gopls"))
@@ -447,8 +447,8 @@ func basicTests() {
 			_, err := testExec.ExecBash("mv ~/manifests/tools.cue ~/manifests/tools.cue.hidden")
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Running toto apply")
-			_, err = testExec.Exec("toto", "apply", "~/manifests/")
+			By("Running tomei apply")
+			_, err = testExec.Exec("tomei", "apply", "~/manifests/")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying tool symlink is removed")
@@ -456,7 +456,7 @@ func basicTests() {
 			Expect(err).To(HaveOccurred())
 
 			By("Verifying tool is removed from state")
-			output, err := testExec.ExecBash("cat ~/.local/share/toto/state.json")
+			output, err := testExec.ExecBash("cat ~/.local/share/tomei/state.json")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).NotTo(MatchRegexp(`"gh"\s*:`))
 		})
@@ -470,8 +470,8 @@ func basicTests() {
 			_, err = testExec.ExecBash("mv ~/manifests/toolset.cue ~/manifests/toolset.cue.hidden")
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Running toto apply — should succeed since all dependents are removed")
-			_, err = testExec.Exec("toto", "apply", "~/manifests/")
+			By("Running tomei apply — should succeed since all dependents are removed")
+			_, err = testExec.Exec("tomei", "apply", "~/manifests/")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying runtime symlink is removed")
@@ -483,7 +483,7 @@ func basicTests() {
 			Expect(err).To(HaveOccurred())
 
 			By("Verifying state.json has no runtime or gopls")
-			output, err := testExec.ExecBash("cat ~/.local/share/toto/state.json")
+			output, err := testExec.ExecBash("cat ~/.local/share/tomei/state.json")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).NotTo(MatchRegexp(`"go"\s*:`))
 			Expect(output).NotTo(MatchRegexp(`"gopls"\s*:`))

--- a/e2e/config/delegation-test/rust-delegation.cue
+++ b/e2e/config/delegation-test/rust-delegation.cue
@@ -1,11 +1,11 @@
-package toto
+package tomei
 
 // sd - intuitive find & replace CLI installed via cargo install (Runtime Delegation)
 
 _sdVersion: "1.0.0"
 
 sd: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Tool"
 	metadata: name: "sd"
 	spec: {

--- a/e2e/config/delegation-test/rust-runtime.cue
+++ b/e2e/config/delegation-test/rust-runtime.cue
@@ -1,4 +1,4 @@
-package toto
+package tomei
 
 // Rust runtime for E2E testing (delegation pattern via rustup)
 // Uses rustup to bootstrap the Rust toolchain, then cargo install for tools.
@@ -6,7 +6,7 @@ package toto
 _rustVersion: "stable"
 
 rustRuntime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Runtime"
 	metadata: name: "rust"
 	spec: {

--- a/e2e/config/dependency-test/circular.cue
+++ b/e2e/config/dependency-test/circular.cue
@@ -1,8 +1,8 @@
-package toto
+package tomei
 
 // Circular dependency test: Installer(a) -> Tool(b) -> Installer(a)
 installerA: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Installer"
 	metadata: name: "installer-a"
 	spec: {
@@ -15,7 +15,7 @@ installerA: {
 }
 
 toolB: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Tool"
 	metadata: name: "tool-b"
 	spec: {

--- a/e2e/config/dependency-test/circular3.cue
+++ b/e2e/config/dependency-test/circular3.cue
@@ -1,8 +1,8 @@
-package toto
+package tomei
 
 // 3-node circular dependency test: A -> B -> C -> A
 toolA: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Tool"
 	metadata: name: "tool-a"
 	spec: {
@@ -12,7 +12,7 @@ toolA: {
 }
 
 installerB: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Installer"
 	metadata: name: "installer-b"
 	spec: {
@@ -23,7 +23,7 @@ installerB: {
 }
 
 toolC: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Tool"
 	metadata: name: "tool-c"
 	spec: {
@@ -33,7 +33,7 @@ toolC: {
 }
 
 installerC: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Installer"
 	metadata: name: "installer-c"
 	spec: {

--- a/e2e/config/dependency-test/invalid-installer.cue
+++ b/e2e/config/dependency-test/invalid-installer.cue
@@ -1,8 +1,8 @@
-package toto
+package tomei
 
 // Invalid installer test: cannot specify both runtimeRef and toolRef
 invalidInstaller: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Installer"
 	metadata: name: "invalid"
 	spec: {

--- a/e2e/config/dependency-test/parallel.cue
+++ b/e2e/config/dependency-test/parallel.cue
@@ -1,4 +1,4 @@
-package toto
+package tomei
 
 // Parallel tool installation test: multiple independent tools
 
@@ -78,7 +78,7 @@ _batSource: {
 }
 
 aquaInstaller: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Installer"
 	metadata: name: "aqua"
 	spec: {
@@ -87,7 +87,7 @@ aquaInstaller: {
 }
 
 rg: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Tool"
 	metadata: name: "rg"
 	spec: {
@@ -98,7 +98,7 @@ rg: {
 }
 
 fd: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Tool"
 	metadata: name: "fd"
 	spec: {
@@ -109,7 +109,7 @@ fd: {
 }
 
 bat: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Tool"
 	metadata: name: "bat"
 	spec: {

--- a/e2e/config/dependency-test/runtime-chain.cue
+++ b/e2e/config/dependency-test/runtime-chain.cue
@@ -1,4 +1,4 @@
-package toto
+package tomei
 
 // Runtime to Tool dependency chain test: go runtime -> go installer -> gopls
 
@@ -11,7 +11,7 @@ _goSource: {
 
 // Go Runtime
 goRuntime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Runtime"
 	metadata: name: "go"
 	spec: {
@@ -22,7 +22,7 @@ goRuntime: {
 		binDir:      "~/go/bin"
 		toolBinPath: "~/go/bin"
 		env: {
-			GOROOT: "~/.local/share/toto/runtimes/go/\(_goVersion)"
+			GOROOT: "~/.local/share/tomei/runtimes/go/\(_goVersion)"
 			GOBIN:  "~/go/bin"
 		}
 		commands: {
@@ -34,7 +34,7 @@ goRuntime: {
 
 // Go Installer - depends on Go Runtime via runtimeRef
 goInstaller: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Installer"
 	metadata: name: "go"
 	spec: {
@@ -48,7 +48,7 @@ goInstaller: {
 
 // gopls Tool - installed via go installer
 gopls: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Tool"
 	metadata: name: "gopls"
 	spec: {

--- a/e2e/config/dependency-test/toolref.cue
+++ b/e2e/config/dependency-test/toolref.cue
@@ -1,4 +1,4 @@
-package toto
+package tomei
 
 // ToolRef dependency test: aqua -> jq -> jq-installer
 
@@ -29,7 +29,7 @@ _jqSource: {
 
 // Base installer (download pattern)
 aquaInstaller: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Installer"
 	metadata: name: "aqua"
 	spec: {
@@ -39,7 +39,7 @@ aquaInstaller: {
 
 // jq tool installed via aqua
 jqTool: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Tool"
 	metadata: name: "jq"
 	spec: {
@@ -51,7 +51,7 @@ jqTool: {
 
 // jq-based installer - depends on jq tool via toolRef
 jqInstaller: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Installer"
 	metadata: name: "jq-installer"
 	spec: {

--- a/e2e/config/installer-repo-test/helm-only.cue
+++ b/e2e/config/installer-repo-test/helm-only.cue
@@ -1,4 +1,4 @@
-package toto
+package tomei
 
 // Reduced manifest for removal test:
 // Only Tool/helm (no InstallerRepository, no common-chart)
@@ -6,7 +6,7 @@ package toto
 
 // Helm tool installed via aqua registry (latest version)
 helmTool: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Tool"
 	metadata: name: "helm"
 	spec: {

--- a/e2e/config/installer-repo-test/helm-repo.cue
+++ b/e2e/config/installer-repo-test/helm-repo.cue
@@ -1,11 +1,11 @@
-package toto
+package tomei
 
 // InstallerRepository test: delegation pattern with helm
 // Dependency chain: Tool/helm (aqua, latest) → Installer/helm (delegation) → InstallerRepository/bitnami
 
 // Helm tool installed via aqua registry (latest version)
 helmTool: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Tool"
 	metadata: name: "helm"
 	spec: {
@@ -17,7 +17,7 @@ helmTool: {
 // Helm installer: delegation pattern using helm binary
 // Used by InstallerRepository to add/manage helm repositories
 helmInstaller: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Installer"
 	metadata: name: "helm"
 	spec: {
@@ -31,7 +31,7 @@ helmInstaller: {
 
 // Bitnami helm repository managed via delegation
 bitnamiRepo: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "InstallerRepository"
 	metadata: name: "bitnami"
 	spec: {

--- a/e2e/config/installer-repo-test/repo-with-tool.cue
+++ b/e2e/config/installer-repo-test/repo-with-tool.cue
@@ -1,4 +1,4 @@
-package toto
+package tomei
 
 // Full dependency chain test:
 // Tool/helm (aqua, latest) → Installer/helm (delegation) → InstallerRepository/bitnami → Tool/common-chart
@@ -9,7 +9,7 @@ package toto
 
 // Helm tool installed via aqua registry (latest version)
 helmTool: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Tool"
 	metadata: name: "helm"
 	spec: {
@@ -21,21 +21,21 @@ helmTool: {
 // Helm installer: delegation pattern for pulling charts
 // {{.Package}} = spec.package (chart name), {{.Version}} = spec.version
 helmInstaller: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Installer"
 	metadata: name: "helm"
 	spec: {
 		type:    "delegation"
 		toolRef: "helm"
 		commands: {
-			install: "mkdir -p /tmp/toto-e2e-charts && helm pull bitnami/{{.Package}} --destination /tmp/toto-e2e-charts"
+			install: "mkdir -p /tmp/tomei-e2e-charts && helm pull bitnami/{{.Package}} --destination /tmp/tomei-e2e-charts"
 		}
 	}
 }
 
 // Bitnami helm repository managed via delegation
 bitnamiRepo: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "InstallerRepository"
 	metadata: name: "bitnami"
 	spec: {
@@ -55,7 +55,7 @@ bitnamiRepo: {
 // Common chart: bitnami/common (helper-only chart, very small)
 // Installed via helm pull after bitnami repository is added
 commonChart: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Tool"
 	metadata: name: "common-chart"
 	spec: {

--- a/e2e/config/manifests/delegation.cue
+++ b/e2e/config/manifests/delegation.cue
@@ -1,11 +1,11 @@
-package toto
+package tomei
 
 // gopls - Go language server installed via go install (Runtime Delegation)
 
 _goplsVersion: "v0.21.0"
 
 gopls: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Tool"
 	metadata: name: "gopls"
 	spec: {

--- a/e2e/config/manifests/runtime.cue
+++ b/e2e/config/manifests/runtime.cue
@@ -1,4 +1,4 @@
-package toto
+package tomei
 
 // Go runtime for E2E testing
 // Initially installs Go 1.25.6, then can be upgraded to 1.25.7
@@ -7,7 +7,7 @@ package toto
 _goVersion: "1.25.6"
 
 goRuntime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Runtime"
 	metadata: name: "go"
 	spec: {
@@ -23,7 +23,7 @@ goRuntime: {
 		binDir:      "~/go/bin" // Runtime binaries go to GOBIN (same as toolBinPath)
 		toolBinPath: "~/go/bin"
 		env: {
-			GOROOT: "~/.local/share/toto/runtimes/go/\(spec.version)"
+			GOROOT: "~/.local/share/tomei/runtimes/go/\(spec.version)"
 			GOBIN:  "~/go/bin"
 		}
 		// Commands for tool installation via go install

--- a/e2e/config/manifests/runtime.cue.upgrade
+++ b/e2e/config/manifests/runtime.cue.upgrade
@@ -1,4 +1,4 @@
-package toto
+package tomei
 
 // Go runtime upgraded to 1.25.7
 // Uses _env for OS/arch portability
@@ -6,7 +6,7 @@ package toto
 _goVersionUpgrade: "1.25.7"
 
 goRuntime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Runtime"
 	metadata: name: "go"
 	spec: {
@@ -22,7 +22,7 @@ goRuntime: {
 		binDir:      "~/go/bin"
 		toolBinPath: "~/go/bin"
 		env: {
-			GOROOT: "~/.local/share/toto/runtimes/go/\(spec.version)"
+			GOROOT: "~/.local/share/tomei/runtimes/go/\(spec.version)"
 			GOBIN:  "~/go/bin"
 		}
 		commands: {

--- a/e2e/config/manifests/tools.cue
+++ b/e2e/config/manifests/tools.cue
@@ -1,11 +1,11 @@
-package toto
+package tomei
 
 // gh CLI tool - uses _env for OS/arch portability
 
 _ghVersion: "2.86.0"
 
 gh: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Tool"
 	metadata: name: "gh"
 	spec: {

--- a/e2e/config/manifests/toolset.cue
+++ b/e2e/config/manifests/toolset.cue
@@ -1,8 +1,8 @@
-package toto
+package tomei
 
 // ToolSet: multiple Go tools installed via runtime delegation
 goTools: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "ToolSet"
 	metadata: name: "go-tools"
 	spec: {

--- a/e2e/config/registry/tools.cue
+++ b/e2e/config/registry/tools.cue
@@ -6,7 +6,7 @@ _jqVersion: "jq-1.8.1"
 
 // ripgrep - Install via aqua registry
 ripgrep: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Tool"
 	metadata: name: "rg"
 	spec: {
@@ -18,7 +18,7 @@ ripgrep: {
 
 // fd - Install via aqua registry
 fd: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Tool"
 	metadata: name: "fd"
 	spec: {
@@ -30,7 +30,7 @@ fd: {
 
 // jq - Install via aqua registry
 jq: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Tool"
 	metadata: name: "jq"
 	spec: {

--- a/e2e/config/registry/tools.cue.old
+++ b/e2e/config/registry/tools.cue.old
@@ -6,7 +6,7 @@ _jqVersionOld: "jq-1.7.1"
 
 // ripgrep - Install via aqua registry (older version for upgrade test)
 ripgrep: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Tool"
 	metadata: name: "rg"
 	spec: {
@@ -18,7 +18,7 @@ ripgrep: {
 
 // fd - Install via aqua registry (older version for upgrade test)
 fd: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Tool"
 	metadata: name: "fd"
 	spec: {
@@ -30,7 +30,7 @@ fd: {
 
 // jq - Install via aqua registry (older version for upgrade test)
 jq: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Tool"
 	metadata: name: "jq"
 	spec: {

--- a/e2e/containers/ubuntu/Dockerfile
+++ b/e2e/containers/ubuntu/Dockerfile
@@ -11,9 +11,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Create test user
 RUN useradd -m -s /bin/bash testuser
 
-# Copy toto binary
-COPY toto /usr/local/bin/toto
-RUN chmod +x /usr/local/bin/toto
+# Copy tomei binary
+COPY tomei /usr/local/bin/tomei
+RUN chmod +x /usr/local/bin/tomei
 
 # Setup user environment
 USER testuser
@@ -23,7 +23,7 @@ WORKDIR /home/testuser
 ENV PATH="/home/testuser/.local/bin:/home/testuser/go/bin:${PATH}"
 
 # Copy resource definitions to ~/manifests directory
-# runtime.cue.upgrade is not a .cue file so toto won't load it until renamed
+# runtime.cue.upgrade is not a .cue file so tomei won't load it until renamed
 COPY --chown=testuser:testuser config/manifests/runtime.cue /home/testuser/manifests/runtime.cue
 COPY --chown=testuser:testuser config/manifests/runtime.cue.upgrade /home/testuser/manifests/runtime.cue.upgrade
 COPY --chown=testuser:testuser config/manifests/tools.cue /home/testuser/manifests/tools.cue
@@ -44,4 +44,4 @@ COPY --chown=testuser:testuser config/dependency-test/ /home/testuser/dependency
 COPY --chown=testuser:testuser config/installer-repo-test/ /home/testuser/installer-repo-test/
 
 # Default command
-CMD ["toto", "version"]
+CMD ["tomei", "version"]

--- a/e2e/delegation_test.go
+++ b/e2e/delegation_test.go
@@ -12,16 +12,16 @@ import (
 func delegationTests() {
 
 	BeforeAll(func() {
-		// Initialize toto (may already be initialized by other tests, ignore errors)
-		_, _ = testExec.Exec("toto", "init", "--yes")
+		// Initialize tomei (may already be initialized by other tests, ignore errors)
+		_, _ = testExec.Exec("tomei", "init", "--yes")
 		// Reset state to avoid interference from previous test contexts
-		_, _ = testExec.ExecBash(`echo '{"runtimes":{},"tools":{},"installers":{}}' > ~/.local/share/toto/state.json`)
+		_, _ = testExec.ExecBash(`echo '{"runtimes":{},"tools":{},"installers":{}}' > ~/.local/share/tomei/state.json`)
 	})
 
 	Context("Rust Runtime Installation (Delegation Pattern)", func() {
 		It("validates Rust runtime manifest", func() {
-			By("Running toto validate on delegation-test directory")
-			output, err := testExec.Exec("toto", "validate", "~/delegation-test/")
+			By("Running tomei validate on delegation-test directory")
+			output, err := testExec.Exec("tomei", "validate", "~/delegation-test/")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).To(ContainSubstring("Validation successful"))
 			Expect(output).To(ContainSubstring("Runtime/rust"))
@@ -29,8 +29,8 @@ func delegationTests() {
 		})
 
 		It("installs Rust runtime and tool via delegation", func() {
-			By("Running toto apply on delegation-test directory")
-			_, err := testExec.Exec("toto", "apply", "~/delegation-test/")
+			By("Running tomei apply on delegation-test directory")
+			_, err := testExec.Exec("tomei", "apply", "~/delegation-test/")
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -57,7 +57,7 @@ func delegationTests() {
 
 		It("records delegation state in state.json", func() {
 			By("Reading state.json")
-			output, err := testExec.ExecBash("cat ~/.local/share/toto/state.json")
+			output, err := testExec.ExecBash("cat ~/.local/share/tomei/state.json")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking rust runtime is recorded")
@@ -79,8 +79,8 @@ func delegationTests() {
 		})
 
 		It("exports Rust environment variables", func() {
-			By("Running toto env")
-			output, err := testExec.Exec("toto", "env")
+			By("Running tomei env")
+			output, err := testExec.Exec("tomei", "env")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking CARGO_HOME export")
@@ -108,7 +108,7 @@ func delegationTests() {
 
 		It("records sd tool state in state.json", func() {
 			By("Reading state.json")
-			output, err := testExec.ExecBash("cat ~/.local/share/toto/state.json")
+			output, err := testExec.ExecBash("cat ~/.local/share/tomei/state.json")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking sd is in tools section")
@@ -121,8 +121,8 @@ func delegationTests() {
 
 	Context("Rust Delegation Idempotency", func() {
 		It("is idempotent on subsequent applies", func() {
-			By("Running toto apply again")
-			_, err := testExec.Exec("toto", "apply", "~/delegation-test/")
+			By("Running tomei apply again")
+			_, err := testExec.Exec("tomei", "apply", "~/delegation-test/")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying rustc still works")

--- a/e2e/dependency_test.go
+++ b/e2e/dependency_test.go
@@ -12,28 +12,28 @@ import (
 
 func dependencyTests() {
 	BeforeAll(func() {
-		// Initialize toto (may already be initialized by other tests, ignore errors)
-		_, _ = testExec.Exec("toto", "init", "--yes")
+		// Initialize tomei (may already be initialized by other tests, ignore errors)
+		_, _ = testExec.Exec("tomei", "init", "--yes")
 	})
 
 	Context("Circular Dependency Detection", func() {
 		It("detects circular dependency between installer and tool", func() {
-			By("Running toto validate on circular.cue - should detect cycle")
-			output, err := testExec.Exec("toto", "validate", "~/dependency-test/circular.cue")
+			By("Running tomei validate on circular.cue - should detect cycle")
+			output, err := testExec.Exec("tomei", "validate", "~/dependency-test/circular.cue")
 			Expect(err).To(HaveOccurred())
 			Expect(output).To(ContainSubstring("circular dependency"))
 		})
 
 		It("detects circular dependency in three-node cycle", func() {
-			By("Running toto validate on circular3.cue - should detect cycle")
-			output, err := testExec.Exec("toto", "validate", "~/dependency-test/circular3.cue")
+			By("Running tomei validate on circular3.cue - should detect cycle")
+			output, err := testExec.Exec("tomei", "validate", "~/dependency-test/circular3.cue")
 			Expect(err).To(HaveOccurred())
 			Expect(output).To(ContainSubstring("circular dependency"))
 		})
 
 		It("rejects installer with both runtimeRef and toolRef", func() {
-			By("Running toto validate on invalid-installer.cue - should reject")
-			output, err := testExec.Exec("toto", "validate", "~/dependency-test/invalid-installer.cue")
+			By("Running tomei validate on invalid-installer.cue - should reject")
+			output, err := testExec.Exec("tomei", "validate", "~/dependency-test/invalid-installer.cue")
 			Expect(err).To(HaveOccurred())
 			Expect(output).To(ContainSubstring("runtimeRef"))
 			Expect(output).To(ContainSubstring("toolRef"))
@@ -43,20 +43,20 @@ func dependencyTests() {
 	Context("Parallel Tool Installation", func() {
 		BeforeAll(func() {
 			// Reset state.json and clean up tools/symlinks to ensure clean state
-			_, _ = testExec.ExecBash(`echo '{"runtimes":{},"tools":{},"installers":{}}' > ~/.local/share/toto/state.json`)
+			_, _ = testExec.ExecBash(`echo '{"runtimes":{},"tools":{},"installers":{}}' > ~/.local/share/tomei/state.json`)
 			// Remove tools that may have been installed by previous tests with different versions
-			_, _ = testExec.ExecBash(`rm -rf ~/.local/share/toto/tools/rg ~/.local/share/toto/tools/fd ~/.local/share/toto/tools/bat`)
+			_, _ = testExec.ExecBash(`rm -rf ~/.local/share/tomei/tools/rg ~/.local/share/tomei/tools/fd ~/.local/share/tomei/tools/bat`)
 			_, _ = testExec.ExecBash(`rm -f ~/.local/bin/rg ~/.local/bin/fd ~/.local/bin/bat`)
 		})
 
 		It("installs multiple independent tools in parallel", func() {
-			By("Running toto validate on parallel.cue")
-			output, err := testExec.Exec("toto", "validate", "~/dependency-test/parallel.cue")
+			By("Running tomei validate on parallel.cue")
+			output, err := testExec.Exec("tomei", "validate", "~/dependency-test/parallel.cue")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).To(ContainSubstring("Validation successful"))
 
-			By("Running toto apply on parallel.cue")
-			_, err = testExec.Exec("toto", "apply", "~/dependency-test/parallel.cue")
+			By("Running tomei apply on parallel.cue")
+			_, err = testExec.Exec("tomei", "apply", "~/dependency-test/parallel.cue")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying rg works")
@@ -76,8 +76,8 @@ func dependencyTests() {
 		})
 
 		It("is idempotent - second apply reports no changes", func() {
-			By("Running toto apply again on parallel.cue")
-			_, err := testExec.Exec("toto", "apply", "~/dependency-test/parallel.cue")
+			By("Running tomei apply again on parallel.cue")
+			_, err := testExec.Exec("tomei", "apply", "~/dependency-test/parallel.cue")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying tools still work after second apply")
@@ -90,14 +90,14 @@ func dependencyTests() {
 	Context("Parallel Flag Behavior", func() {
 		BeforeAll(func() {
 			// Reset state.json and clean up tools/symlinks to ensure clean state
-			_, _ = testExec.ExecBash(`echo '{"runtimes":{},"tools":{},"installers":{}}' > ~/.local/share/toto/state.json`)
-			_, _ = testExec.ExecBash(`rm -rf ~/.local/share/toto/tools/rg ~/.local/share/toto/tools/fd ~/.local/share/toto/tools/bat`)
+			_, _ = testExec.ExecBash(`echo '{"runtimes":{},"tools":{},"installers":{}}' > ~/.local/share/tomei/state.json`)
+			_, _ = testExec.ExecBash(`rm -rf ~/.local/share/tomei/tools/rg ~/.local/share/tomei/tools/fd ~/.local/share/tomei/tools/bat`)
 			_, _ = testExec.ExecBash(`rm -f ~/.local/bin/rg ~/.local/bin/fd ~/.local/bin/bat`)
 		})
 
 		It("installs all tools with --parallel 1 (sequential)", func() {
-			By("Running toto apply with --parallel 1")
-			output, err := testExec.Exec("toto", "apply", "--parallel", "1", "~/dependency-test/parallel.cue")
+			By("Running tomei apply with --parallel 1")
+			output, err := testExec.Exec("tomei", "apply", "--parallel", "1", "~/dependency-test/parallel.cue")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying rg works")
@@ -121,12 +121,12 @@ func dependencyTests() {
 
 		It("shows Commands: header exactly once with default parallelism", func() {
 			By("Reset state for fresh install")
-			_, _ = testExec.ExecBash(`echo '{"runtimes":{},"tools":{},"installers":{}}' > ~/.local/share/toto/state.json`)
-			_, _ = testExec.ExecBash(`rm -rf ~/.local/share/toto/tools/rg ~/.local/share/toto/tools/fd ~/.local/share/toto/tools/bat`)
+			_, _ = testExec.ExecBash(`echo '{"runtimes":{},"tools":{},"installers":{}}' > ~/.local/share/tomei/state.json`)
+			_, _ = testExec.ExecBash(`rm -rf ~/.local/share/tomei/tools/rg ~/.local/share/tomei/tools/fd ~/.local/share/tomei/tools/bat`)
 			_, _ = testExec.ExecBash(`rm -f ~/.local/bin/rg ~/.local/bin/fd ~/.local/bin/bat`)
 
-			By("Running toto apply without --parallel flag (default)")
-			output, err := testExec.Exec("toto", "apply", "~/dependency-test/parallel.cue")
+			By("Running tomei apply without --parallel flag (default)")
+			output, err := testExec.Exec("tomei", "apply", "~/dependency-test/parallel.cue")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying all tools installed")
@@ -145,16 +145,16 @@ func dependencyTests() {
 	Context("Runtime and Tool Mixed Parallel Execution", func() {
 		BeforeAll(func() {
 			// Reset state.json to clean state
-			_, _ = testExec.ExecBash(`echo '{"runtimes":{},"tools":{},"installers":{}}' > ~/.local/share/toto/state.json`)
+			_, _ = testExec.ExecBash(`echo '{"runtimes":{},"tools":{},"installers":{}}' > ~/.local/share/tomei/state.json`)
 		})
 
 		It("installs runtime before dependent tool in parallel mode", func() {
-			By("Running toto apply on runtime-chain.cue with default parallelism")
-			_, err := testExec.Exec("toto", "apply", "~/dependency-test/runtime-chain.cue")
+			By("Running tomei apply on runtime-chain.cue with default parallelism")
+			_, err := testExec.Exec("tomei", "apply", "~/dependency-test/runtime-chain.cue")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying go runtime is installed")
-			output, err := testExec.ExecBash(fmt.Sprintf("GOTOOLCHAIN=local ~/.local/share/toto/runtimes/go/%s/bin/go version", versions.DepGoVersion))
+			output, err := testExec.ExecBash(fmt.Sprintf("GOTOOLCHAIN=local ~/.local/share/tomei/runtimes/go/%s/bin/go version", versions.DepGoVersion))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).To(ContainSubstring("go" + versions.DepGoVersion))
 
@@ -164,7 +164,7 @@ func dependencyTests() {
 			Expect(output).To(ContainSubstring("golang.org/x/tools/gopls"))
 
 			By("Verifying state.json records both resources")
-			stateOutput, err := testExec.ExecBash("cat ~/.local/share/toto/state.json")
+			stateOutput, err := testExec.ExecBash("cat ~/.local/share/tomei/state.json")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(stateOutput).To(ContainSubstring(`"go"`))
 			Expect(stateOutput).To(ContainSubstring(`"gopls"`))
@@ -174,12 +174,12 @@ func dependencyTests() {
 	Context("Tool as Installer Dependency (ToolRef)", func() {
 		BeforeAll(func() {
 			// Reset state.json to clean state
-			_, _ = testExec.ExecBash(`echo '{"runtimes":{},"tools":{},"installers":{}}' > ~/.local/share/toto/state.json`)
+			_, _ = testExec.ExecBash(`echo '{"runtimes":{},"tools":{},"installers":{}}' > ~/.local/share/tomei/state.json`)
 		})
 
 		It("validates toolRef dependency chain", func() {
-			By("Running toto validate on toolref.cue")
-			output, err := testExec.Exec("toto", "validate", "~/dependency-test/toolref.cue")
+			By("Running tomei validate on toolref.cue")
+			output, err := testExec.Exec("tomei", "validate", "~/dependency-test/toolref.cue")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).To(ContainSubstring("Validation successful"))
 
@@ -190,8 +190,8 @@ func dependencyTests() {
 		})
 
 		It("installs tool before dependent installer is available", func() {
-			By("Running toto apply on toolref.cue")
-			_, err := testExec.Exec("toto", "apply", "~/dependency-test/toolref.cue")
+			By("Running tomei apply on toolref.cue")
+			_, err := testExec.Exec("tomei", "apply", "~/dependency-test/toolref.cue")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying jq is installed and works")
@@ -204,12 +204,12 @@ func dependencyTests() {
 	Context("Runtime to Tool Dependency Chain", func() {
 		BeforeAll(func() {
 			// Reset state.json to clean state
-			_, _ = testExec.ExecBash(`echo '{"runtimes":{},"tools":{},"installers":{}}' > ~/.local/share/toto/state.json`)
+			_, _ = testExec.ExecBash(`echo '{"runtimes":{},"tools":{},"installers":{}}' > ~/.local/share/tomei/state.json`)
 		})
 
 		It("validates runtime -> installer -> tool chain", func() {
-			By("Running toto validate on runtime-chain.cue")
-			output, err := testExec.Exec("toto", "validate", "~/dependency-test/runtime-chain.cue")
+			By("Running tomei validate on runtime-chain.cue")
+			output, err := testExec.Exec("tomei", "validate", "~/dependency-test/runtime-chain.cue")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).To(ContainSubstring("Validation successful"))
 
@@ -220,13 +220,13 @@ func dependencyTests() {
 		})
 
 		It("installs runtime before dependent tools", func() {
-			By("Running toto apply on runtime-chain.cue")
-			_, err := testExec.Exec("toto", "apply", "~/dependency-test/runtime-chain.cue")
+			By("Running tomei apply on runtime-chain.cue")
+			_, err := testExec.Exec("tomei", "apply", "~/dependency-test/runtime-chain.cue")
 			Expect(err).NotTo(HaveOccurred())
 
 			By(fmt.Sprintf("Verifying go runtime %s is installed in expected location", versions.DepGoVersion))
 			// Set GOTOOLCHAIN=local to prevent auto-upgrade to newer Go version
-			output, err := testExec.ExecBash(fmt.Sprintf("GOTOOLCHAIN=local ~/.local/share/toto/runtimes/go/%s/bin/go version", versions.DepGoVersion))
+			output, err := testExec.ExecBash(fmt.Sprintf("GOTOOLCHAIN=local ~/.local/share/tomei/runtimes/go/%s/bin/go version", versions.DepGoVersion))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).To(ContainSubstring("go" + versions.DepGoVersion))
 

--- a/e2e/executor.go
+++ b/e2e/executor.go
@@ -40,8 +40,8 @@ func (e *containerExecutor) Exec(name string, args ...string) (string, error) {
 	cmdArgs := append([]string{"exec", e.containerName, name}, args...)
 	cmd := exec.Command("docker", cmdArgs...)
 	output, err := cmd.CombinedOutput()
-	// Only output toto commands to GinkgoWriter
-	if name == "toto" {
+	// Only output tomei commands to GinkgoWriter
+	if name == "tomei" {
 		fmt.Fprintf(GinkgoWriter, "$ %s %v\n%s", name, args, output)
 		if err != nil {
 			fmt.Fprintf(GinkgoWriter, "Error: %v\n", err)
@@ -97,22 +97,22 @@ func (e *containerExecutor) Getenv(key string) string {
 // nativeExecutor executes commands directly on the host machine.
 // It uses a temporary HOME directory to isolate test state.
 type nativeExecutor struct {
-	testHome   string            // Temporary HOME directory for test isolation
-	totoBinary string            // Path to toto binary
-	envVars    map[string]string // Additional environment variables
+	testHome    string            // Temporary HOME directory for test isolation
+	tomeiBinary string            // Path to tomei binary
+	envVars     map[string]string // Additional environment variables
 }
 
 func (e *nativeExecutor) Exec(name string, args ...string) (string, error) {
 	var cmd *exec.Cmd
-	if name == "toto" {
-		cmd = exec.Command(e.totoBinary, args...)
+	if name == "tomei" {
+		cmd = exec.Command(e.tomeiBinary, args...)
 	} else {
 		cmd = exec.Command(name, args...)
 	}
 	cmd.Env = e.buildEnv()
 	output, err := cmd.CombinedOutput()
-	// Only output toto commands to GinkgoWriter
-	if name == "toto" {
+	// Only output tomei commands to GinkgoWriter
+	if name == "tomei" {
 		fmt.Fprintf(GinkgoWriter, "$ %s %v\n%s", name, args, output)
 		if err != nil {
 			fmt.Fprintf(GinkgoWriter, "Error: %v\n", err)
@@ -142,7 +142,7 @@ func (e *nativeExecutor) buildEnv() []string {
 
 func (e *nativeExecutor) Setup() error {
 	var err error
-	e.testHome, err = os.MkdirTemp("", "toto-e2e-")
+	e.testHome, err = os.MkdirTemp("", "tomei-e2e-")
 	if err != nil {
 		return fmt.Errorf("failed to create temp home: %w", err)
 	}
@@ -150,9 +150,9 @@ func (e *nativeExecutor) Setup() error {
 	// Create necessary directory structure
 	dirs := []string{
 		filepath.Join(e.testHome, ".local", "bin"),
-		filepath.Join(e.testHome, ".local", "share", "toto", "tools"),
-		filepath.Join(e.testHome, ".local", "share", "toto", "runtimes"),
-		filepath.Join(e.testHome, ".config", "toto"),
+		filepath.Join(e.testHome, ".local", "share", "tomei", "tools"),
+		filepath.Join(e.testHome, ".local", "share", "tomei", "runtimes"),
+		filepath.Join(e.testHome, ".config", "tomei"),
 		filepath.Join(e.testHome, "go", "bin"),
 	}
 	for _, dir := range dirs {
@@ -261,31 +261,31 @@ func (e *nativeExecutor) Getenv(key string) string {
 // newExecutor creates an executor based on environment variables.
 //
 // Environment variables:
-//   - TOTO_E2E_CONTAINER: Container name for container mode
-//   - TOTO_E2E_NATIVE: Set to "true" for native mode
-//   - TOTO_E2E_BINARY: Path to toto binary (native mode, optional)
+//   - TOMEI_E2E_CONTAINER: Container name for container mode
+//   - TOMEI_E2E_NATIVE: Set to "true" for native mode
+//   - TOMEI_E2E_BINARY: Path to tomei binary (native mode, optional)
 func newExecutor() (executor, error) {
-	// 1. Container mode (TOTO_E2E_CONTAINER is set)
-	if container := os.Getenv("TOTO_E2E_CONTAINER"); container != "" {
+	// 1. Container mode (TOMEI_E2E_CONTAINER is set)
+	if container := os.Getenv("TOMEI_E2E_CONTAINER"); container != "" {
 		return &containerExecutor{containerName: container}, nil
 	}
 
-	// 2. Native mode (TOTO_E2E_NATIVE is set)
-	if os.Getenv("TOTO_E2E_NATIVE") == "true" {
-		binary := os.Getenv("TOTO_E2E_BINARY")
+	// 2. Native mode (TOMEI_E2E_NATIVE is set)
+	if os.Getenv("TOMEI_E2E_NATIVE") == "true" {
+		binary := os.Getenv("TOMEI_E2E_BINARY")
 		if binary == "" {
-			// Look for toto in PATH
+			// Look for tomei in PATH
 			var err error
-			binary, err = exec.LookPath("toto")
+			binary, err = exec.LookPath("tomei")
 			if err != nil {
-				return nil, fmt.Errorf("toto binary not found in PATH, set TOTO_E2E_BINARY")
+				return nil, fmt.Errorf("tomei binary not found in PATH, set TOMEI_E2E_BINARY")
 			}
 		}
-		return &nativeExecutor{totoBinary: binary}, nil
+		return &nativeExecutor{tomeiBinary: binary}, nil
 	}
 
 	// 3. Neither mode is set
-	return nil, fmt.Errorf("set TOTO_E2E_CONTAINER for container mode, or TOTO_E2E_NATIVE=true for native mode")
+	return nil, fmt.Errorf("set TOMEI_E2E_CONTAINER for container mode, or TOMEI_E2E_NATIVE=true for native mode")
 }
 
 // testExec is the global executor instance used by all tests

--- a/e2e/installer_repository_test.go
+++ b/e2e/installer_repository_test.go
@@ -16,15 +16,15 @@ func installerRepositoryTests() {
 		// Clean up any pre-existing helm repos and binaries (before init resets state)
 		_, _ = testExec.ExecBash("helm repo remove bitnami 2>/dev/null || true")
 		_, _ = testExec.ExecBash("rm -f ~/.local/bin/helm")
-		_, _ = testExec.ExecBash("rm -rf ~/.local/share/toto/tools/helm")
-		// Initialize toto with --force: creates clean state.json with registry info (required for aqua resolver)
-		_, _ = testExec.Exec("toto", "init", "--yes", "--force")
+		_, _ = testExec.ExecBash("rm -rf ~/.local/share/tomei/tools/helm")
+		// Initialize tomei with --force: creates clean state.json with registry info (required for aqua resolver)
+		_, _ = testExec.Exec("tomei", "init", "--yes", "--force")
 	})
 
 	Context("Delegation: Helm Repository", func() {
 		It("validates helm-repo manifest", func() {
-			By("Running toto validate on helm-repo.cue")
-			output, err := testExec.Exec("toto", "validate", "~/installer-repo-test/helm-repo.cue")
+			By("Running tomei validate on helm-repo.cue")
+			output, err := testExec.Exec("tomei", "validate", "~/installer-repo-test/helm-repo.cue")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).To(ContainSubstring("Validation successful"))
 
@@ -36,8 +36,8 @@ func installerRepositoryTests() {
 		})
 
 		It("installs helm and adds bitnami repository", func() {
-			By("Running toto apply on helm-repo.cue")
-			_, err := testExec.Exec("toto", "apply", "~/installer-repo-test/helm-repo.cue")
+			By("Running tomei apply on helm-repo.cue")
+			_, err := testExec.Exec("tomei", "apply", "~/installer-repo-test/helm-repo.cue")
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -57,7 +57,7 @@ func installerRepositoryTests() {
 
 		It("records InstallerRepository in state.json", func() {
 			By("Reading state.json")
-			output, err := testExec.ExecBash("cat ~/.local/share/toto/state.json")
+			output, err := testExec.ExecBash("cat ~/.local/share/tomei/state.json")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking bitnami is in installerRepositories section")
@@ -71,8 +71,8 @@ func installerRepositoryTests() {
 		})
 
 		It("is idempotent on subsequent apply", func() {
-			By("Running toto apply again")
-			_, err := testExec.Exec("toto", "apply", "~/installer-repo-test/helm-repo.cue")
+			By("Running tomei apply again")
+			_, err := testExec.Exec("tomei", "apply", "~/installer-repo-test/helm-repo.cue")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking bitnami still registered")
@@ -87,16 +87,16 @@ func installerRepositoryTests() {
 			// Clean up helm repos and binaries
 			_, _ = testExec.ExecBash("helm repo remove bitnami 2>/dev/null || true")
 			_, _ = testExec.ExecBash("rm -f ~/.local/bin/helm")
-			_, _ = testExec.ExecBash("rm -rf ~/.local/share/toto/tools/helm")
+			_, _ = testExec.ExecBash("rm -rf ~/.local/share/tomei/tools/helm")
 			// Clean up chart download destination
-			_, _ = testExec.ExecBash("rm -rf /tmp/toto-e2e-charts")
-			// Re-initialize toto with --force: creates clean state.json with registry info
-			_, _ = testExec.Exec("toto", "init", "--yes", "--force")
+			_, _ = testExec.ExecBash("rm -rf /tmp/tomei-e2e-charts")
+			// Re-initialize tomei with --force: creates clean state.json with registry info
+			_, _ = testExec.Exec("tomei", "init", "--yes", "--force")
 		})
 
 		It("validates repo-with-tool manifest", func() {
-			By("Running toto validate on repo-with-tool.cue")
-			output, err := testExec.Exec("toto", "validate", "~/installer-repo-test/repo-with-tool.cue")
+			By("Running tomei validate on repo-with-tool.cue")
+			output, err := testExec.Exec("tomei", "validate", "~/installer-repo-test/repo-with-tool.cue")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).To(ContainSubstring("Validation successful"))
 
@@ -111,8 +111,8 @@ func installerRepositoryTests() {
 		})
 
 		It("installs InstallerRepository then pulls chart via dependent Tool", func() {
-			By("Running toto apply on repo-with-tool.cue")
-			_, err := testExec.Exec("toto", "apply", "~/installer-repo-test/repo-with-tool.cue")
+			By("Running tomei apply on repo-with-tool.cue")
+			_, err := testExec.Exec("tomei", "apply", "~/installer-repo-test/repo-with-tool.cue")
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -124,14 +124,14 @@ func installerRepositoryTests() {
 		})
 
 		It("chart tgz was downloaded", func() {
-			By("Checking /tmp/toto-e2e-charts/common-*.tgz exists")
-			_, err := testExec.ExecBash("ls /tmp/toto-e2e-charts/common-*.tgz")
+			By("Checking /tmp/tomei-e2e-charts/common-*.tgz exists")
+			_, err := testExec.ExecBash("ls /tmp/tomei-e2e-charts/common-*.tgz")
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("state.json records common-chart tool and bitnami repository", func() {
 			By("Reading state.json")
-			output, err := testExec.ExecBash("cat ~/.local/share/toto/state.json")
+			output, err := testExec.ExecBash("cat ~/.local/share/tomei/state.json")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking common-chart is in tools")
@@ -142,8 +142,8 @@ func installerRepositoryTests() {
 		})
 
 		It("is idempotent on subsequent apply", func() {
-			By("Running toto apply again")
-			_, err := testExec.Exec("toto", "apply", "~/installer-repo-test/repo-with-tool.cue")
+			By("Running tomei apply again")
+			_, err := testExec.Exec("tomei", "apply", "~/installer-repo-test/repo-with-tool.cue")
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -151,7 +151,7 @@ func installerRepositoryTests() {
 	Context("Removal", func() {
 		It("removes InstallerRepository and Tool when manifest reduced", func() {
 			By("Applying helm-only manifest (no InstallerRepository, no common-chart)")
-			_, err := testExec.Exec("toto", "apply", "~/installer-repo-test/helm-only.cue")
+			_, err := testExec.Exec("tomei", "apply", "~/installer-repo-test/helm-only.cue")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking bitnami is NOT in helm repo list")
@@ -159,7 +159,7 @@ func installerRepositoryTests() {
 			Expect(output).NotTo(ContainSubstring("bitnami"))
 
 			By("Checking state.json does not contain bitnami")
-			output, err = testExec.ExecBash("cat ~/.local/share/toto/state.json")
+			output, err = testExec.ExecBash("cat ~/.local/share/tomei/state.json")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).NotTo(ContainSubstring(`"bitnami"`))
 

--- a/e2e/registry_test.go
+++ b/e2e/registry_test.go
@@ -12,15 +12,15 @@ import (
 func registryTests() {
 
 	BeforeAll(func() {
-		By("Running toto init to ensure state.json exists")
-		_, err := testExec.Exec("toto", "init", "--yes", "--force")
+		By("Running tomei init to ensure state.json exists")
+		_, err := testExec.Exec("tomei", "init", "--yes", "--force")
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	Context("Registry Initialization", func() {
 		It("init saves registry ref to state.json", func() {
 			By("Reading state.json after init (from basic tests)")
-			output, err := testExec.ExecBash("cat ~/.local/share/toto/state.json")
+			output, err := testExec.ExecBash("cat ~/.local/share/tomei/state.json")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking registry.aqua.ref exists")
@@ -31,7 +31,7 @@ func registryTests() {
 
 		It("registry ref is valid format", func() {
 			By("Extracting registry ref from state.json")
-			output, err := testExec.ExecBash("cat ~/.local/share/toto/state.json | grep -o '\"ref\": \"v[0-9]*\\.[0-9]*\\.[0-9]*\"'")
+			output, err := testExec.ExecBash("cat ~/.local/share/tomei/state.json | grep -o '\"ref\": \"v[0-9]*\\.[0-9]*\\.[0-9]*\"'")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking ref starts with v")
@@ -41,8 +41,8 @@ func registryTests() {
 
 	Context("Tool Installation - Aqua Registry", func() {
 		It("validates registry manifests", func() {
-			By("Running toto validate on registry manifests")
-			output, err := testExec.Exec("toto", "validate", "~/manifests/registry/")
+			By("Running tomei validate on registry manifests")
+			output, err := testExec.Exec("tomei", "validate", "~/manifests/registry/")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking validation succeeded")
@@ -59,8 +59,8 @@ func registryTests() {
 		})
 
 		It("installs tools via aqua registry", func() {
-			By("Running toto apply on registry manifests")
-			_, err := testExec.Exec("toto", "apply", "~/manifests/registry/")
+			By("Running tomei apply on registry manifests")
+			_, err := testExec.Exec("tomei", "apply", "~/manifests/registry/")
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -131,7 +131,7 @@ func registryTests() {
 
 		It("records package in state.json", func() {
 			By("Reading state.json")
-			output, err := testExec.ExecBash("cat ~/.local/share/toto/state.json")
+			output, err := testExec.ExecBash("cat ~/.local/share/tomei/state.json")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking rg tool has package recorded")
@@ -153,16 +153,16 @@ func registryTests() {
 
 	Context("Registry Sync", func() {
 		It("--sync flag works with apply", func() {
-			By("Running toto apply --sync")
-			_, err := testExec.Exec("toto", "apply", "--sync", "~/manifests/registry/")
+			By("Running tomei apply --sync")
+			_, err := testExec.Exec("tomei", "apply", "--sync", "~/manifests/registry/")
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 
 	Context("Idempotency", func() {
 		It("subsequent apply has no changes", func() {
-			By("Running toto apply again on registry manifests")
-			_, err := testExec.Exec("toto", "apply", "~/manifests/registry/")
+			By("Running tomei apply again on registry manifests")
+			_, err := testExec.Exec("tomei", "apply", "~/manifests/registry/")
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -192,8 +192,8 @@ func registryTests() {
 			_, err = testExec.ExecBash("mv ~/manifests/registry/tools.cue.old ~/manifests/registry/tools.cue")
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Running toto apply with older version")
-			_, err = testExec.Exec("toto", "apply", "~/manifests/registry/")
+			By("Running tomei apply with older version")
+			_, err = testExec.Exec("tomei", "apply", "~/manifests/registry/")
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -221,8 +221,8 @@ func registryTests() {
 			_, err = testExec.ExecBash("mv ~/manifests/registry/tools.cue.new ~/manifests/registry/tools.cue")
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Running toto apply with newer version")
-			_, err = testExec.Exec("toto", "apply", "~/manifests/registry/")
+			By("Running tomei apply with newer version")
+			_, err = testExec.Exec("tomei", "apply", "~/manifests/registry/")
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -244,8 +244,8 @@ func registryTests() {
 		})
 
 		It("is idempotent after version changes", func() {
-			By("Running toto apply again")
-			_, err := testExec.Exec("toto", "apply", "~/manifests/registry/")
+			By("Running tomei apply again")
+			_, err := testExec.Exec("tomei", "apply", "~/manifests/registry/")
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/e2e/scenario.md
+++ b/e2e/scenario.md
@@ -1,21 +1,21 @@
 # E2E Test Scenarios
 
-This document describes the scenarios verified by toto's E2E tests.
+This document describes the scenarios verified by tomei's E2E tests.
 
 ## Test Environment
 
 - **Container**: Ubuntu 24.04-based Docker container (arm64)
-- **Image**: `toto-ubuntu:test`
-- **Container Name**: `toto-e2e-ubuntu`
+- **Image**: `tomei-ubuntu:test`
+- **Container Name**: `tomei-e2e-ubuntu`
 - **User**: `testuser` (non-root)
-- **Environment Variable**: `TOTO_E2E_CONTAINER` specifies the container name
+- **Environment Variable**: `TOMEI_E2E_CONTAINER` specifies the container name
 - **Config Files**: CUE manifests pre-copied to `/home/testuser/manifests/`
 
 ## Test Suite Overview
 
 | Suite | Tests | Description |
 |-------|-------|-------------|
-| toto on Ubuntu | 33 | Basic commands, installation, env export, idempotency, doctor, runtime upgrade, resource removal |
+| tomei on Ubuntu | 33 | Basic commands, installation, env export, idempotency, doctor, runtime upgrade, resource removal |
 | State Backup and Diff | 13 | Backup creation, diff (text/JSON), idempotent diff, upgrade diff, removal diff, backup overwrite |
 | Aqua Registry | 10 | Registry initialization, tool installation via aqua registry, OS/arch resolution |
 | Delegation Runtime | 9 | Rust runtime installation via delegation, cargo install tool, idempotency |
@@ -26,12 +26,12 @@ This document describes the scenarios verified by toto's E2E tests.
 
 ```mermaid
 flowchart TD
-    subgraph S1["1. toto on Ubuntu"]
+    subgraph S1["1. tomei on Ubuntu"]
         direction TB
         S1_1["1.1 Basic Commands<br/>version / init / validate / plan"]
         S1_2["1.2 Apply<br/>Runtime(go 1.25.5) + Tool(gh) + Tool(gopls)"]
         S1_3["1.3-1.5 Verify<br/>directories / symlinks / state.json"]
-        S1_5a["1.5a Environment Export<br/>toto env / --shell fish / --export"]
+        S1_5a["1.5a Environment Export<br/>tomei env / --shell fish / --export"]
         S1_6["1.6 Idempotency<br/>total_actions=0"]
         S1_7["1.7 Delegation<br/>gopls via go install"]
         S1_8["1.8 Doctor<br/>unmanaged tool detection"]
@@ -90,7 +90,7 @@ flowchart TD
         S5_2_1["5.2.1 --parallel Flag<br/>--parallel 1 (seq) / default<br/>Downloads: header once"]
         S5_2_2["5.2.2 Mixed Parallel<br/>Runtime(go) → Tool(gopls)<br/>dependency order in parallel"]
         S5_3["5.3 ToolRef Chain<br/>aqua → jq → jq-installer"]
-        S5_4["5.4 Tool→Installer→Tool<br/>gh → gh-installer → toto-src"]
+        S5_4["5.4 Tool→Installer→Tool<br/>gh → gh-installer → tomei-src"]
         S5_5["5.5 Runtime→Tool Chain<br/>go → go-installer → gopls"]
 
         S5_1 --> S5_2 --> S5_2_1 --> S5_2_2 --> S5_3 --> S5_4 --> S5_5
@@ -122,7 +122,7 @@ graph LR
     subgraph P4["Mixed Chain"]
         I5[Installer/download] --> T6[Tool/gh]
         T6 -.->|toolRef| I6[Installer/gh]
-        I6 --> T7[Tool/toto-src]
+        I6 --> T7[Tool/tomei-src]
     end
 
     subgraph P5["InstallerRepository Chain"]
@@ -135,23 +135,23 @@ graph LR
 
 ---
 
-## 1. toto on Ubuntu (Basic Functionality)
+## 1. tomei on Ubuntu (Basic Functionality)
 
 ### 1.1 Basic Commands
 
-#### `toto version`
+#### `tomei version`
 - Displays version information
-- Output contains "toto version"
+- Output contains "tomei version"
 
-#### `toto init`
+#### `tomei init`
 - Run with `--yes --force` options
 - Verifies creation of:
-  - `~/.config/toto/config.cue` (contains `package toto`)
-  - `~/.local/share/toto/` directory
+  - `~/.config/tomei/config.cue` (contains `package tomei`)
+  - `~/.local/share/tomei/` directory
   - `~/.local/bin/` directory
-  - `~/.local/share/toto/state.json` (contains `version` field)
+  - `~/.local/share/tomei/state.json` (contains `version` field)
 
-#### `toto validate`
+#### `tomei validate`
 - Validates CUE configuration in `~/manifests/`
 - Outputs "Validation successful"
 - Displays recognized resources:
@@ -159,13 +159,13 @@ graph LR
   - Tool/gopls
   - Runtime/go
 
-#### `toto plan`
+#### `tomei plan`
 - Shows execution plan
 - Output contains "Found" and "resource"
 
 ### 1.2 Runtime and Tool Installation
 
-#### `toto apply` (Initial Run)
+#### `tomei apply` (Initial Run)
 - Installs Runtime (Go 1.25.5)
 - Installs Tool (gh 2.86.0 - download pattern)
 - Installs Tool (gopls v0.21.0 - runtime delegation pattern)
@@ -177,12 +177,12 @@ graph LR
 ### 1.3 Runtime Installation Verification
 
 #### Directory Structure
-- Placed in `~/.local/share/toto/runtimes/go/1.25.5/`
+- Placed in `~/.local/share/tomei/runtimes/go/1.25.5/`
 - `bin/` directory exists
 
 #### Symbolic Links
-- `~/go/bin/go` → `~/.local/share/toto/runtimes/go/1.25.5/bin/go`
-- `~/go/bin/gofmt` → `~/.local/share/toto/runtimes/go/1.25.5/bin/gofmt`
+- `~/go/bin/go` → `~/.local/share/tomei/runtimes/go/1.25.5/bin/go`
+- `~/go/bin/gofmt` → `~/.local/share/tomei/runtimes/go/1.25.5/bin/gofmt`
 - Verifies go and gofmt symlinks are **NOT** in `~/.local/bin/`
 
 #### Execution Verification
@@ -192,7 +192,7 @@ graph LR
 ### 1.4 Tool Installation Verification (Download Pattern)
 
 #### Directory Structure
-- Placed in `~/.local/share/toto/tools/gh/2.86.0/`
+- Placed in `~/.local/share/tomei/tools/gh/2.86.0/`
 - `gh` binary exists
 
 #### Symbolic Links
@@ -214,25 +214,25 @@ graph LR
 
 ### 1.5a Environment Export
 
-#### POSIX Output (`toto env`)
-1. Run `toto env`
+#### POSIX Output (`tomei env`)
+1. Run `tomei env`
 2. Verify:
    - Output contains `export GOROOT=`
    - Output contains `export GOBIN=`
    - Output contains `go/bin` and `.local/bin` in PATH
    - Output is eval-safe and PATH works: `eval '<output>' && GOTOOLCHAIN=local go version` succeeds
 
-#### Fish Output (`toto env --shell fish`)
-1. Run `toto env --shell fish`
+#### Fish Output (`tomei env --shell fish`)
+1. Run `tomei env --shell fish`
 2. Verify:
    - Output contains `set -gx GOROOT`
    - Output contains `fish_add_path`
 
-#### File Export (`toto env --export`)
-1. Run `toto env --export`
+#### File Export (`tomei env --export`)
+1. Run `tomei env --export`
 2. Verify:
    - Output mentions `env.sh` file
-   - File `~/.config/toto/env.sh` exists
+   - File `~/.config/tomei/env.sh` exists
    - File contains `export GOROOT=`
    - File contains `export PATH=`
 
@@ -258,13 +258,13 @@ graph LR
 - Outputs "No issues found"
 
 #### Unmanaged Tool Detection
-1. Install goimports using toto-managed Go:
+1. Install goimports using tomei-managed Go:
    ```bash
-   export GOROOT=$HOME/.local/share/toto/runtimes/go/1.25.5
+   export GOROOT=$HOME/.local/share/tomei/runtimes/go/1.25.5
    export GOBIN=$HOME/go/bin
    ~/go/bin/go install golang.org/x/tools/cmd/goimports@latest
    ```
-2. Run `toto doctor`
+2. Run `tomei doctor`
 3. Verify:
    - Displayed in "[go]" section
    - "goimports" detected as "unmanaged"
@@ -278,19 +278,19 @@ graph LR
    mv ~/manifests/runtime.cue ~/manifests/runtime.cue.old
    mv ~/manifests/runtime.cue.upgrade ~/manifests/runtime.cue
    ```
-2. Run `toto plan` to preview changes
+2. Run `tomei plan` to preview changes
 3. Verify:
    - Output contains "Runtime/go"
    - Output contains "Execution Plan"
 
 #### Upgrade Process
-1. Run `toto apply`
+1. Run `tomei apply`
 2. Verify:
    - Output contains "installing runtime", "name=go", "version=1.25.6"
 
 #### Post-Upgrade Verification
 - `GOTOOLCHAIN=local ~/go/bin/go version` → contains "go1.25.6"
-- New runtime placed in `~/.local/share/toto/runtimes/go/1.25.6/`
+- New runtime placed in `~/.local/share/tomei/runtimes/go/1.25.6/`
 - Symlink `~/go/bin/go` points to new version (contains "1.25.6")
 
 #### Taint Logic
@@ -311,7 +311,7 @@ graph LR
    ```bash
    mv ~/manifests/runtime.cue ~/manifests/runtime.cue.hidden
    ```
-2. Run `toto apply ~/manifests/`
+2. Run `tomei apply ~/manifests/`
 3. Verify:
    - Apply fails with error
    - Error contains "cannot remove runtime"
@@ -326,7 +326,7 @@ graph LR
    ```bash
    mv ~/manifests/tools.cue ~/manifests/tools.cue.hidden
    ```
-2. Run `toto apply ~/manifests/`
+2. Run `tomei apply ~/manifests/`
 3. Verify:
    - Apply succeeds
    - `~/.local/bin/gh` symlink no longer exists
@@ -339,7 +339,7 @@ graph LR
    mv ~/manifests/delegation.cue ~/manifests/delegation.cue.hidden
    mv ~/manifests/toolset.cue ~/manifests/toolset.cue.hidden
    ```
-2. Run `toto apply ~/manifests/`
+2. Run `tomei apply ~/manifests/`
 3. Verify:
    - Apply succeeds (no blocking — all dependents removed)
    - `~/go/bin/go` symlink no longer exists
@@ -354,14 +354,14 @@ graph LR
 
 #### No Backup Message
 - Environment is reset (init --force, backup/tools/runtimes removed)
-- Run `toto state diff`
+- Run `tomei state diff`
 - Outputs "No backup found"
 
 ### 1b.2 Backup Creation
 
 #### `state.json.bak` Created During Apply
 1. Record `state.json` content before apply
-2. Run `toto apply ~/manifests/`
+2. Run `tomei apply ~/manifests/`
 3. Verify `state.json.bak` exists
 4. Verify backup content matches pre-apply state
 
@@ -372,44 +372,44 @@ graph LR
 ### 1b.3 Diff After First Apply
 
 #### Text Format
-- `toto state diff` shows "State changes" header
+- `tomei state diff` shows "State changes" header
 - Shows `+` marker for added resources
 - Shows go (with version), gh (with version), gopls
 - Summary line contains "added"
 
 #### JSON Format
-- `toto state diff --output json`
+- `tomei state diff --output json`
 - Contains `"changes"` array, `"type": "added"`
 - Contains `"kind": "runtime"`, `"name": "go"`
 - Contains `"kind": "tool"`, `"name": "gh"`
 
 #### `--no-color` Flag
-- `toto state diff --no-color`
+- `tomei state diff --no-color`
 - Output does NOT contain ANSI escape codes (`\x1b[`)
 - Output still contains "State changes" and diff content
 
 ### 1b.4 Diff After Idempotent Apply
 
 #### No Changes
-1. Run `toto apply ~/manifests/` (second time, no changes)
-2. Run `toto state diff`
+1. Run `tomei apply ~/manifests/` (second time, no changes)
+2. Run `tomei state diff`
 3. Output contains "No changes since last apply"
 
 ### 1b.5 Diff After Version Upgrade
 
 #### Backup Contains Old Version
 1. Swap `runtime.cue` with `runtime.cue.upgrade` (go version change)
-2. Run `toto apply ~/manifests/`
+2. Run `tomei apply ~/manifests/`
 3. Backup contains old go version
 4. Current state contains new go version
 
 #### Text Diff Shows Modification
-- `toto state diff` shows "State changes"
+- `tomei state diff` shows "State changes"
 - Contains go, old version, new version
 - Summary contains "modified"
 
 #### JSON Diff Shows Modification
-- `toto state diff --output json`
+- `tomei state diff --output json`
 - Contains `"type": "modified"`, `"name": "go"`
 - Contains `"oldVersion"` and `"newVersion"` with correct versions
 
@@ -420,11 +420,11 @@ graph LR
 
 #### Text Diff Shows Removed
 1. Hide `tools.cue` (rename to `.hidden`)
-2. Run `toto apply ~/manifests/`
-3. `toto state diff` shows gh with "removed"
+2. Run `tomei apply ~/manifests/`
+3. `tomei state diff` shows gh with "removed"
 
 #### JSON Diff Shows Removed
-- `toto state diff --output json`
+- `tomei state diff --output json`
 - Contains `"type": "removed"`, `"name": "gh"`
 
 #### Cleanup
@@ -434,7 +434,7 @@ graph LR
 
 #### Overwrites on Each Apply
 1. Record current backup content
-2. Run `toto apply ~/manifests/`
+2. Run `tomei apply ~/manifests/`
 3. New backup content differs from previous backup
 
 ---
@@ -443,8 +443,8 @@ graph LR
 
 ### 2.1 Registry Initialization
 
-#### `toto init` with Registry
-- Run `toto init --yes --force`
+#### `tomei init` with Registry
+- Run `tomei init --yes --force`
 - Verifies state.json contains:
   - `registry.aqua.ref` (e.g., "v4.465.0")
   - `registry.aqua.updatedAt`
@@ -461,11 +461,11 @@ graph LR
   - jq jq-1.8.1 (`jqlang/jq`)
 
 #### Validation
-- `toto validate ~/manifests/registry/` succeeds
+- `tomei validate ~/manifests/registry/` succeeds
 - Recognizes Tool/rg, Tool/fd, Tool/jq
 
 #### Installation
-- `toto apply ~/manifests/registry/` installs all tools
+- `tomei apply ~/manifests/registry/` installs all tools
 - Output contains "installing tool" and "tool installed"
 
 #### Version Verification
@@ -490,13 +490,13 @@ graph LR
 ### 2.5 Registry Sync
 
 #### `--sync` Flag
-- `toto apply --sync ~/manifests/registry/`
+- `tomei apply --sync ~/manifests/registry/`
 - Logs contain "aqua registry" message
 
 ### 2.6 Idempotency
 
 #### Subsequent Applies
-- Second `toto apply ~/manifests/registry/` outputs "total_actions=0"
+- Second `tomei apply ~/manifests/registry/` outputs "total_actions=0"
 - All tools continue to work correctly
 
 ### 2.7 Version Upgrade/Downgrade
@@ -507,7 +507,7 @@ graph LR
    mv ~/manifests/registry/tools.cue ~/manifests/registry/tools.cue.new
    mv ~/manifests/registry/tools.cue.old ~/manifests/registry/tools.cue
    ```
-2. Run `toto apply ~/manifests/registry/`
+2. Run `tomei apply ~/manifests/registry/`
 3. Verify older versions installed:
    - `~/.local/bin/rg --version` → "ripgrep 14.1.1"
    - `~/.local/bin/fd --version` → "fd 10.2.0"
@@ -515,7 +515,7 @@ graph LR
 
 #### Upgrade to Newer Version
 1. Swap manifest back to newer versions
-2. Run `toto apply ~/manifests/registry/`
+2. Run `tomei apply ~/manifests/registry/`
 3. Verify newer versions installed:
    - `~/.local/bin/rg --version` → "ripgrep 15.1.0"
    - `~/.local/bin/fd --version` → "fd 10.3.0"
@@ -541,11 +541,11 @@ Tool/helm (aqua) → Installer/helm (toolRef) → InstallerRepository/bitnami
 ```
 
 #### Validation
-- `toto validate ~/installer-repo-test/helm-repo.cue` succeeds
+- `tomei validate ~/installer-repo-test/helm-repo.cue` succeeds
 - Recognizes Tool/helm, InstallerRepository/bitnami
 
 #### Installation
-- `toto apply ~/installer-repo-test/helm-repo.cue` installs helm and adds bitnami repository
+- `tomei apply ~/installer-repo-test/helm-repo.cue` installs helm and adds bitnami repository
 
 #### Helm Binary Verification
 - `~/.local/bin/helm version` is executable
@@ -561,7 +561,7 @@ Tool/helm (aqua) → Installer/helm (toolRef) → InstallerRepository/bitnami
   - `"installerRef": "helm"`
 
 #### Idempotency
-- Second `toto apply ~/installer-repo-test/helm-repo.cue` succeeds
+- Second `tomei apply ~/installer-repo-test/helm-repo.cue` succeeds
 - `helm repo list` still contains "bitnami"
 
 ### 4.2 Dependency Chain: InstallerRepository → Tool (helm pull)
@@ -581,31 +581,31 @@ Tool/helm (aqua) → Installer/helm (toolRef)
 ```
 
 #### Validation
-- `toto validate ~/installer-repo-test/repo-with-tool.cue` succeeds
+- `tomei validate ~/installer-repo-test/repo-with-tool.cue` succeeds
 - Recognizes Tool/helm, InstallerRepository/bitnami, Tool/common-chart
 
 #### Installation
-- `toto apply ~/installer-repo-test/repo-with-tool.cue` succeeds
+- `tomei apply ~/installer-repo-test/repo-with-tool.cue` succeeds
 - InstallerRepository installed before dependent Tool (ordering guaranteed by repositoryRef)
 
 #### Repository Registration
 - `helm repo list` → output contains "bitnami"
 
 #### Chart Download Verification
-- `/tmp/toto-e2e-charts/common-*.tgz` file exists (latest version)
+- `/tmp/tomei-e2e-charts/common-*.tgz` file exists (latest version)
 
 #### State Recording
 - state.json `tools` section contains `"common-chart"`
 - state.json `installerRepositories` section contains `"bitnami"`
 
 #### Idempotency
-- Second `toto apply ~/installer-repo-test/repo-with-tool.cue` succeeds without errors
+- Second `tomei apply ~/installer-repo-test/repo-with-tool.cue` succeeds without errors
 
 ### 4.3 Removal
 
 #### Manifest Reduction
 1. Apply a reduced manifest containing only Tool/helm (no InstallerRepository, no common-chart)
-2. `toto apply ~/installer-repo-test/helm-only.cue` succeeds
+2. `tomei apply ~/installer-repo-test/helm-only.cue` succeeds
 
 #### Verification
 - `helm repo list` does NOT contain "bitnami" (repository removed)
@@ -624,7 +624,7 @@ Installer(a) → Tool(b) → Installer(a)
 ```
 - Installer references Tool via toolRef
 - Tool references that Installer via installerRef
-- `toto validate` returns error
+- `tomei validate` returns error
 - Error message contains "circular dependency"
 
 #### Three-Node Cycle
@@ -632,12 +632,12 @@ Installer(a) → Tool(b) → Installer(a)
 Tool(a) → Installer(c) → Tool(c) → Installer(b) → Tool(a)
 ```
 - Circular reference involving 3 resources
-- `toto validate` returns error
+- `tomei validate` returns error
 - Error message contains "circular dependency"
 
 #### Both runtimeRef and toolRef Specified
 - Installer specifies both runtimeRef and toolRef
-- `toto validate` returns error
+- `tomei validate` returns error
 - Error message contains "runtimeRef" and "toolRef"
 
 ### 5.2 Parallel Tool Installation
@@ -650,8 +650,8 @@ Tool(a) → Installer(c) → Tool(c) → Installer(b) → Tool(a)
   - bat 0.24.0
 
 #### Verification
-1. `toto validate` succeeds
-2. `toto apply` installs all 3 tools
+1. `tomei validate` succeeds
+2. `tomei apply` installs all 3 tools
 3. Version check for each tool:
    - `~/.local/bin/rg --version` → "ripgrep 14.1.1"
    - `~/.local/bin/fd --version` → "fd 10.2.0"
@@ -663,7 +663,7 @@ Tool(a) → Installer(c) → Tool(c) → Installer(b) → Tool(a)
 ### 5.2.1 `--parallel` Flag Behavior
 
 #### Sequential Execution (`--parallel 1`)
-- `toto apply --parallel 1 ~/dependency-test/parallel.cue`
+- `tomei apply --parallel 1 ~/dependency-test/parallel.cue`
 - All 3 tools (rg, fd, bat) installed correctly
 - Version verification:
   - `~/.local/bin/rg --version` → "ripgrep 14.1.1"
@@ -672,7 +672,7 @@ Tool(a) → Installer(c) → Tool(c) → Installer(b) → Tool(a)
 - Non-TTY output contains "Commands:" header exactly once
 
 #### Default Parallelism (`--parallel 5`)
-- `toto apply ~/dependency-test/parallel.cue` (no flag, default)
+- `tomei apply ~/dependency-test/parallel.cue` (no flag, default)
 - All 3 tools installed correctly
 - Non-TTY output contains "Commands:" header exactly once (no duplicates from concurrent writes)
 
@@ -685,9 +685,9 @@ Runtime(go) → Installer(go) → Tool(gopls)
 - Same as runtime-chain.cue but executed with default parallelism
 
 #### Verification
-1. `toto apply ~/dependency-test/runtime-chain.cue` succeeds
+1. `tomei apply ~/dependency-test/runtime-chain.cue` succeeds
 2. Go runtime installed before gopls (dependency order preserved in parallel mode):
-   - `GOTOOLCHAIN=local ~/.local/share/toto/runtimes/go/1.23.5/bin/go version` → "go1.23"
+   - `GOTOOLCHAIN=local ~/.local/share/tomei/runtimes/go/1.23.5/bin/go version` → "go1.23"
    - `~/go/bin/gopls version` → "golang.org/x/tools/gopls"
 3. state.json records both "go" and "gopls"
 
@@ -702,34 +702,34 @@ Installer(aqua) → Tool(jq) → Installer(jq-installer)
 - jq-installer: Installer referencing jq via toolRef
 
 #### Verification
-1. `toto validate` correctly recognizes dependencies:
+1. `tomei validate` correctly recognizes dependencies:
    - Installer/aqua
    - Tool/jq
    - Installer/jq-installer
-2. `toto apply` installs jq
+2. `tomei apply` installs jq
 3. `~/.local/bin/jq --version` → contains "jq-1.7"
 
 ### 5.4 Tool → Installer → Tool Chain (gh clone)
 
 #### Configuration
 ```
-Tool(gh) → Installer(gh) [toolRef] → Tool(toto-src)
+Tool(gh) → Installer(gh) [toolRef] → Tool(tomei-src)
 ```
 - gh: Tool installed via download pattern
 - gh installer: Installer referencing gh via toolRef, uses `gh repo clone`
-- toto-src: Tool (repository) cloned via gh installer
+- tomei-src: Tool (repository) cloned via gh installer
 
 #### Verification
-1. `toto validate` recognizes all resources:
+1. `tomei validate` recognizes all resources:
    - Tool/gh
    - Installer/gh
-   - Tool/toto-src
-2. `toto apply` installs gh tool first
+   - Tool/tomei-src
+2. `tomei apply` installs gh tool first
 3. gh is available: `~/.local/bin/gh --version`
-4. toto repository is cloned:
-   - `~/repos/toto-src/` directory exists
-   - `~/repos/toto-src/go.mod` exists
-   - `~/repos/toto-src/cmd/toto/main.go` exists
+4. tomei repository is cloned:
+   - `~/repos/tomei-src/` directory exists
+   - `~/repos/tomei-src/go.mod` exists
+   - `~/repos/tomei-src/cmd/tomei/main.go` exists
 
 ### 5.5 Runtime → Tool Dependency Chain
 
@@ -742,15 +742,15 @@ Runtime(go) → Installer(go) → Tool(gopls)
 - gopls Tool: references Go Installer via installerRef and Go Runtime via runtimeRef
 
 #### Verification
-1. `toto validate` recognizes all resources:
+1. `tomei validate` recognizes all resources:
    - Runtime/go
    - Installer/go
    - Tool/gopls
-2. `toto apply` installs in correct order:
+2. `tomei apply` installs in correct order:
    - Runtime installed first
    - Tool installed after
 3. Go 1.23.5 correctly installed:
-   - `GOTOOLCHAIN=local ~/.local/share/toto/runtimes/go/1.23.5/bin/go version`
+   - `GOTOOLCHAIN=local ~/.local/share/tomei/runtimes/go/1.23.5/bin/go version`
    - Contains "go1.23"
 4. gopls correctly installed:
    - `~/go/bin/gopls version`
@@ -773,12 +773,12 @@ make test-e2e
 ```
 
 This command automatically:
-1. Builds toto binary for linux/arm64
-2. Builds Docker image (`toto-ubuntu:test`) with:
-   - toto binary installed at `/usr/local/bin/toto`
+1. Builds tomei binary for linux/arm64
+2. Builds Docker image (`tomei-ubuntu:test`) with:
+   - tomei binary installed at `/usr/local/bin/tomei`
    - Config files pre-copied to `/home/testuser/manifests/`
    - Non-root user (`testuser`) for realistic testing
-3. Starts container (`toto-e2e-ubuntu`)
+3. Starts container (`tomei-e2e-ubuntu`)
 4. Runs Ginkgo tests
 5. Cleans up container
 
@@ -807,7 +807,7 @@ make down
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `TOTO_E2E_CONTAINER` | Container name for tests | `toto-e2e-ubuntu` |
+| `TOMEI_E2E_CONTAINER` | Container name for tests | `tomei-e2e-ubuntu` |
 
 ---
 
@@ -829,7 +829,7 @@ gopls v0.21.0 definition (runtime delegation pattern)
 ### `e2e/config/toolref.cue`
 Tool → Installer → Tool chain definition:
 - gh installer with toolRef (depends on gh tool)
-- toto-src tool (cloned via gh installer)
+- tomei-src tool (cloned via gh installer)
 
 ### `e2e/config/registry/tools.cue`
 Aqua registry-based tool definitions:

--- a/e2e/state_backup_diff_test.go
+++ b/e2e/state_backup_diff_test.go
@@ -18,25 +18,25 @@ func stateBackupDiffTests() {
 		_, _ = testExec.ExecBash("if [ -f ~/manifests/runtime.cue.old ]; then mv ~/manifests/runtime.cue ~/manifests/runtime.cue.upgrade && mv ~/manifests/runtime.cue.old ~/manifests/runtime.cue; fi")
 
 		By("Initializing clean environment for state backup/diff tests")
-		_, err := testExec.Exec("toto", "init", "--yes", "--force")
+		_, err := testExec.Exec("tomei", "init", "--yes", "--force")
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Removing any leftover backup file")
-		_, _ = testExec.ExecBash("rm -f ~/.local/share/toto/state.json.bak")
+		_, _ = testExec.ExecBash("rm -f ~/.local/share/tomei/state.json.bak")
 
 		By("Removing any leftover tools/runtimes from previous tests")
-		_, _ = testExec.ExecBash("rm -rf ~/.local/share/toto/tools ~/.local/share/toto/runtimes")
+		_, _ = testExec.ExecBash("rm -rf ~/.local/share/tomei/tools ~/.local/share/tomei/runtimes")
 		_, _ = testExec.ExecBash("rm -f ~/.local/bin/* ~/go/bin/*")
 	})
 
 	Context("Diff Before First Apply", func() {
 		It("shows no backup message when backup does not exist", func() {
 			By("Ensuring no backup file exists")
-			_, err := testExec.ExecBash("test ! -f ~/.local/share/toto/state.json.bak")
+			_, err := testExec.ExecBash("test ! -f ~/.local/share/tomei/state.json.bak")
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Running toto state diff")
-			output, err := testExec.Exec("toto", "state", "diff")
+			By("Running tomei state diff")
+			output, err := testExec.Exec("tomei", "state", "diff")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking output contains 'No backup found' message")
@@ -47,26 +47,26 @@ func stateBackupDiffTests() {
 	Context("Backup Creation", func() {
 		It("creates state.json.bak during apply", func() {
 			By("Recording state.json content before apply")
-			stateBefore, err := testExec.ExecBash("cat ~/.local/share/toto/state.json")
+			stateBefore, err := testExec.ExecBash("cat ~/.local/share/tomei/state.json")
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Running toto apply to install runtime and tools")
-			_, err = testExec.Exec("toto", "apply", "~/manifests/")
+			By("Running tomei apply to install runtime and tools")
+			_, err = testExec.Exec("tomei", "apply", "~/manifests/")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying state.json.bak was created")
-			_, err = testExec.ExecBash("test -f ~/.local/share/toto/state.json.bak")
+			_, err = testExec.ExecBash("test -f ~/.local/share/tomei/state.json.bak")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying backup content matches pre-apply state")
-			backupContent, err := testExec.ExecBash("cat ~/.local/share/toto/state.json.bak")
+			backupContent, err := testExec.ExecBash("cat ~/.local/share/tomei/state.json.bak")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(backupContent).To(Equal(stateBefore))
 		})
 
 		It("backup differs from current state after first apply", func() {
 			By("Reading current state.json")
-			stateCurrent, err := testExec.ExecBash("cat ~/.local/share/toto/state.json")
+			stateCurrent, err := testExec.ExecBash("cat ~/.local/share/tomei/state.json")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking current state has installed resources")
@@ -74,7 +74,7 @@ func stateBackupDiffTests() {
 			Expect(stateCurrent).To(ContainSubstring(fmt.Sprintf(`"version": "%s"`, versions.GhVersion)))
 
 			By("Reading backup state")
-			backupContent, err := testExec.ExecBash("cat ~/.local/share/toto/state.json.bak")
+			backupContent, err := testExec.ExecBash("cat ~/.local/share/tomei/state.json.bak")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying backup does NOT contain installed tool versions")
@@ -84,8 +84,8 @@ func stateBackupDiffTests() {
 
 	Context("Diff After First Apply", func() {
 		It("shows added resources in text format", func() {
-			By("Running toto state diff")
-			output, err := testExec.Exec("toto", "state", "diff")
+			By("Running tomei state diff")
+			output, err := testExec.Exec("tomei", "state", "diff")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking header is shown")
@@ -108,8 +108,8 @@ func stateBackupDiffTests() {
 		})
 
 		It("shows added resources in JSON format", func() {
-			By("Running toto state diff --output json")
-			output, err := testExec.Exec("toto", "state", "diff", "--output", "json")
+			By("Running tomei state diff --output json")
+			output, err := testExec.Exec("tomei", "state", "diff", "--output", "json")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking JSON contains changes array")
@@ -128,8 +128,8 @@ func stateBackupDiffTests() {
 		})
 
 		It("supports --no-color flag", func() {
-			By("Running toto state diff --no-color")
-			output, err := testExec.Exec("toto", "state", "diff", "--no-color")
+			By("Running tomei state diff --no-color")
+			output, err := testExec.Exec("tomei", "state", "diff", "--no-color")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking output does not contain ANSI escape codes")
@@ -143,12 +143,12 @@ func stateBackupDiffTests() {
 
 	Context("Diff After Idempotent Apply", func() {
 		It("shows no changes after idempotent apply", func() {
-			By("Running toto apply again (idempotent)")
-			_, err := testExec.Exec("toto", "apply", "~/manifests/")
+			By("Running tomei apply again (idempotent)")
+			_, err := testExec.Exec("tomei", "apply", "~/manifests/")
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Running toto state diff")
-			output, err := testExec.Exec("toto", "state", "diff")
+			By("Running tomei state diff")
+			output, err := testExec.Exec("tomei", "state", "diff")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking output says no changes")
@@ -164,24 +164,24 @@ func stateBackupDiffTests() {
 			_, err = testExec.ExecBash("mv ~/manifests/runtime.cue.upgrade ~/manifests/runtime.cue")
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Running toto apply with upgraded config")
-			_, err = testExec.Exec("toto", "apply", "~/manifests/")
+			By("Running tomei apply with upgraded config")
+			_, err = testExec.Exec("tomei", "apply", "~/manifests/")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying backup contains old version")
-			backupContent, err := testExec.ExecBash("cat ~/.local/share/toto/state.json.bak")
+			backupContent, err := testExec.ExecBash("cat ~/.local/share/tomei/state.json.bak")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(backupContent).To(ContainSubstring(fmt.Sprintf(`"version": "%s"`, versions.GoVersion)))
 
 			By("Verifying current state contains new version")
-			stateContent, err := testExec.ExecBash("cat ~/.local/share/toto/state.json")
+			stateContent, err := testExec.ExecBash("cat ~/.local/share/tomei/state.json")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(stateContent).To(ContainSubstring(fmt.Sprintf(`"version": "%s"`, versions.GoVersionUpgrade)))
 		})
 
 		It("shows runtime modification in text diff", func() {
-			By("Running toto state diff")
-			output, err := testExec.Exec("toto", "state", "diff")
+			By("Running tomei state diff")
+			output, err := testExec.Exec("tomei", "state", "diff")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking diff shows runtime version change")
@@ -195,8 +195,8 @@ func stateBackupDiffTests() {
 		})
 
 		It("shows runtime modification in JSON diff", func() {
-			By("Running toto state diff --output json")
-			output, err := testExec.Exec("toto", "state", "diff", "--output", "json")
+			By("Running tomei state diff --output json")
+			output, err := testExec.Exec("tomei", "state", "diff", "--output", "json")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking JSON contains modified type for runtime")
@@ -212,7 +212,7 @@ func stateBackupDiffTests() {
 			_, _ = testExec.ExecBash("mv ~/manifests/runtime.cue.old ~/manifests/runtime.cue")
 
 			By("Restoring original runtime version via apply")
-			_, _ = testExec.Exec("toto", "apply", "~/manifests/")
+			_, _ = testExec.Exec("tomei", "apply", "~/manifests/")
 		})
 	})
 
@@ -222,12 +222,12 @@ func stateBackupDiffTests() {
 			_, err := testExec.ExecBash("mv ~/manifests/tools.cue ~/manifests/tools.cue.hidden")
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Running toto apply")
-			_, err = testExec.Exec("toto", "apply", "~/manifests/")
+			By("Running tomei apply")
+			_, err = testExec.Exec("tomei", "apply", "~/manifests/")
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Running toto state diff")
-			output, err := testExec.Exec("toto", "state", "diff")
+			By("Running tomei state diff")
+			output, err := testExec.Exec("tomei", "state", "diff")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking diff shows gh as removed")
@@ -236,8 +236,8 @@ func stateBackupDiffTests() {
 		})
 
 		It("shows removed tool in JSON diff", func() {
-			By("Running toto state diff --output json")
-			output, err := testExec.Exec("toto", "state", "diff", "--output", "json")
+			By("Running tomei state diff --output json")
+			output, err := testExec.Exec("tomei", "state", "diff", "--output", "json")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking JSON contains removed type for gh")
@@ -254,15 +254,15 @@ func stateBackupDiffTests() {
 	Context("Backup Overwrite", func() {
 		It("overwrites backup on each apply", func() {
 			By("Recording current backup content")
-			backupBefore, err := testExec.ExecBash("cat ~/.local/share/toto/state.json.bak")
+			backupBefore, err := testExec.ExecBash("cat ~/.local/share/tomei/state.json.bak")
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Running toto apply again")
-			_, err = testExec.Exec("toto", "apply", "~/manifests/")
+			By("Running tomei apply again")
+			_, err = testExec.Exec("tomei", "apply", "~/manifests/")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Reading new backup content")
-			backupAfter, err := testExec.ExecBash("cat ~/.local/share/toto/state.json.bak")
+			backupAfter, err := testExec.ExecBash("cat ~/.local/share/tomei/state.json.bak")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying backup was updated")

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -34,7 +34,7 @@ var _ = AfterSuite(func() {
 })
 
 // Single top-level Describe with Ordered to guarantee execution order across all contexts.
-var _ = Describe("toto E2E", Ordered, func() {
+var _ = Describe("tomei E2E", Ordered, func() {
 	Context("Basic", basicTests)
 	Context("State Backup and Diff", stateBackupDiffTests)
 	Context("ToolSet", toolsetTests)

--- a/e2e/toolset_test.go
+++ b/e2e/toolset_test.go
@@ -11,17 +11,17 @@ func toolsetTests() {
 
 	BeforeAll(func() {
 		By("Initializing environment")
-		_, err := testExec.Exec("toto", "init", "--yes", "--force")
+		_, err := testExec.Exec("tomei", "init", "--yes", "--force")
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Cleaning previous state")
-		_, _ = testExec.ExecBash("rm -rf ~/.local/share/toto/tools ~/.local/bin/* ~/go/bin/*")
+		_, _ = testExec.ExecBash("rm -rf ~/.local/share/tomei/tools ~/.local/bin/* ~/go/bin/*")
 	})
 
 	Context("Validation", func() {
 		It("validates ToolSet manifest with runtime", func() {
-			By("Running toto validate on toolset + runtime")
-			output, err := testExec.Exec("toto", "validate", "~/manifests/toolset.cue", "~/manifests/runtime.cue")
+			By("Running tomei validate on toolset + runtime")
+			output, err := testExec.Exec("tomei", "validate", "~/manifests/toolset.cue", "~/manifests/runtime.cue")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking validation succeeded")
@@ -35,8 +35,8 @@ func toolsetTests() {
 
 	Context("Installation", func() {
 		It("installs all tools from ToolSet via runtime delegation", func() {
-			By("Running toto apply on toolset + runtime")
-			output, err := testExec.Exec("toto", "apply", "~/manifests/toolset.cue", "~/manifests/runtime.cue")
+			By("Running tomei apply on toolset + runtime")
+			output, err := testExec.Exec("tomei", "apply", "~/manifests/toolset.cue", "~/manifests/runtime.cue")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking apply completed")
@@ -59,7 +59,7 @@ func toolsetTests() {
 
 		It("saved individual tool states", func() {
 			By("Checking state.json contains staticcheck and godoc")
-			output, err := testExec.ExecBash("cat ~/.local/share/toto/state.json")
+			output, err := testExec.ExecBash("cat ~/.local/share/tomei/state.json")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).To(ContainSubstring(`"staticcheck"`))
 			Expect(output).To(ContainSubstring(`"godoc"`))
@@ -68,8 +68,8 @@ func toolsetTests() {
 
 	Context("Re-apply (idempotent)", func() {
 		It("reports no changes on re-apply", func() {
-			By("Running toto apply again")
-			output, err := testExec.Exec("toto", "apply", "~/manifests/toolset.cue", "~/manifests/runtime.cue")
+			By("Running tomei apply again")
+			output, err := testExec.Exec("tomei", "apply", "~/manifests/toolset.cue", "~/manifests/runtime.cue")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).To(ContainSubstring("No changes to apply"))
 		})

--- a/e2e/versions_test.go
+++ b/e2e/versions_test.go
@@ -8,8 +8,8 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/terassyi/toto/internal/config"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/config"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // e2eVersions holds version strings extracted from CUE manifests.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terassyi/toto
+module github.com/terassyi/tomei
 
 go 1.25.6
 
@@ -15,6 +15,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/vbauerster/mpb/v8 v8.11.3
+	golang.org/x/sync v0.19.0
 	pgregory.net/rapid v1.2.0
 )
 
@@ -63,7 +64,6 @@ require (
 	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/oauth2 v0.32.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/tools v0.41.0 // indirect

--- a/internal/checksum/checksum.go
+++ b/internal/checksum/checksum.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // Algorithm represents a checksum hash algorithm.

--- a/internal/checksum/checksum_test.go
+++ b/internal/checksum/checksum_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 func TestParse(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,13 +14,13 @@ import (
 
 // Default path constants
 const (
-	DefaultConfigDir = "~/.config/toto"
-	DefaultDataDir   = "~/.local/share/toto"
+	DefaultConfigDir = "~/.config/tomei"
+	DefaultDataDir   = "~/.local/share/tomei"
 	DefaultBinDir    = "~/.local/bin"
-	DefaultEnvDir    = "~/.config/toto"
+	DefaultEnvDir    = "~/.config/tomei"
 )
 
-// Config represents toto configuration.
+// Config represents tomei configuration.
 type Config struct {
 	DataDir string `json:"dataDir"`
 	BinDir  string `json:"binDir"`
@@ -102,5 +102,5 @@ func (c *Config) ToCue() ([]byte, error) {
 		return nil, fmt.Errorf("failed to format config: %w", err)
 	}
 
-	return append([]byte("package toto\n\n"), b...), nil
+	return append([]byte("package tomei\n\n"), b...), nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -30,7 +30,7 @@ func TestLoadConfig_WithConfigFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.cue")
 
-	cueContent := `package toto
+	cueContent := `package tomei
 
 config: {
     dataDir: "~/my-data"
@@ -52,7 +52,7 @@ func TestLoadConfig_PartialConfig(t *testing.T) {
 	configPath := filepath.Join(tmpDir, "config.cue")
 
 	// Only dataDir specified
-	cueContent := `package toto
+	cueContent := `package tomei
 
 config: {
     dataDir: "~/custom-data"
@@ -74,7 +74,7 @@ func TestLoadConfig_NoConfigBlock(t *testing.T) {
 	configPath := filepath.Join(tmpDir, "config.cue")
 
 	// config.cue exists but has no config block
-	cueContent := `package toto
+	cueContent := `package tomei
 
 somethingElse: "value"
 `
@@ -94,7 +94,7 @@ func TestLoadConfig_InvalidCue(t *testing.T) {
 	configPath := filepath.Join(tmpDir, "config.cue")
 
 	// Invalid CUE syntax
-	cueContent := `package toto
+	cueContent := `package tomei
 config: {
     dataDir: "~/my-data"
     // missing closing brace
@@ -117,7 +117,7 @@ func TestConfig_ToCue(t *testing.T) {
 	require.NoError(t, err)
 
 	cueContent := string(cueBytes)
-	assert.Contains(t, cueContent, "package toto")
+	assert.Contains(t, cueContent, "package tomei")
 	assert.Contains(t, cueContent, "config")
 	assert.Contains(t, cueContent, "dataDir")
 	assert.Contains(t, cueContent, "~/my-data")

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -11,11 +11,11 @@ import (
 	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/cue/load"
 
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 const (
-	// ConfigFileName is the name of the toto config file that should be ignored when loading manifests.
+	// ConfigFileName is the name of the tomei config file that should be ignored when loading manifests.
 	ConfigFileName = "config.cue"
 )
 
@@ -106,7 +106,7 @@ func detectPackageName(source string) string {
 }
 
 // Load loads CUE configuration from the given directory.
-// config.cue files are excluded from loading as they contain toto configuration, not manifests.
+// config.cue files are excluded from loading as they contain tomei configuration, not manifests.
 func (l *Loader) Load(dir string) ([]resource.Resource, error) {
 	// Check if directory exists
 	info, err := os.Stat(dir)

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 func TestLoader_LoadFile_Tool(t *testing.T) {
@@ -13,7 +13,7 @@ func TestLoader_LoadFile_Tool(t *testing.T) {
 	cueFile := filepath.Join(dir, "tool.cue")
 
 	content := `
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Tool"
 metadata: name: "ripgrep"
 spec: {
@@ -67,7 +67,7 @@ func TestLoader_LoadFile_ToolSet(t *testing.T) {
 	cueFile := filepath.Join(dir, "toolset.cue")
 
 	content := `
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "ToolSet"
 metadata: name: "cli-tools"
 spec: {
@@ -114,7 +114,7 @@ func TestLoader_LoadFile_Runtime(t *testing.T) {
 	cueFile := filepath.Join(dir, "runtime.cue")
 
 	content := `
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Runtime"
 metadata: name: "go"
 spec: {
@@ -127,7 +127,7 @@ spec: {
     binaries: ["go", "gofmt"]
     toolBinPath: "~/go/bin"
     env: {
-        GOROOT: "~/.local/share/toto/runtimes/go/1.25.1"
+        GOROOT: "~/.local/share/tomei/runtimes/go/1.25.1"
     }
 }
 `
@@ -163,7 +163,7 @@ func TestLoader_LoadFile_SystemPackageSet(t *testing.T) {
 	cueFile := filepath.Join(dir, "syspkg.cue")
 
 	content := `
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "SystemPackageSet"
 metadata: name: "cli-tools"
 spec: {
@@ -200,7 +200,7 @@ func TestLoader_LoadFile_WithLabels(t *testing.T) {
 	cueFile := filepath.Join(dir, "tool.cue")
 
 	content := `
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Tool"
 metadata: {
     name: "ripgrep"
@@ -239,9 +239,9 @@ func TestLoader_Load_Directory(t *testing.T) {
 
 	// Write a CUE file with package declaration
 	content := `
-package toto
+package tomei
 
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Tool"
 metadata: name: "ripgrep"
 spec: {
@@ -282,7 +282,7 @@ func TestLoader_InjectEnv_StringInterpolation(t *testing.T) {
 
 	// Use _env in string interpolation
 	content := `
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Tool"
 metadata: name: "gh"
 spec: {
@@ -330,7 +330,7 @@ func TestLoader_InjectEnv_RuntimeURL(t *testing.T) {
 
 	// Use _env for runtime URL
 	content := `
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Runtime"
 metadata: name: "go"
 spec: {
@@ -366,7 +366,7 @@ func TestLoader_InjectEnv_Headless(t *testing.T) {
 
 	// Use _env.headless for conditional field
 	content := `
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Tool"
 metadata: name: "test-tool"
 spec: {
@@ -414,10 +414,10 @@ func TestLoader_InjectEnv_DirectoryLoad(t *testing.T) {
 
 	// Write a CUE file with package declaration using _env
 	content := `
-package toto
+package tomei
 
 tool: {
-    apiVersion: "toto.terassyi.net/v1beta1"
+    apiVersion: "tomei.terassyi.net/v1beta1"
     kind: "Tool"
     metadata: name: "gh"
     spec: {
@@ -461,7 +461,7 @@ func TestLoader_InjectEnv_PlatformMapping(t *testing.T) {
 			name: "platform.os.apple darwin",
 			env:  &Env{OS: "darwin", Arch: "arm64", Headless: false},
 			cueTemplate: `
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Tool"
 metadata: name: "gh"
 spec: {
@@ -478,7 +478,7 @@ spec: {
 			name: "platform.os.apple linux",
 			env:  &Env{OS: "linux", Arch: "amd64", Headless: false},
 			cueTemplate: `
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Tool"
 metadata: name: "gh"
 spec: {
@@ -495,7 +495,7 @@ spec: {
 			name: "platform.arch.gnu amd64",
 			env:  &Env{OS: "linux", Arch: "amd64", Headless: false},
 			cueTemplate: `
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Tool"
 metadata: name: "ripgrep"
 spec: {
@@ -512,7 +512,7 @@ spec: {
 			name: "platform.arch.gnu arm64",
 			env:  &Env{OS: "linux", Arch: "arm64", Headless: false},
 			cueTemplate: `
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Tool"
 metadata: name: "ripgrep"
 spec: {
@@ -529,7 +529,7 @@ spec: {
 			name: "platform.os.go and platform.arch.go",
 			env:  &Env{OS: "darwin", Arch: "amd64", Headless: false},
 			cueTemplate: `
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Tool"
 metadata: name: "test"
 spec: {
@@ -572,7 +572,7 @@ func TestLoader_LoadFile_InstallerRepository_Delegation(t *testing.T) {
 	cueFile := filepath.Join(dir, "repo.cue")
 
 	content := `
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "InstallerRepository"
 metadata: name: "bitnami"
 spec: {
@@ -629,7 +629,7 @@ func TestLoader_LoadFile_InstallerRepository_Git(t *testing.T) {
 	cueFile := filepath.Join(dir, "repo.cue")
 
 	content := `
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "InstallerRepository"
 metadata: name: "custom-registry"
 spec: {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/terassyi/toto/internal/path"
-	"github.com/terassyi/toto/internal/resource"
-	"github.com/terassyi/toto/internal/state"
+	"github.com/terassyi/tomei/internal/path"
+	"github.com/terassyi/tomei/internal/resource"
+	"github.com/terassyi/tomei/internal/state"
 )
 
-// Doctor checks the health of the toto-managed environment.
+// Doctor checks the health of the tomei-managed environment.
 type Doctor struct {
 	paths     *path.Paths
 	state     *state.UserState
@@ -18,7 +18,7 @@ type Doctor struct {
 
 // Result contains the findings from a doctor check.
 type Result struct {
-	// UnmanagedTools maps category (runtime name or "toto") to unmanaged tools found.
+	// UnmanagedTools maps category (runtime name or "tomei") to unmanaged tools found.
 	UnmanagedTools map[string][]UnmanagedTool
 	// Conflicts contains tools found in multiple locations.
 	Conflicts []Conflict
@@ -26,7 +26,7 @@ type Result struct {
 	StateIssues []StateIssue
 }
 
-// UnmanagedTool represents a tool not managed by toto.
+// UnmanagedTool represents a tool not managed by tomei.
 type UnmanagedTool struct {
 	Name string
 	Path string
@@ -101,7 +101,7 @@ func New(paths *path.Paths, st *state.UserState) (*Doctor, error) {
 		}
 	}
 
-	// Always scan the toto bin directory
+	// Always scan the tomei bin directory
 	scanPaths[resource.ProjectName] = paths.UserBinDir()
 
 	return &Doctor{

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/terassyi/toto/internal/path"
-	"github.com/terassyi/toto/internal/resource"
-	"github.com/terassyi/toto/internal/state"
+	"github.com/terassyi/tomei/internal/path"
+	"github.com/terassyi/tomei/internal/resource"
+	"github.com/terassyi/tomei/internal/state"
 )
 
 func TestNew(t *testing.T) {
@@ -53,8 +53,8 @@ func TestDoctor_ScanForUnmanaged(t *testing.T) {
 		unmanaged, err := doc.scanForUnmanaged()
 		require.NoError(t, err)
 
-		assert.Len(t, unmanaged["toto"], 1)
-		assert.Equal(t, "unmanaged-tool", unmanaged["toto"][0].Name)
+		assert.Len(t, unmanaged["tomei"], 1)
+		assert.Equal(t, "unmanaged-tool", unmanaged["tomei"][0].Name)
 	})
 
 	t.Run("does not detect managed tools", func(t *testing.T) {
@@ -84,7 +84,7 @@ func TestDoctor_ScanForUnmanaged(t *testing.T) {
 		unmanaged, err := doc.scanForUnmanaged()
 		require.NoError(t, err)
 
-		assert.Empty(t, unmanaged["toto"])
+		assert.Empty(t, unmanaged["tomei"])
 	})
 
 	t.Run("empty directory", func(t *testing.T) {
@@ -393,7 +393,7 @@ func TestResult_HasIssues(t *testing.T) {
 	t.Run("has unmanaged tools", func(t *testing.T) {
 		result := &Result{
 			UnmanagedTools: map[string][]UnmanagedTool{
-				"toto": {{Name: "tool", Path: "/path"}},
+				"tomei": {{Name: "tool", Path: "/path"}},
 			},
 		}
 		assert.True(t, result.HasIssues())
@@ -419,8 +419,8 @@ func TestResult_HasIssues(t *testing.T) {
 func TestResult_UnmanagedToolNames(t *testing.T) {
 	result := &Result{
 		UnmanagedTools: map[string][]UnmanagedTool{
-			"toto": {{Name: "tool1", Path: "/path1"}},
-			"go":   {{Name: "tool2", Path: "/path2"}, {Name: "tool1", Path: "/path3"}}, // tool1 duplicate
+			"tomei": {{Name: "tool1", Path: "/path1"}},
+			"go":    {{Name: "tool2", Path: "/path2"}, {Name: "tool1", Path: "/path3"}}, // tool1 duplicate
 		},
 	}
 

--- a/internal/doctor/integrity.go
+++ b/internal/doctor/integrity.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/terassyi/toto/internal/path"
+	"github.com/terassyi/tomei/internal/path"
 )
 
 // checkStateIntegrity verifies that the state matches the filesystem.

--- a/internal/doctor/scan.go
+++ b/internal/doctor/scan.go
@@ -6,7 +6,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // executableBits is the Unix permission bitmask for executable files (owner/group/other execute).
@@ -68,7 +68,7 @@ func (d *Doctor) scanPath(category, binPath string) ([]UnmanagedTool, error) {
 			continue
 		}
 
-		// Check if this tool is managed by toto
+		// Check if this tool is managed by tomei
 		if !d.isManagedTool(name, category) {
 			unmanaged = append(unmanaged, UnmanagedTool{
 				Name: name,
@@ -80,7 +80,7 @@ func (d *Doctor) scanPath(category, binPath string) ([]UnmanagedTool, error) {
 	return unmanaged, nil
 }
 
-// isManagedTool checks if a tool is managed by toto.
+// isManagedTool checks if a tool is managed by tomei.
 func (d *Doctor) isManagedTool(name, category string) bool {
 	if d.state == nil {
 		return false
@@ -102,9 +102,9 @@ func (d *Doctor) isManagedTool(name, category string) bool {
 		return false
 	}
 
-	// For toto category, check if the tool is managed with download pattern
+	// For tomei category, check if the tool is managed with download pattern
 	if category == resource.ProjectName {
-		// If tool exists in state and has no runtimeRef, it's managed by toto directly
+		// If tool exists in state and has no runtimeRef, it's managed by tomei directly
 		return tool.RuntimeRef == ""
 	}
 

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // Generate produces environment variable statements for the given runtimes.

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 func TestGenerate(t *testing.T) {
@@ -45,14 +45,14 @@ func TestGenerate(t *testing.T) {
 					BinDir:      home + "/go/bin",
 					ToolBinPath: home + "/go/bin",
 					Env: map[string]string{
-						"GOROOT": home + "/.local/share/toto/runtimes/go/1.25.6",
+						"GOROOT": home + "/.local/share/tomei/runtimes/go/1.25.6",
 						"GOBIN":  home + "/go/bin",
 					},
 				},
 			},
 			shell: ShellPosix,
 			wantContains: []string{
-				`export GOROOT="$HOME/.local/share/toto/runtimes/go/1.25.6"`,
+				`export GOROOT="$HOME/.local/share/tomei/runtimes/go/1.25.6"`,
 				`export GOBIN="$HOME/go/bin"`,
 				`$HOME/.local/bin`,
 				`$HOME/go/bin`,
@@ -67,13 +67,13 @@ func TestGenerate(t *testing.T) {
 					BinDir:      home + "/go/bin",
 					ToolBinPath: home + "/go/bin",
 					Env: map[string]string{
-						"GOROOT": home + "/.local/share/toto/runtimes/go/1.25.6",
+						"GOROOT": home + "/.local/share/tomei/runtimes/go/1.25.6",
 					},
 				},
 			},
 			shell: ShellFish,
 			wantContains: []string{
-				`set -gx GOROOT "$HOME/.local/share/toto/runtimes/go/1.25.6"`,
+				`set -gx GOROOT "$HOME/.local/share/tomei/runtimes/go/1.25.6"`,
 				`fish_add_path`,
 				`$HOME/go/bin`,
 			},
@@ -86,7 +86,7 @@ func TestGenerate(t *testing.T) {
 					BinDir:      home + "/go/bin",
 					ToolBinPath: home + "/go/bin",
 					Env: map[string]string{
-						"GOROOT": home + "/.local/share/toto/runtimes/go/1.25.6",
+						"GOROOT": home + "/.local/share/tomei/runtimes/go/1.25.6",
 					},
 				},
 				"rust": {
@@ -113,14 +113,14 @@ func TestGenerate(t *testing.T) {
 			runtimes: map[string]*resource.RuntimeState{
 				"go": {
 					Version:     "1.25.6",
-					BinDir:      home + "/.local/share/toto/runtimes/go/1.25.6/bin",
+					BinDir:      home + "/.local/share/tomei/runtimes/go/1.25.6/bin",
 					ToolBinPath: home + "/go/bin",
 					Env:         map[string]string{},
 				},
 			},
 			shell: ShellPosix,
 			wantContains: []string{
-				`$HOME/.local/share/toto/runtimes/go/1.25.6/bin`,
+				`$HOME/.local/share/tomei/runtimes/go/1.25.6/bin`,
 				`$HOME/go/bin`,
 			},
 		},
@@ -172,8 +172,8 @@ func TestToShellPath(t *testing.T) {
 		},
 		{
 			name:  "nested path under home",
-			input: home + "/.local/share/toto/runtimes/go/1.25.6",
-			want:  "$HOME/.local/share/toto/runtimes/go/1.25.6",
+			input: home + "/.local/share/tomei/runtimes/go/1.25.6",
+			want:  "$HOME/.local/share/tomei/runtimes/go/1.25.6",
 		},
 	}
 

--- a/internal/env/shell_test.go
+++ b/internal/env/shell_test.go
@@ -69,8 +69,8 @@ func TestPosixFormatter(t *testing.T) {
 	f := posixFormatter{}
 
 	t.Run("ExportVar", func(t *testing.T) {
-		got := f.ExportVar("GOROOT", "$HOME/.local/share/toto/runtimes/go/1.25.6")
-		assert.Equal(t, `export GOROOT="$HOME/.local/share/toto/runtimes/go/1.25.6"`, got)
+		got := f.ExportVar("GOROOT", "$HOME/.local/share/tomei/runtimes/go/1.25.6")
+		assert.Equal(t, `export GOROOT="$HOME/.local/share/tomei/runtimes/go/1.25.6"`, got)
 	})
 
 	t.Run("ExportPath", func(t *testing.T) {
@@ -87,8 +87,8 @@ func TestFishFormatter(t *testing.T) {
 	f := fishFormatter{}
 
 	t.Run("ExportVar", func(t *testing.T) {
-		got := f.ExportVar("GOROOT", "$HOME/.local/share/toto/runtimes/go/1.25.6")
-		assert.Equal(t, `set -gx GOROOT "$HOME/.local/share/toto/runtimes/go/1.25.6"`, got)
+		got := f.ExportVar("GOROOT", "$HOME/.local/share/tomei/runtimes/go/1.25.6")
+		assert.Equal(t, `set -gx GOROOT "$HOME/.local/share/tomei/runtimes/go/1.25.6"`, got)
 	})
 
 	t.Run("ExportPath", func(t *testing.T) {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,4 +1,4 @@
-// Package errors provides structured error types for toto.
+// Package errors provides structured error types for tomei.
 // These errors carry rich context information that can be formatted
 // for human-readable CLI output or machine-readable JSON.
 //
@@ -46,7 +46,7 @@ const (
 	CodeRegistryError Code = "E601"
 )
 
-// Error is the base error type for toto.
+// Error is the base error type for tomei.
 // It provides structured information that can be formatted for CLI output.
 type Error struct {
 	// Category classifies the error type.

--- a/internal/errors/format.go
+++ b/internal/errors/format.go
@@ -101,7 +101,7 @@ func (f *Formatter) Format(err error) string {
 	case errors.As(err, &baseErr):
 		f.formatBaseError(&sb, baseErr)
 	default:
-		// Fallback for non-toto errors
+		// Fallback for non-tomei errors
 		sb.WriteString(f.errorColor.Sprint("Error: "))
 		sb.WriteString(err.Error())
 		sb.WriteString("\n")
@@ -147,7 +147,7 @@ func (f *Formatter) FormatJSON(err error) ([]byte, error) {
 	case errors.As(err, &baseErr):
 		return json.MarshalIndent(baseErr, "", "  ")
 	default:
-		// Fallback for non-toto errors
+		// Fallback for non-tomei errors
 		return json.MarshalIndent(map[string]string{"error": err.Error()}, "", "  ")
 	}
 }
@@ -366,7 +366,7 @@ func (f *Formatter) formatStateError(sb *strings.Builder, err *StateError) {
 
 	if err.LockPID > 0 {
 		sb.WriteString("  ")
-		sb.WriteString(f.dimColor.Sprint("Another toto process is running (PID: "))
+		sb.WriteString(f.dimColor.Sprint("Another tomei process is running (PID: "))
 		sb.WriteString(f.gotColor.Sprintf("%d", err.LockPID))
 		sb.WriteString(f.dimColor.Sprint(")"))
 		sb.WriteString("\n")

--- a/internal/errors/install.go
+++ b/internal/errors/install.go
@@ -70,7 +70,7 @@ func NewChecksumError(resource, url, expected, got string) *ChecksumError {
 			Category: CategoryInstall,
 			Code:     CodeChecksumMismatch,
 			Message:  "checksum verification failed",
-			Hint:     "The file may have been corrupted during download.\nRun 'toto apply --force' to skip verification, or\nupdate the checksum in your manifest.",
+			Hint:     "The file may have been corrupted during download.\nRun 'tomei apply --force' to skip verification, or\nupdate the checksum in your manifest.",
 		},
 		Resource: resource,
 		URL:      url,

--- a/internal/graph/dag.go
+++ b/internal/graph/dag.go
@@ -5,7 +5,7 @@ import (
 	"maps"
 	"slices"
 
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // NodeID is a unique identifier for a node in the dependency graph.

--- a/internal/graph/dag_test.go
+++ b/internal/graph/dag_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 func TestNewNodeID(t *testing.T) {

--- a/internal/graph/error.go
+++ b/internal/graph/error.go
@@ -1,7 +1,7 @@
 package graph
 
 import (
-	"github.com/terassyi/toto/internal/errors"
+	"github.com/terassyi/tomei/internal/errors"
 )
 
 // NewCycleError creates a DependencyError for circular dependencies.

--- a/internal/graph/export.go
+++ b/internal/graph/export.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/goccy/go-yaml"
 
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // PlanOutput represents the structured output of a plan.

--- a/internal/graph/property_test.go
+++ b/internal/graph/property_test.go
@@ -64,7 +64,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 	"pgregory.net/rapid"
 )
 

--- a/internal/graph/resolver.go
+++ b/internal/graph/resolver.go
@@ -3,7 +3,7 @@ package graph
 import (
 	"fmt"
 
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // Edge represents a dependency edge in the graph.

--- a/internal/graph/resolver_test.go
+++ b/internal/graph/resolver_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 func TestResolver_AddResource_Runtime(t *testing.T) {

--- a/internal/graph/scenario_test.go
+++ b/internal/graph/scenario_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // =============================================================================

--- a/internal/graph/tree.go
+++ b/internal/graph/tree.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/fatih/color"
 
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // Action represents the action to be taken on a resource.

--- a/internal/installer/builtin/builtin.go
+++ b/internal/installer/builtin/builtin.go
@@ -1,8 +1,8 @@
 package builtin
 
 import (
-	"github.com/terassyi/toto/internal/installer/download"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/installer/download"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // installers holds all builtin installer definitions.

--- a/internal/installer/builtin/builtin_test.go
+++ b/internal/installer/builtin/builtin_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 func TestInstallers(t *testing.T) {

--- a/internal/installer/download/builtin.go
+++ b/internal/installer/download/builtin.go
@@ -1,6 +1,6 @@
 package download
 
-import "github.com/terassyi/toto/internal/resource"
+import "github.com/terassyi/tomei/internal/resource"
 
 // BuiltinInstaller is the builtin "download" installer definition.
 var BuiltinInstaller = &resource.Installer{

--- a/internal/installer/download/downloader.go
+++ b/internal/installer/download/downloader.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/terassyi/toto/internal/checksum"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/checksum"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // ProgressCallback is called during download to report progress.

--- a/internal/installer/download/downloader_test.go
+++ b/internal/installer/download/downloader_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 func TestNewDownloader(t *testing.T) {

--- a/internal/installer/engine/engine.go
+++ b/internal/installer/engine/engine.go
@@ -11,13 +11,13 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/terassyi/toto/internal/graph"
-	"github.com/terassyi/toto/internal/installer/download"
-	"github.com/terassyi/toto/internal/installer/executor"
-	"github.com/terassyi/toto/internal/installer/reconciler"
-	"github.com/terassyi/toto/internal/installer/tool"
-	"github.com/terassyi/toto/internal/resource"
-	"github.com/terassyi/toto/internal/state"
+	"github.com/terassyi/tomei/internal/graph"
+	"github.com/terassyi/tomei/internal/installer/download"
+	"github.com/terassyi/tomei/internal/installer/executor"
+	"github.com/terassyi/tomei/internal/installer/reconciler"
+	"github.com/terassyi/tomei/internal/installer/tool"
+	"github.com/terassyi/tomei/internal/resource"
+	"github.com/terassyi/tomei/internal/state"
 	"golang.org/x/sync/semaphore"
 )
 

--- a/internal/installer/engine/engine_test.go
+++ b/internal/installer/engine/engine_test.go
@@ -13,11 +13,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/terassyi/toto/internal/config"
-	"github.com/terassyi/toto/internal/installer/download"
-	"github.com/terassyi/toto/internal/installer/tool"
-	"github.com/terassyi/toto/internal/resource"
-	"github.com/terassyi/toto/internal/state"
+	"github.com/terassyi/tomei/internal/config"
+	"github.com/terassyi/tomei/internal/installer/download"
+	"github.com/terassyi/tomei/internal/installer/tool"
+	"github.com/terassyi/tomei/internal/resource"
+	"github.com/terassyi/tomei/internal/state"
 	"pgregory.net/rapid"
 )
 
@@ -127,10 +127,10 @@ func TestEngine_Apply(t *testing.T) {
 	// Create test config directory with CUE file
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "tools.cue")
-	cueContent := `package toto
+	cueContent := `package tomei
 
 tool: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "test-tool"
 	spec: {
@@ -197,10 +197,10 @@ func TestEngine_Apply_NoChanges(t *testing.T) {
 	// Create test config directory with CUE file
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "tools.cue")
-	cueContent := `package toto
+	cueContent := `package tomei
 
 tool: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "test-tool"
 	spec: {
@@ -265,10 +265,10 @@ func TestEngine_Apply_WithRuntime(t *testing.T) {
 	// Create test config directory with CUE file
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "resources.cue")
-	cueContent := `package toto
+	cueContent := `package tomei
 
 runtime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Runtime"
 	metadata: name: "myruntime"
 	spec: {
@@ -289,7 +289,7 @@ runtime: {
 }
 
 tool: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "test-tool"
 	spec: {
@@ -377,10 +377,10 @@ func TestEngine_TaintDependentTools(t *testing.T) {
 	// Include both runtime and dependent tool - tool should be tainted when runtime is upgraded
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "resources.cue")
-	cueContent := `package toto
+	cueContent := `package tomei
 
 runtime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
@@ -401,7 +401,7 @@ runtime: {
 }
 
 tool: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "gopls"
 	spec: {
@@ -502,10 +502,10 @@ func TestEngine_Apply_DependencyOrder(t *testing.T) {
 	// Tool can directly reference Runtime via runtimeRef
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "resources.cue")
-	cueContent := `package toto
+	cueContent := `package tomei
 
 goRuntime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
@@ -528,7 +528,7 @@ goRuntime: {
 }
 
 pnpmTool: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "pnpm"
 	spec: {
@@ -539,7 +539,7 @@ pnpmTool: {
 }
 
 pnpmInstaller: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Installer"
 	metadata: name: "pnpm"
 	spec: {
@@ -552,7 +552,7 @@ pnpmInstaller: {
 }
 
 biomeTool: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "biome"
 	spec: {
@@ -646,10 +646,10 @@ func TestEngine_Apply_CircularDependency(t *testing.T) {
 	// Test that circular dependencies are detected and rejected
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "resources.cue")
-	cueContent := `package toto
+	cueContent := `package tomei
 
 installerA: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Installer"
 	metadata: name: "installer-a"
 	spec: {
@@ -662,7 +662,7 @@ installerA: {
 }
 
 toolB: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "tool-b"
 	spec: {
@@ -696,10 +696,10 @@ func TestEngine_Apply_ParallelExecution(t *testing.T) {
 	// Test that independent tools are executed in parallel
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "resources.cue")
-	cueContent := `package toto
+	cueContent := `package tomei
 
 aquaInstaller: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Installer"
 	metadata: name: "aqua"
 	spec: {
@@ -708,7 +708,7 @@ aquaInstaller: {
 }
 
 ripgrep: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "ripgrep"
 	spec: {
@@ -722,7 +722,7 @@ ripgrep: {
 }
 
 fd: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "fd"
 	spec: {
@@ -736,7 +736,7 @@ fd: {
 }
 
 bat: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "bat"
 	spec: {
@@ -817,10 +817,10 @@ func TestEngine_Apply_ParallelExecution_CancelOnError(t *testing.T) {
 	// Test that when one tool fails in a parallel layer, other tools are canceled
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "resources.cue")
-	cueContent := `package toto
+	cueContent := `package tomei
 
 aquaInstaller: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Installer"
 	metadata: name: "aqua"
 	spec: {
@@ -829,7 +829,7 @@ aquaInstaller: {
 }
 
 ripgrep: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "ripgrep"
 	spec: {
@@ -843,7 +843,7 @@ ripgrep: {
 }
 
 fd: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "fd"
 	spec: {
@@ -857,7 +857,7 @@ fd: {
 }
 
 bat: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "bat"
 	spec: {
@@ -928,10 +928,10 @@ func TestEngine_Apply_RuntimeBeforeTool_SameLayer(t *testing.T) {
 	// Test that Runtime nodes always execute before Tool nodes even in the same layer
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "resources.cue")
-	cueContent := `package toto
+	cueContent := `package tomei
 
 goRuntime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
@@ -947,7 +947,7 @@ goRuntime: {
 }
 
 ripgrep: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "ripgrep"
 	spec: {
@@ -1029,10 +1029,10 @@ func TestEngine_Apply_ParallelRuntimeExecution(t *testing.T) {
 	// Test that multiple independent runtimes are executed in parallel
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "resources.cue")
-	cueContent := `package toto
+	cueContent := `package tomei
 
 goRuntime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
@@ -1048,7 +1048,7 @@ goRuntime: {
 }
 
 rustRuntime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Runtime"
 	metadata: name: "rust"
 	spec: {
@@ -1064,7 +1064,7 @@ rustRuntime: {
 }
 
 nodeRuntime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Runtime"
 	metadata: name: "node"
 	spec: {
@@ -1172,10 +1172,10 @@ func TestEngine_Apply_ParallelismLimit(t *testing.T) {
 
 	// Create 6 tools to exceed parallelism limit of 2
 	var sb strings.Builder
-	sb.WriteString(`package toto
+	sb.WriteString(`package tomei
 
 aquaInstaller: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Installer"
 	metadata: name: "aqua"
 	spec: { pattern: "download" }
@@ -1188,7 +1188,7 @@ aquaInstaller: {
 	for _, td := range toolDefs {
 		fmt.Fprintf(&sb, `
 %s: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "%s"
 	spec: {
@@ -1256,10 +1256,10 @@ func TestEngine_ResolverConfigurer(t *testing.T) {
 	// but before any installation happens
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "tools.cue")
-	cueContent := `package toto
+	cueContent := `package tomei
 
 tool: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "test-tool"
 	spec: {
@@ -1288,7 +1288,7 @@ tool: {
 	store, err := state.NewStore[state.UserState](stateDir)
 	require.NoError(t, err)
 
-	// Pre-populate state with registry info (simulating toto init)
+	// Pre-populate state with registry info (simulating tomei init)
 	require.NoError(t, store.Lock())
 	initialState := state.NewUserState()
 	initialState.Registry = &state.RegistryState{
@@ -1346,10 +1346,10 @@ func TestEngine_ResolverConfigurer_NilRegistry(t *testing.T) {
 	// Test that ResolverConfigurer handles nil registry gracefully
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "tools.cue")
-	cueContent := `package toto
+	cueContent := `package tomei
 
 tool: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "test-tool"
 	spec: {
@@ -1373,7 +1373,7 @@ tool: {
 	store, err := state.NewStore[state.UserState](stateDir)
 	require.NoError(t, err)
 
-	// No pre-populated state (simulating fresh install without toto init)
+	// No pre-populated state (simulating fresh install without tomei init)
 
 	configurerCalled := false
 	var registryIsNil bool
@@ -1408,10 +1408,10 @@ func TestEngine_PlanAll(t *testing.T) {
 	// Create test config directory with CUE file
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "resources.cue")
-	cueContent := `package toto
+	cueContent := `package tomei
 
 runtime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Runtime"
 	metadata: name: "myruntime"
 	spec: {
@@ -1427,7 +1427,7 @@ runtime: {
 }
 
 tool: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "test-tool"
 	spec: {
@@ -1475,10 +1475,10 @@ tool: {
 // generateToolsCUE generates a CUE manifest with an Installer and N tools.
 func generateToolsCUE(toolNames []string) string {
 	var sb strings.Builder
-	sb.WriteString(`package toto
+	sb.WriteString(`package tomei
 
 aquaInstaller: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Installer"
 	metadata: name: "aqua"
 	spec: { pattern: "download" }
@@ -1487,7 +1487,7 @@ aquaInstaller: {
 	for _, name := range toolNames {
 		fmt.Fprintf(&sb, `
 %s: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "%s"
 	spec: {
@@ -1507,12 +1507,12 @@ aquaInstaller: {
 // generateRuntimesAndToolsCUE generates a CUE manifest with N runtimes and M tools.
 func generateRuntimesAndToolsCUE(runtimeNames, toolNames []string) string {
 	var sb strings.Builder
-	sb.WriteString("package toto\n")
+	sb.WriteString("package tomei\n")
 
 	for _, name := range runtimeNames {
 		fmt.Fprintf(&sb, `
 %sRuntime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Runtime"
 	metadata: name: "%s"
 	spec: {
@@ -1532,7 +1532,7 @@ func generateRuntimesAndToolsCUE(runtimeNames, toolNames []string) string {
 	for _, name := range toolNames {
 		fmt.Fprintf(&sb, `
 %s: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "%s"
 	spec: {
@@ -2097,10 +2097,10 @@ func TestEngine_Apply_RemoveRuntimeWithDependentTool(t *testing.T) {
 	stateDir := t.TempDir()
 
 	// Initial config: runtime + delegated tool
-	cueContent := `package toto
+	cueContent := `package tomei
 
 runtime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
@@ -2116,7 +2116,7 @@ runtime: {
 }
 
 gopls: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "gopls"
 	spec: {
@@ -2145,10 +2145,10 @@ gopls: {
 	require.NoError(t, err)
 
 	// Second apply: remove runtime only, keep gopls
-	cueContentV2 := `package toto
+	cueContentV2 := `package tomei
 
 gopls: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "gopls"
 	spec: {
@@ -2199,10 +2199,10 @@ func TestEngine_PlanAll_RemoveRuntimeWithDependentTool(t *testing.T) {
 	require.NoError(t, store.Unlock())
 
 	// Config with only gopls (runtime removed)
-	cueContent := `package toto
+	cueContent := `package tomei
 
 gopls: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "gopls"
 	spec: {
@@ -2234,10 +2234,10 @@ func TestEngine_Apply_RemoveRuntimeAndDependentTool(t *testing.T) {
 	stateDir := t.TempDir()
 
 	// Initial config: runtime + delegated tool
-	cueContent := `package toto
+	cueContent := `package tomei
 
 runtime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
@@ -2253,7 +2253,7 @@ runtime: {
 }
 
 gopls: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "gopls"
 	spec: {
@@ -2295,10 +2295,10 @@ gopls: {
 	require.NoError(t, err)
 
 	// Second apply: remove both (empty config with just a placeholder)
-	cueContentV2 := `package toto
+	cueContentV2 := `package tomei
 
 placeholder: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "fzf"
 	spec: {
@@ -2443,10 +2443,10 @@ func TestEngine_SyncMode_Apply(t *testing.T) {
 	configDir := t.TempDir()
 	stateDir := t.TempDir()
 
-	cueContent := `package toto
+	cueContent := `package tomei
 
 fd: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "fd"
 	spec: {
@@ -2510,10 +2510,10 @@ func TestEngine_SyncMode_ExactVersionNotReinstalled(t *testing.T) {
 	configDir := t.TempDir()
 	stateDir := t.TempDir()
 
-	cueContent := `package toto
+	cueContent := `package tomei
 
 rg: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "rg"
 	spec: {
@@ -2569,10 +2569,10 @@ rg: {
 func TestEngine_Apply_InstallerRepository(t *testing.T) {
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "resources.cue")
-	cueContent := `package toto
+	cueContent := `package tomei
 
 repo: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "InstallerRepository"
 	metadata: name: "bitnami"
 	spec: {
@@ -2626,10 +2626,10 @@ repo: {
 func TestEngine_Apply_InstallerRepositoryWithTool(t *testing.T) {
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "resources.cue")
-	cueContent := `package toto
+	cueContent := `package tomei
 
 repo: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "InstallerRepository"
 	metadata: name: "bitnami"
 	spec: {
@@ -2647,7 +2647,7 @@ repo: {
 }
 
 tool: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "nginx"
 	spec: {
@@ -2748,10 +2748,10 @@ func TestEngine_Apply_InstallerRepository_Remove(t *testing.T) {
 func TestEngine_PlanAll_InstallerRepository(t *testing.T) {
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "resources.cue")
-	cueContent := `package toto
+	cueContent := `package tomei
 
 repo: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "InstallerRepository"
 	metadata: name: "bitnami"
 	spec: {

--- a/internal/installer/executor/executor.go
+++ b/internal/installer/executor/executor.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/terassyi/toto/internal/installer/reconciler"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/installer/reconciler"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // Installer defines the interface for installing resources.

--- a/internal/installer/executor/executor_test.go
+++ b/internal/installer/executor/executor_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/terassyi/toto/internal/installer/reconciler"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/installer/reconciler"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // mockInstaller is a mock implementation for testing.

--- a/internal/installer/executor/installer_repository_store.go
+++ b/internal/installer/executor/installer_repository_store.go
@@ -3,8 +3,8 @@ package executor
 import (
 	"sync"
 
-	"github.com/terassyi/toto/internal/resource"
-	"github.com/terassyi/toto/internal/state"
+	"github.com/terassyi/tomei/internal/resource"
+	"github.com/terassyi/tomei/internal/state"
 )
 
 // InstallerRepositoryStateStore adapts state.Store to the StateStore interface for InstallerRepositories.

--- a/internal/installer/executor/runtime_store.go
+++ b/internal/installer/executor/runtime_store.go
@@ -3,8 +3,8 @@ package executor
 import (
 	"sync"
 
-	"github.com/terassyi/toto/internal/resource"
-	"github.com/terassyi/toto/internal/state"
+	"github.com/terassyi/tomei/internal/resource"
+	"github.com/terassyi/tomei/internal/state"
 )
 
 // RuntimeStateStore adapts state.Store to the StateStore interface for Runtimes.

--- a/internal/installer/executor/store_factory.go
+++ b/internal/installer/executor/store_factory.go
@@ -3,7 +3,7 @@ package executor
 import (
 	"sync"
 
-	"github.com/terassyi/toto/internal/state"
+	"github.com/terassyi/tomei/internal/state"
 )
 
 // StateStoreFactory creates StateStore instances that share a single mutex.

--- a/internal/installer/executor/store_test.go
+++ b/internal/installer/executor/store_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/terassyi/toto/internal/resource"
-	"github.com/terassyi/toto/internal/state"
+	"github.com/terassyi/tomei/internal/resource"
+	"github.com/terassyi/tomei/internal/state"
 	"pgregory.net/rapid"
 )
 

--- a/internal/installer/executor/tool_store.go
+++ b/internal/installer/executor/tool_store.go
@@ -3,8 +3,8 @@ package executor
 import (
 	"sync"
 
-	"github.com/terassyi/toto/internal/resource"
-	"github.com/terassyi/toto/internal/state"
+	"github.com/terassyi/tomei/internal/resource"
+	"github.com/terassyi/tomei/internal/state"
 )
 
 // ToolStateStore adapts state.Store to the StateStore interface for Tools.

--- a/internal/installer/place/placer.go
+++ b/internal/installer/place/placer.go
@@ -73,7 +73,7 @@ type Placer interface {
 
 // filePlacer implements Placer.
 type filePlacer struct {
-	toolsDir string // e.g., ~/.local/share/toto/tools
+	toolsDir string // e.g., ~/.local/share/tomei/tools
 	binDir   string // e.g., ~/.local/bin
 }
 

--- a/internal/installer/reconciler/installer_repository.go
+++ b/internal/installer/reconciler/installer_repository.go
@@ -1,7 +1,7 @@
 package reconciler
 
 import (
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // InstallerRepositoryComparator returns a comparator for InstallerRepository resources.

--- a/internal/installer/reconciler/installer_repository_test.go
+++ b/internal/installer/reconciler/installer_repository_test.go
@@ -6,14 +6,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 func TestInstallerRepositoryReconciler_Install(t *testing.T) {
 	repos := []*resource.InstallerRepository{
 		{
 			BaseResource: resource.BaseResource{
-				APIVersion:   "toto.terassyi.net/v1beta1",
+				APIVersion:   "tomei.terassyi.net/v1beta1",
 				ResourceKind: resource.KindInstallerRepository,
 				Metadata:     resource.Metadata{Name: "bitnami"},
 			},
@@ -43,7 +43,7 @@ func TestInstallerRepositoryReconciler_NoChange(t *testing.T) {
 	repos := []*resource.InstallerRepository{
 		{
 			BaseResource: resource.BaseResource{
-				APIVersion:   "toto.terassyi.net/v1beta1",
+				APIVersion:   "tomei.terassyi.net/v1beta1",
 				ResourceKind: resource.KindInstallerRepository,
 				Metadata:     resource.Metadata{Name: "bitnami"},
 			},
@@ -74,7 +74,7 @@ func TestInstallerRepositoryReconciler_Upgrade_URLChanged(t *testing.T) {
 	repos := []*resource.InstallerRepository{
 		{
 			BaseResource: resource.BaseResource{
-				APIVersion:   "toto.terassyi.net/v1beta1",
+				APIVersion:   "tomei.terassyi.net/v1beta1",
 				ResourceKind: resource.KindInstallerRepository,
 				Metadata:     resource.Metadata{Name: "custom-registry"},
 			},
@@ -110,7 +110,7 @@ func TestInstallerRepositoryReconciler_Upgrade_TypeChanged(t *testing.T) {
 	repos := []*resource.InstallerRepository{
 		{
 			BaseResource: resource.BaseResource{
-				APIVersion:   "toto.terassyi.net/v1beta1",
+				APIVersion:   "tomei.terassyi.net/v1beta1",
 				ResourceKind: resource.KindInstallerRepository,
 				Metadata:     resource.Metadata{Name: "my-repo"},
 			},

--- a/internal/installer/reconciler/reconciler.go
+++ b/internal/installer/reconciler/reconciler.go
@@ -1,7 +1,7 @@
 package reconciler
 
 import (
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // Action represents a planned operation on a resource.

--- a/internal/installer/reconciler/reconciler_test.go
+++ b/internal/installer/reconciler/reconciler_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 func TestNew(t *testing.T) {
@@ -20,7 +20,7 @@ func TestReconciler_Reconcile_Install(t *testing.T) {
 	tools := []*resource.Tool{
 		{
 			BaseResource: resource.BaseResource{
-				APIVersion:   "toto.terassyi.net/v1beta1",
+				APIVersion:   "tomei.terassyi.net/v1beta1",
 				ResourceKind: resource.KindTool,
 				Metadata:     resource.Metadata{Name: "ripgrep"},
 			},
@@ -47,7 +47,7 @@ func TestReconciler_Reconcile_Upgrade(t *testing.T) {
 	tools := []*resource.Tool{
 		{
 			BaseResource: resource.BaseResource{
-				APIVersion:   "toto.terassyi.net/v1beta1",
+				APIVersion:   "tomei.terassyi.net/v1beta1",
 				ResourceKind: resource.KindTool,
 				Metadata:     resource.Metadata{Name: "ripgrep"},
 			},
@@ -84,7 +84,7 @@ func TestReconciler_Reconcile_Skip(t *testing.T) {
 	tools := []*resource.Tool{
 		{
 			BaseResource: resource.BaseResource{
-				APIVersion:   "toto.terassyi.net/v1beta1",
+				APIVersion:   "tomei.terassyi.net/v1beta1",
 				ResourceKind: resource.KindTool,
 				Metadata:     resource.Metadata{Name: "ripgrep"},
 			},
@@ -143,7 +143,7 @@ func TestReconciler_Reconcile_MultipleTools(t *testing.T) {
 	tools := []*resource.Tool{
 		{
 			BaseResource: resource.BaseResource{
-				APIVersion:   "toto.terassyi.net/v1beta1",
+				APIVersion:   "tomei.terassyi.net/v1beta1",
 				ResourceKind: resource.KindTool,
 				Metadata:     resource.Metadata{Name: "ripgrep"},
 			},
@@ -154,7 +154,7 @@ func TestReconciler_Reconcile_MultipleTools(t *testing.T) {
 		},
 		{
 			BaseResource: resource.BaseResource{
-				APIVersion:   "toto.terassyi.net/v1beta1",
+				APIVersion:   "tomei.terassyi.net/v1beta1",
 				ResourceKind: resource.KindTool,
 				Metadata:     resource.Metadata{Name: "fd"},
 			},
@@ -207,7 +207,7 @@ func TestReconciler_Reconcile_Tainted(t *testing.T) {
 	tools := []*resource.Tool{
 		{
 			BaseResource: resource.BaseResource{
-				APIVersion:   "toto.terassyi.net/v1beta1",
+				APIVersion:   "tomei.terassyi.net/v1beta1",
 				ResourceKind: resource.KindTool,
 				Metadata:     resource.Metadata{Name: "ripgrep"},
 			},

--- a/internal/installer/reconciler/runtime.go
+++ b/internal/installer/reconciler/runtime.go
@@ -1,7 +1,7 @@
 package reconciler
 
 import (
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // RuntimeComparator returns a comparator for Runtime resources.

--- a/internal/installer/reconciler/tool.go
+++ b/internal/installer/reconciler/tool.go
@@ -1,7 +1,7 @@
 package reconciler
 
 import (
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // specVersionChanged determines whether the spec's version specification

--- a/internal/installer/repository/installer.go
+++ b/internal/installer/repository/installer.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 	"time"
 
-	gogit "github.com/terassyi/toto/internal/git"
-	"github.com/terassyi/toto/internal/installer/command"
-	"github.com/terassyi/toto/internal/resource"
+	gogit "github.com/terassyi/tomei/internal/git"
+	"github.com/terassyi/tomei/internal/installer/command"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // commandRunner is the interface for executing shell commands.

--- a/internal/installer/repository/installer_test.go
+++ b/internal/installer/repository/installer_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/terassyi/toto/internal/installer/command"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/installer/command"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // --- mock implementations ---

--- a/internal/installer/runtime/installer.go
+++ b/internal/installer/runtime/installer.go
@@ -8,12 +8,12 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/terassyi/toto/internal/checksum"
-	"github.com/terassyi/toto/internal/installer/command"
-	"github.com/terassyi/toto/internal/installer/download"
-	"github.com/terassyi/toto/internal/installer/extract"
-	"github.com/terassyi/toto/internal/path"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/checksum"
+	"github.com/terassyi/tomei/internal/installer/command"
+	"github.com/terassyi/tomei/internal/installer/download"
+	"github.com/terassyi/tomei/internal/installer/extract"
+	"github.com/terassyi/tomei/internal/path"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // CommandRunner is the interface for executing shell commands.
@@ -93,7 +93,7 @@ func (i *Installer) installDownload(ctx context.Context, spec *resource.RuntimeS
 	}
 
 	// Download
-	tmpDir, err := os.MkdirTemp("", "toto-runtime-*")
+	tmpDir, err := os.MkdirTemp("", "tomei-runtime-*")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp dir: %w", err)
 	}

--- a/internal/installer/runtime/installer_test.go
+++ b/internal/installer/runtime/installer_test.go
@@ -17,9 +17,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/terassyi/toto/internal/installer/command"
-	"github.com/terassyi/toto/internal/installer/download"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/installer/command"
+	"github.com/terassyi/tomei/internal/installer/download"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 func TestNewInstaller(t *testing.T) {
@@ -78,7 +78,7 @@ func TestInstaller_Install(t *testing.T) {
 				BinDir:      binDir, // Explicit BinDir
 				ToolBinPath: "~/myruntime/bin",
 				Env: map[string]string{
-					"MY_RUNTIME_HOME": "~/.local/share/toto/runtimes/myruntime/1.0.0",
+					"MY_RUNTIME_HOME": "~/.local/share/tomei/runtimes/myruntime/1.0.0",
 				},
 			},
 		}
@@ -96,7 +96,7 @@ func TestInstaller_Install(t *testing.T) {
 		// ToolBinPath and Env values should have ~ expanded
 		home, _ := os.UserHomeDir()
 		assert.Equal(t, filepath.Join(home, "myruntime/bin"), state.ToolBinPath)
-		assert.Equal(t, filepath.Join(home, ".local/share/toto/runtimes/myruntime/1.0.0"), state.Env["MY_RUNTIME_HOME"])
+		assert.Equal(t, filepath.Join(home, ".local/share/tomei/runtimes/myruntime/1.0.0"), state.Env["MY_RUNTIME_HOME"])
 
 		// Verify install directory exists
 		assert.DirExists(t, state.InstallPath)

--- a/internal/installer/tool/installer.go
+++ b/internal/installer/tool/installer.go
@@ -9,19 +9,19 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/terassyi/toto/internal/checksum"
-	"github.com/terassyi/toto/internal/installer"
-	"github.com/terassyi/toto/internal/installer/command"
-	"github.com/terassyi/toto/internal/installer/download"
-	"github.com/terassyi/toto/internal/installer/extract"
-	"github.com/terassyi/toto/internal/installer/place"
-	"github.com/terassyi/toto/internal/registry/aqua"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/checksum"
+	"github.com/terassyi/tomei/internal/installer"
+	"github.com/terassyi/tomei/internal/installer/command"
+	"github.com/terassyi/tomei/internal/installer/download"
+	"github.com/terassyi/tomei/internal/installer/extract"
+	"github.com/terassyi/tomei/internal/installer/place"
+	"github.com/terassyi/tomei/internal/registry/aqua"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // RuntimeInfo contains the information needed to install tools via runtime delegation.
 type RuntimeInfo struct {
-	InstallPath string            // Path where runtime is installed (e.g., ~/.local/share/toto/runtimes/go/1.25.5)
+	InstallPath string            // Path where runtime is installed (e.g., ~/.local/share/tomei/runtimes/go/1.25.5)
 	ToolBinPath string            // Path where tools should be installed (e.g., ~/go/bin)
 	Env         map[string]string // Environment variables (e.g., GOROOT, GOBIN)
 	Commands    *resource.CommandsSpec
@@ -190,7 +190,7 @@ func (i *Installer) installByDownload(ctx context.Context, res *resource.Tool, n
 	}
 
 	// Download
-	tmpDir, err := os.MkdirTemp("", "toto-download-*")
+	tmpDir, err := os.MkdirTemp("", "tomei-download-*")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp dir: %w", err)
 	}
@@ -279,7 +279,7 @@ func (i *Installer) installFromRegistry(ctx context.Context, res *resource.Tool,
 		return nil, fmt.Errorf("aqua-registry resolver not configured")
 	}
 	if i.registryRef == "" {
-		return nil, fmt.Errorf("aqua-registry ref not configured; run 'toto init' first")
+		return nil, fmt.Errorf("aqua-registry ref not configured; run 'tomei init' first")
 	}
 
 	// Determine version: use spec.Version or fetch latest

--- a/internal/installer/tool/installer_test.go
+++ b/internal/installer/tool/installer_test.go
@@ -16,10 +16,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/terassyi/toto/internal/installer/download"
-	"github.com/terassyi/toto/internal/installer/place"
-	"github.com/terassyi/toto/internal/registry/aqua"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/installer/download"
+	"github.com/terassyi/tomei/internal/installer/place"
+	"github.com/terassyi/tomei/internal/registry/aqua"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 func TestNewInstaller(t *testing.T) {

--- a/internal/path/path.go
+++ b/internal/path/path.go
@@ -5,22 +5,22 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/terassyi/toto/internal/config"
+	"github.com/terassyi/tomei/internal/config"
 )
 
 // Default path constants
 const (
-	DefaultSystemDataDir = "/var/lib/toto"
+	DefaultSystemDataDir = "/var/lib/tomei"
 )
 
 // Default path suffixes (relative to home directory)
 const (
-	defaultUserDataSuffix  = ".local/share/toto"
+	defaultUserDataSuffix  = ".local/share/tomei"
 	defaultUserBinSuffix   = ".local/bin"
-	defaultUserCacheSuffix = ".cache/toto"
+	defaultUserCacheSuffix = ".cache/tomei"
 )
 
-// Paths holds configurable paths for toto.
+// Paths holds configurable paths for tomei.
 type Paths struct {
 	userDataDir   string
 	userBinDir    string

--- a/internal/path/path_test.go
+++ b/internal/path/path_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/terassyi/toto/internal/config"
+	"github.com/terassyi/tomei/internal/config"
 )
 
 func TestNew(t *testing.T) {
@@ -24,7 +24,7 @@ func TestNew(t *testing.T) {
 		{
 			name:            "default paths",
 			opts:            nil,
-			wantUserDataDir: filepath.Join(home, ".local/share/toto"),
+			wantUserDataDir: filepath.Join(home, ".local/share/tomei"),
 			wantUserBinDir:  filepath.Join(home, ".local/bin"),
 			wantSystemDir:   DefaultSystemDataDir,
 		},
@@ -38,14 +38,14 @@ func TestNew(t *testing.T) {
 		{
 			name:            "with custom user bin dir",
 			opts:            []Option{WithUserBinDir("/custom/bin")},
-			wantUserDataDir: filepath.Join(home, ".local/share/toto"),
+			wantUserDataDir: filepath.Join(home, ".local/share/tomei"),
 			wantUserBinDir:  "/custom/bin",
 			wantSystemDir:   DefaultSystemDataDir,
 		},
 		{
 			name:            "with custom system data dir",
 			opts:            []Option{WithSystemDataDir("/custom/system")},
-			wantUserDataDir: filepath.Join(home, ".local/share/toto"),
+			wantUserDataDir: filepath.Join(home, ".local/share/tomei"),
 			wantUserBinDir:  filepath.Join(home, ".local/bin"),
 			wantSystemDir:   "/custom/system",
 		},
@@ -91,10 +91,10 @@ func TestPaths_ToolInstallDir(t *testing.T) {
 		},
 		{
 			name:        "fd",
-			userDataDir: "/home/user/.local/share/toto",
+			userDataDir: "/home/user/.local/share/tomei",
 			toolName:    "fd",
 			version:     "9.0.0",
-			want:        "/home/user/.local/share/toto/tools/fd/9.0.0",
+			want:        "/home/user/.local/share/tomei/tools/fd/9.0.0",
 		},
 	}
 
@@ -223,8 +223,8 @@ func TestExpand(t *testing.T) {
 	}{
 		{
 			name: "expand tilde with path",
-			path: "~/.local/share/toto",
-			want: filepath.Join(home, ".local/share/toto"),
+			path: "~/.local/share/tomei",
+			want: filepath.Join(home, ".local/share/tomei"),
 		},
 		{
 			name: "expand tilde only",
@@ -277,7 +277,7 @@ func TestNewFromConfig(t *testing.T) {
 				DataDir: config.DefaultDataDir,
 				BinDir:  config.DefaultBinDir,
 			},
-			wantUserDataDir: filepath.Join(home, ".local/share/toto"),
+			wantUserDataDir: filepath.Join(home, ".local/share/tomei"),
 			wantUserBinDir:  filepath.Join(home, ".local/bin"),
 		},
 		{
@@ -292,11 +292,11 @@ func TestNewFromConfig(t *testing.T) {
 		{
 			name: "absolute paths",
 			cfg: &config.Config{
-				DataDir: "/opt/toto/data",
-				BinDir:  "/opt/toto/bin",
+				DataDir: "/opt/tomei/data",
+				BinDir:  "/opt/tomei/bin",
 			},
-			wantUserDataDir: "/opt/toto/data",
-			wantUserBinDir:  "/opt/toto/bin",
+			wantUserDataDir: "/opt/tomei/data",
+			wantUserBinDir:  "/opt/tomei/bin",
 		},
 	}
 

--- a/internal/registry/aqua/fetcher_test.go
+++ b/internal/registry/aqua/fetcher_test.go
@@ -163,7 +163,7 @@ func TestFetcher_Fetch_ServerError(t *testing.T) {
 }
 
 func TestFetcher_cachePath(t *testing.T) {
-	f := newFetcher("/home/user/.cache/toto/registry/aqua", nil)
+	f := newFetcher("/home/user/.cache/tomei/registry/aqua", nil)
 
 	tests := []struct {
 		ref      string
@@ -173,12 +173,12 @@ func TestFetcher_cachePath(t *testing.T) {
 		{
 			ref:      "v4.465.0",
 			pkg:      "cli/cli",
-			expected: "/home/user/.cache/toto/registry/aqua/v4.465.0/pkgs/cli/cli/registry.yaml",
+			expected: "/home/user/.cache/tomei/registry/aqua/v4.465.0/pkgs/cli/cli/registry.yaml",
 		},
 		{
 			ref:      "v4.500.0",
 			pkg:      "BurntSushi/ripgrep",
-			expected: "/home/user/.cache/toto/registry/aqua/v4.500.0/pkgs/BurntSushi/ripgrep/registry.yaml",
+			expected: "/home/user/.cache/tomei/registry/aqua/v4.500.0/pkgs/BurntSushi/ripgrep/registry.yaml",
 		},
 	}
 
@@ -214,7 +214,7 @@ func TestFetcher_writeCache_AtomicWrite(t *testing.T) {
 }
 
 func TestFetcher_cachePath_PathTraversal(t *testing.T) {
-	f := newFetcher("/home/user/.cache/toto/registry/aqua", nil)
+	f := newFetcher("/home/user/.cache/tomei/registry/aqua", nil)
 
 	tests := []struct {
 		name    string

--- a/internal/registry/aqua/resolver.go
+++ b/internal/registry/aqua/resolver.go
@@ -43,7 +43,7 @@ type ResolvedSource struct {
 	Files []FileSpec
 
 	// Warnings contains non-fatal issues detected during resolution.
-	// These should be displayed to the user during `toto plan`.
+	// These should be displayed to the user during `tomei plan`.
 	// Example: "version v1.5.0 uses legacy asset format"
 	Warnings []string
 
@@ -76,7 +76,7 @@ type Resolver struct {
 // NewResolver creates a new Resolver with the specified cache directory and HTTP client.
 //
 // The cache directory is used to store fetched registry.yaml files.
-// Files are cached per registry ref (e.g., ~/.cache/toto/registry/aqua/v4.465.0/pkgs/cli/cli/registry.yaml).
+// Files are cached per registry ref (e.g., ~/.cache/tomei/registry/aqua/v4.465.0/pkgs/cli/cli/registry.yaml).
 // If client is nil, a default HTTP client with timeout is used.
 func NewResolver(cacheDir string, client *http.Client) *Resolver {
 	f := newFetcher(cacheDir, client)

--- a/internal/registry/aqua/sync.go
+++ b/internal/registry/aqua/sync.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/terassyi/toto/internal/state"
+	"github.com/terassyi/tomei/internal/state"
 )
 
 // Store is an interface for state storage operations.

--- a/internal/resource/installer.go
+++ b/internal/resource/installer.go
@@ -7,8 +7,8 @@ import (
 
 // InstallerSpec defines a user-level installer that can install tools.
 // Installers come in two patterns:
-//   - Download: toto directly downloads and places binaries (e.g., aqua for GitHub releases)
-//   - Delegation: toto delegates to external package managers (e.g., brew, cargo binstall)
+//   - Download: tomei directly downloads and places binaries (e.g., aqua for GitHub releases)
+//   - Delegation: tomei delegates to external package managers (e.g., brew, cargo binstall)
 //
 // Note: For tools installed via a Runtime (e.g., go install, cargo install),
 // use Tool.RuntimeRef directly instead of creating an Installer.

--- a/internal/resource/installer_repository.go
+++ b/internal/resource/installer_repository.go
@@ -13,7 +13,7 @@ const (
 	// via shell commands (e.g., helm repo add, kubectl krew index add).
 	InstallerRepositorySourceDelegation InstallerRepositorySourceType = "delegation"
 
-	// InstallerRepositorySourceGit means toto clones/manages a git repository
+	// InstallerRepositorySourceGit means tomei clones/manages a git repository
 	// (e.g., aqua custom registries).
 	InstallerRepositorySourceGit InstallerRepositorySourceType = "git"
 )
@@ -22,7 +22,7 @@ const (
 type InstallerRepositorySourceSpec struct {
 	// Type specifies how the repository is managed.
 	// "delegation": uses Commands to add/check/remove the repo via the installer CLI.
-	// "git": toto clones a git repository to a local path.
+	// "git": tomei clones a git repository to a local path.
 	Type InstallerRepositorySourceType `json:"type"`
 
 	// URL is the repository URL.

--- a/internal/resource/runtime.go
+++ b/internal/resource/runtime.go
@@ -12,8 +12,8 @@ import (
 //   - Environment variables needed for the runtime to function
 //
 // Runtimes support two installation types:
-//   - Download: toto downloads and extracts a tarball (e.g., Go)
-//   - Delegation: toto executes an external installer script (e.g., Rust via rustup)
+//   - Download: tomei downloads and extracts a tarball (e.g., Go)
+//   - Delegation: tomei executes an external installer script (e.g., Rust via rustup)
 type RuntimeSpec struct {
 	// Type specifies how this runtime is installed.
 	// Must be either "download" or "delegation".
@@ -34,7 +34,7 @@ type RuntimeSpec struct {
 
 	// Binaries lists the executable names provided by this runtime.
 	// These binaries will be symlinked to BinDir for PATH access.
-	// Optional: if empty, toto auto-detects executables in the bin directory.
+	// Optional: if empty, tomei auto-detects executables in the bin directory.
 	// Example for Go: ["go", "gofmt"]
 	// Example for Rust: ["rustc", "cargo", "rustup"]
 	Binaries []string `json:"binaries,omitempty"`
@@ -152,7 +152,7 @@ type RuntimeState struct {
 	Digest string `json:"digest,omitempty"`
 
 	// InstallPath is the absolute path where the runtime is installed.
-	// For download pattern: ~/.local/share/toto/runtimes/go/1.25.1
+	// For download pattern: ~/.local/share/tomei/runtimes/go/1.25.1
 	// For delegation pattern: may be empty (managed by external tool)
 	InstallPath string `json:"installPath,omitempty"`
 

--- a/internal/resource/tool.go
+++ b/internal/resource/tool.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/terassyi/toto/internal/installer/extract"
+	"github.com/terassyi/tomei/internal/installer/extract"
 )
 
 // DownloadSource holds download configuration for tools and runtimes
@@ -455,7 +455,7 @@ type ToolState struct {
 	Digest string `json:"digest,omitempty"`
 
 	// InstallPath is the absolute path to the installed binary.
-	// For download pattern: ~/.local/share/toto/tools/{name}/{version}/{binary}
+	// For download pattern: ~/.local/share/tomei/tools/{name}/{version}/{binary}
 	// For delegation pattern: depends on the installer (e.g., ~/go/bin/{name})
 	InstallPath string `json:"installPath"`
 

--- a/internal/resource/types.go
+++ b/internal/resource/types.go
@@ -19,10 +19,10 @@ const (
 
 const (
 	// ProjectName is the name of the project.
-	ProjectName = "toto"
+	ProjectName = "tomei"
 
-	// APIGroup is the API group for toto resources.
-	APIGroup = "toto.terassyi.net"
+	// APIGroup is the API group for tomei resources.
+	APIGroup = "tomei.terassyi.net"
 
 	// APIVersion is the API version.
 	APIVersion = "v1beta1"
@@ -49,7 +49,7 @@ type State interface {
 	isState()
 }
 
-// Resource is the interface that all toto resources must implement.
+// Resource is the interface that all tomei resources must implement.
 type Resource interface {
 	Kind() Kind
 	Name() string
@@ -77,12 +77,12 @@ type InstallType string
 
 const (
 	// InstallTypeDownload indicates direct binary download.
-	// toto handles downloading, extracting, and placing binaries.
+	// tomei handles downloading, extracting, and placing binaries.
 	// Example: Go runtime from go.dev, aqua installer for GitHub releases.
 	InstallTypeDownload InstallType = "download"
 
 	// InstallTypeDelegation indicates delegation to external commands.
-	// toto executes configured install/check/remove commands.
+	// tomei executes configured install/check/remove commands.
 	// Example: Rust via rustup, brew install, go install.
 	InstallTypeDelegation InstallType = "delegation"
 )

--- a/internal/state/backup_test.go
+++ b/internal/state/backup_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 func TestBackupPath(t *testing.T) {
@@ -19,8 +19,8 @@ func TestBackupPath(t *testing.T) {
 	}{
 		{
 			name:      "standard path",
-			statePath: "/home/user/.local/share/toto/state.json",
-			want:      "/home/user/.local/share/toto/state.json.bak",
+			statePath: "/home/user/.local/share/tomei/state.json",
+			want:      "/home/user/.local/share/tomei/state.json.bak",
 		},
 		{
 			name:      "relative path",

--- a/internal/state/diff.go
+++ b/internal/state/diff.go
@@ -3,7 +3,7 @@ package state
 import (
 	"sort"
 
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // DiffType represents the type of change between two states.

--- a/internal/state/diff_test.go
+++ b/internal/state/diff_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 func TestDiffUserStates(t *testing.T) {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -3,7 +3,7 @@ package state
 import (
 	"time"
 
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // Version is the current state file format version.

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -22,20 +22,20 @@ type Store[T State] struct {
 }
 
 // NewUserStore creates a Store for user state.
-// Default path: ~/.local/share/toto/state.json
+// Default path: ~/.local/share/tomei/state.json
 func NewUserStore() (*Store[UserState], error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get home directory: %w", err)
 	}
-	dir := filepath.Join(home, ".local", "share", "toto")
+	dir := filepath.Join(home, ".local", "share", "tomei")
 	return NewStore[UserState](dir)
 }
 
 // NewSystemStore creates a Store for system state.
-// Default path: /var/lib/toto/state.json
+// Default path: /var/lib/tomei/state.json
 func NewSystemStore() (*Store[SystemState], error) {
-	return NewStore[SystemState]("/var/lib/toto")
+	return NewStore[SystemState]("/var/lib/tomei")
 }
 
 // NewStore creates a new Store with the given directory.
@@ -71,9 +71,9 @@ func (s *Store[T]) Lock() error {
 		// Read PID from lock file for error message
 		pid, _ := s.readLockPID()
 		if pid > 0 {
-			return fmt.Errorf("another toto process (PID %d) is running", pid)
+			return fmt.Errorf("another tomei process (PID %d) is running", pid)
 		}
-		return errors.New("another toto process is running")
+		return errors.New("another tomei process is running")
 	}
 
 	// Write our PID to the lock file

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 func TestStore_LockUnlock(t *testing.T) {
@@ -63,7 +63,7 @@ func TestStore_LoadSave(t *testing.T) {
 		"go": {
 			Type:        resource.InstallTypeDownload,
 			Version:     "1.25.1",
-			InstallPath: "/home/user/.local/share/toto/runtimes/go/1.25.1",
+			InstallPath: "/home/user/.local/share/tomei/runtimes/go/1.25.1",
 			Binaries:    []string{"go", "gofmt"},
 			ToolBinPath: "/home/user/go/bin",
 			UpdatedAt:   time.Now(),
@@ -73,7 +73,7 @@ func TestStore_LoadSave(t *testing.T) {
 		"ripgrep": {
 			InstallerRef: "aqua",
 			Version:      "14.0.0",
-			InstallPath:  "/home/user/.local/share/toto/tools/ripgrep/14.0.0",
+			InstallPath:  "/home/user/.local/share/tomei/tools/ripgrep/14.0.0",
 			BinPath:      "/home/user/.local/bin/rg",
 			UpdatedAt:    time.Now(),
 		},
@@ -520,7 +520,7 @@ func TestStore_SaveAndLoadPreservesAllFields(t *testing.T) {
 					"go": {
 						Type:        resource.InstallTypeDownload,
 						Version:     "1.25.5",
-						InstallPath: "/home/user/.local/share/toto/runtimes/go/1.25.5",
+						InstallPath: "/home/user/.local/share/tomei/runtimes/go/1.25.5",
 						Binaries:    []string{"go", "gofmt"},
 						ToolBinPath: "/home/user/go/bin",
 						UpdatedAt:   now,
@@ -531,7 +531,7 @@ func TestStore_SaveAndLoadPreservesAllFields(t *testing.T) {
 						InstallerRef: "aqua",
 						Version:      "2.86.0",
 						Package:      &resource.Package{Owner: "cli", Repo: "cli"},
-						InstallPath:  "/home/user/.local/share/toto/tools/gh/2.86.0",
+						InstallPath:  "/home/user/.local/share/tomei/tools/gh/2.86.0",
 						BinPath:      "/home/user/.local/bin/gh",
 						Digest:       "sha256:abc123",
 						UpdatedAt:    now,
@@ -654,7 +654,7 @@ func TestStore_RegistryState(t *testing.T) {
 						InstallerRef: "aqua",
 						Version:      "2.86.0",
 						Package:      &resource.Package{Owner: "cli", Repo: "cli"},
-						InstallPath:  "/home/user/.local/share/toto/tools/gh/2.86.0",
+						InstallPath:  "/home/user/.local/share/tomei/tools/gh/2.86.0",
 						BinPath:      "/home/user/.local/bin/gh",
 						UpdatedAt:    now,
 					},

--- a/internal/state/validator_test.go
+++ b/internal/state/validator_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 func TestValidateUserState(t *testing.T) {

--- a/internal/ui/cmdview.go
+++ b/internal/ui/cmdview.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // cmdTask represents a single command execution task.

--- a/internal/ui/cmdview_test.go
+++ b/internal/ui/cmdview_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 func TestCommandView_StartTask(t *testing.T) {

--- a/internal/ui/progress.go
+++ b/internal/ui/progress.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/mattn/go-isatty"
-	"github.com/terassyi/toto/internal/installer/engine"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/installer/engine"
+	"github.com/terassyi/tomei/internal/resource"
 	"github.com/vbauerster/mpb/v8"
 	"github.com/vbauerster/mpb/v8/decor"
 )

--- a/internal/ui/progress_test.go
+++ b/internal/ui/progress_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/terassyi/toto/internal/installer/engine"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/installer/engine"
+	"github.com/terassyi/tomei/internal/resource"
 	"github.com/vbauerster/mpb/v8"
 )
 

--- a/internal/ui/style.go
+++ b/internal/ui/style.go
@@ -2,7 +2,7 @@ package ui
 
 import (
 	"github.com/fatih/color"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // Style holds common output styling for CLI commands.

--- a/tests/aqua_integration_test.go
+++ b/tests/aqua_integration_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/terassyi/toto/internal/registry/aqua"
+	"github.com/terassyi/tomei/internal/registry/aqua"
 )
 
 // TestAquaResolverIntegration tests the full resolver flow with a mock HTTP server.

--- a/tests/doctor_test.go
+++ b/tests/doctor_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/terassyi/toto/internal/doctor"
-	"github.com/terassyi/toto/internal/path"
-	"github.com/terassyi/toto/internal/resource"
-	"github.com/terassyi/toto/internal/state"
+	"github.com/terassyi/tomei/internal/doctor"
+	"github.com/terassyi/tomei/internal/path"
+	"github.com/terassyi/tomei/internal/resource"
+	"github.com/terassyi/tomei/internal/state"
 )
 
 func TestDoctor_Integration_UnmanagedTools(t *testing.T) {
@@ -95,7 +95,7 @@ func TestDoctor_Integration_UnmanagedTools(t *testing.T) {
 	assert.Contains(t, names, "staticcheck")
 
 	// managed-tool should not be in unmanaged
-	assert.Empty(t, result.UnmanagedTools["toto"])
+	assert.Empty(t, result.UnmanagedTools["tomei"])
 }
 
 func TestDoctor_Integration_Conflicts(t *testing.T) {

--- a/tests/engine_test.go
+++ b/tests/engine_test.go
@@ -15,12 +15,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/terassyi/toto/internal/config"
-	"github.com/terassyi/toto/internal/installer/download"
-	"github.com/terassyi/toto/internal/installer/engine"
-	"github.com/terassyi/toto/internal/installer/tool"
-	"github.com/terassyi/toto/internal/resource"
-	"github.com/terassyi/toto/internal/state"
+	"github.com/terassyi/tomei/internal/config"
+	"github.com/terassyi/tomei/internal/installer/download"
+	"github.com/terassyi/tomei/internal/installer/engine"
+	"github.com/terassyi/tomei/internal/installer/tool"
+	"github.com/terassyi/tomei/internal/resource"
+	"github.com/terassyi/tomei/internal/state"
 )
 
 // mockToolInstaller is a thread-safe mock implementation of engine.ToolInstaller.
@@ -181,10 +181,10 @@ func TestEngine_PlanAll_Tool(t *testing.T) {
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
 	// Create CUE config with a tool
-	cueContent := `package toto
+	cueContent := `package tomei
 
 ripgrep: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "ripgrep"
 	spec: {
@@ -224,10 +224,10 @@ func TestEngine_PlanAll_Runtime(t *testing.T) {
 	stateDir := filepath.Join(tmpDir, "state")
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
-	cueContent := `package toto
+	cueContent := `package tomei
 
 goRuntime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
@@ -269,10 +269,10 @@ func TestEngine_Apply_Tool(t *testing.T) {
 	stateDir := filepath.Join(tmpDir, "state")
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
-	cueContent := `package toto
+	cueContent := `package tomei
 
 jq: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "jq"
 	spec: {
@@ -322,10 +322,10 @@ func TestEngine_Apply_Runtime(t *testing.T) {
 	stateDir := filepath.Join(tmpDir, "state")
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
-	cueContent := `package toto
+	cueContent := `package tomei
 
 goRuntime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
@@ -380,10 +380,10 @@ func TestEngine_Apply_Idempotent(t *testing.T) {
 	stateDir := filepath.Join(tmpDir, "state")
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
-	cueContent := `package toto
+	cueContent := `package tomei
 
 fd: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "fd"
 	spec: {
@@ -428,10 +428,10 @@ func TestEngine_Apply_Upgrade(t *testing.T) {
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
 	// Initial config
-	cueContent := `package toto
+	cueContent := `package tomei
 
 bat: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "bat"
 	spec: {
@@ -462,10 +462,10 @@ bat: {
 	require.NoError(t, err)
 
 	// Update config with new version
-	cueContentV2 := `package toto
+	cueContentV2 := `package tomei
 
 bat: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "bat"
 	spec: {
@@ -511,10 +511,10 @@ func TestEngine_Apply_Remove(t *testing.T) {
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
 	// Initial config with tool
-	cueContent := `package toto
+	cueContent := `package tomei
 
 fzf: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "fzf"
 	spec: {
@@ -546,10 +546,10 @@ fzf: {
 	assert.Contains(t, mockTool.installed, "fzf")
 
 	// Remove tool from config (keep another tool so config isn't empty)
-	cueContentWithOther := `package toto
+	cueContentWithOther := `package tomei
 
 other: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "other"
 	spec: {
@@ -606,10 +606,10 @@ func TestEngine_Apply_RuntimeAndTool(t *testing.T) {
 	stateDir := filepath.Join(tmpDir, "state")
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
-	cueContent := `package toto
+	cueContent := `package tomei
 
 goRuntime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
@@ -624,7 +624,7 @@ goRuntime: {
 }
 
 jq: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "jq"
 	spec: {
@@ -680,10 +680,10 @@ func TestEngine_Apply_MultipleTools(t *testing.T) {
 	stateDir := filepath.Join(tmpDir, "state")
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
-	cueContent := `package toto
+	cueContent := `package tomei
 
 ripgrep: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "ripgrep"
 	spec: {
@@ -694,7 +694,7 @@ ripgrep: {
 }
 
 fd: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "fd"
 	spec: {
@@ -705,7 +705,7 @@ fd: {
 }
 
 bat: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "bat"
 	spec: {
@@ -755,10 +755,10 @@ func TestEngine_Apply_RuntimeDelegation(t *testing.T) {
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
 	// CUE config with Runtime that has commands, and Tool with runtimeRef
-	cueContent := `package toto
+	cueContent := `package tomei
 
 goRuntime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
@@ -781,7 +781,7 @@ goRuntime: {
 }
 
 gopls: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "gopls"
 	spec: {
@@ -847,10 +847,10 @@ func TestEngine_Apply_InstallerDelegation(t *testing.T) {
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
 	// CUE config with delegation pattern Installer and Tool
-	cueContent := `package toto
+	cueContent := `package tomei
 
 brewInstaller: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Installer"
 	metadata: name: "brew"
 	spec: {
@@ -863,7 +863,7 @@ brewInstaller: {
 }
 
 jq: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "jq"
 	spec: {
@@ -923,10 +923,10 @@ func TestEngine_Apply_MixedPatterns(t *testing.T) {
 	// - Runtime with commands (for go install)
 	// - Download pattern tool (ripgrep)
 	// - Runtime delegation tool (gopls)
-	cueContent := `package toto
+	cueContent := `package tomei
 
 goRuntime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
@@ -945,7 +945,7 @@ goRuntime: {
 
 // Download pattern tool
 ripgrep: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "ripgrep"
 	spec: {
@@ -959,7 +959,7 @@ ripgrep: {
 
 // Runtime delegation tool
 gopls: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "gopls"
 	spec: {
@@ -971,7 +971,7 @@ gopls: {
 
 // Another runtime delegation tool
 staticcheck: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "staticcheck"
 	spec: {
@@ -1038,10 +1038,10 @@ func TestEngine_Apply_RuntimeWithBinDir(t *testing.T) {
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
 	// CUE config with explicit BinDir
-	cueContent := `package toto
+	cueContent := `package tomei
 
 goRuntime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
@@ -1093,10 +1093,10 @@ func TestEngine_Apply_RemoveRuntimeBlockedByDependentTool(t *testing.T) {
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
 	// Initial config: runtime + delegated tool
-	cueContent := `package toto
+	cueContent := `package tomei
 
 runtime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
@@ -1112,7 +1112,7 @@ runtime: {
 }
 
 gopls: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "gopls"
 	spec: {
@@ -1141,10 +1141,10 @@ gopls: {
 	require.NoError(t, err)
 
 	// Remove runtime only, keep gopls
-	cueContentV2 := `package toto
+	cueContentV2 := `package tomei
 
 gopls: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "gopls"
 	spec: {
@@ -1169,10 +1169,10 @@ gopls: {
 	assert.Contains(t, err.Error(), "cannot remove runtime")
 
 	// Now remove both — should succeed
-	cueContentV3 := `package toto
+	cueContentV3 := `package tomei
 
 placeholder: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "fzf"
 	spec: {
@@ -1207,17 +1207,17 @@ func TestEngine_Apply_ToolSet_InstallerRef(t *testing.T) {
 	stateDir := filepath.Join(tmpDir, "state")
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
-	cueContent := `package toto
+	cueContent := `package tomei
 
 aquaInstaller: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Installer"
 	metadata: name: "aqua"
 	spec: type: "download"
 }
 
 cliTools: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "ToolSet"
 	metadata: name: "cli-tools"
 	spec: {
@@ -1259,10 +1259,10 @@ func TestEngine_Apply_ToolSet_RuntimeRef(t *testing.T) {
 	stateDir := filepath.Join(tmpDir, "state")
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
-	cueContent := `package toto
+	cueContent := `package tomei
 
 goRuntime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
@@ -1274,7 +1274,7 @@ goRuntime: {
 		binaries: ["go", "gofmt"]
 		toolBinPath: "~/go/bin"
 		env: {
-			GOROOT: "~/.local/share/toto/runtimes/go/1.23.5"
+			GOROOT: "~/.local/share/tomei/runtimes/go/1.23.5"
 			GOBIN: "~/go/bin"
 		}
 		commands: {
@@ -1285,7 +1285,7 @@ goRuntime: {
 }
 
 goInstaller: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Installer"
 	metadata: name: "go"
 	spec: {
@@ -1298,7 +1298,7 @@ goInstaller: {
 }
 
 goTools: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "ToolSet"
 	metadata: name: "go-tools"
 	spec: {
@@ -1343,17 +1343,17 @@ func TestEngine_Apply_ToolSet_MixedWithStandalone(t *testing.T) {
 	stateDir := filepath.Join(tmpDir, "state")
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
-	cueContent := `package toto
+	cueContent := `package tomei
 
 aquaInstaller: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Installer"
 	metadata: name: "aqua"
 	spec: type: "download"
 }
 
 ripgrep: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "rg"
 	spec: {
@@ -1364,7 +1364,7 @@ ripgrep: {
 }
 
 cliTools: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "ToolSet"
 	metadata: name: "cli-tools"
 	spec: {
@@ -1408,10 +1408,10 @@ func TestEngine_Apply_ToolProgressCallback(t *testing.T) {
 	stateDir := filepath.Join(tmpDir, "state")
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
-	cueContent := `package toto
+	cueContent := `package tomei
 
 ripgrep: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "ripgrep"
 	spec: {
@@ -1490,10 +1490,10 @@ func TestEngine_Apply_ToolOutputCallback(t *testing.T) {
 	stateDir := filepath.Join(tmpDir, "state")
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
-	cueContent := `package toto
+	cueContent := `package tomei
 
 jq: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "jq"
 	spec: {
@@ -1567,10 +1567,10 @@ func TestEngine_Apply_RuntimeProgressCallback(t *testing.T) {
 	stateDir := filepath.Join(tmpDir, "state")
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
-	cueContent := `package toto
+	cueContent := `package tomei
 
 goRuntime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
@@ -1659,10 +1659,10 @@ func TestEngine_Apply_ParallelCallbackIsolation(t *testing.T) {
 	stateDir := filepath.Join(tmpDir, "state")
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
-	cueContent := `package toto
+	cueContent := `package tomei
 
 ripgrep: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "ripgrep"
 	spec: {
@@ -1673,7 +1673,7 @@ ripgrep: {
 }
 
 fd: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "fd"
 	spec: {
@@ -1684,7 +1684,7 @@ fd: {
 }
 
 bat: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "bat"
 	spec: {
@@ -1770,10 +1770,10 @@ func TestEngine_Apply_ParallelExecution(t *testing.T) {
 	stateDir := filepath.Join(tmpDir, "state")
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
-	cueContent := `package toto
+	cueContent := `package tomei
 
 ripgrep: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "ripgrep"
 	spec: {
@@ -1784,7 +1784,7 @@ ripgrep: {
 }
 
 fd: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "fd"
 	spec: {
@@ -1795,7 +1795,7 @@ fd: {
 }
 
 bat: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "bat"
 	spec: {
@@ -1877,10 +1877,10 @@ func TestEngine_Apply_ParallelCancelOnError(t *testing.T) {
 	stateDir := filepath.Join(tmpDir, "state")
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
-	cueContent := `package toto
+	cueContent := `package tomei
 
 ripgrep: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "ripgrep"
 	spec: {
@@ -1891,7 +1891,7 @@ ripgrep: {
 }
 
 fd: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "fd"
 	spec: {
@@ -1902,7 +1902,7 @@ fd: {
 }
 
 bat: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "bat"
 	spec: {
@@ -1964,7 +1964,7 @@ func TestEngine_Apply_ParallelismLimit(t *testing.T) {
 	stateDir := filepath.Join(tmpDir, "state")
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
-	cueContent := `package toto
+	cueContent := `package tomei
 `
 	toolDefs := []struct{ cueKey, name string }{
 		{"toolA", "tool-a"}, {"toolB", "tool-b"}, {"toolC", "tool-c"},
@@ -1973,7 +1973,7 @@ func TestEngine_Apply_ParallelismLimit(t *testing.T) {
 	for _, td := range toolDefs {
 		cueContent += fmt.Sprintf(`
 %s: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "%s"
 	spec: {
@@ -2046,10 +2046,10 @@ func TestEngine_Apply_RuntimeBeforeTool(t *testing.T) {
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
 	// Runtime and Tool with no dependency between them
-	cueContent := `package toto
+	cueContent := `package tomei
 
 goRuntime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
@@ -2064,7 +2064,7 @@ goRuntime: {
 }
 
 ripgrep: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Tool"
 	metadata: name: "ripgrep"
 	spec: {
@@ -2151,10 +2151,10 @@ func TestEngine_Apply_ParallelRuntimeExecution(t *testing.T) {
 	stateDir := filepath.Join(tmpDir, "state")
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
-	cueContent := `package toto
+	cueContent := `package tomei
 
 goRuntime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
@@ -2167,7 +2167,7 @@ goRuntime: {
 }
 
 rustRuntime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Runtime"
 	metadata: name: "rust"
 	spec: {
@@ -2180,7 +2180,7 @@ rustRuntime: {
 }
 
 nodeRuntime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Runtime"
 	metadata: name: "node"
 	spec: {
@@ -2262,10 +2262,10 @@ func TestEngine_Apply_RuntimeWithoutBinDir(t *testing.T) {
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
 	// CUE config without explicit BinDir (should default to ToolBinPath)
-	cueContent := `package toto
+	cueContent := `package tomei
 
 goRuntime: {
-	apiVersion: "toto.terassyi.net/v1beta1"
+	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {

--- a/tests/env_test.go
+++ b/tests/env_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/terassyi/toto/internal/env"
-	"github.com/terassyi/toto/internal/resource"
-	"github.com/terassyi/toto/internal/state"
+	"github.com/terassyi/tomei/internal/env"
+	"github.com/terassyi/tomei/internal/resource"
+	"github.com/terassyi/tomei/internal/state"
 )
 
 func TestEnv_GenerateFromState(t *testing.T) {
@@ -31,11 +31,11 @@ func TestEnv_GenerateFromState(t *testing.T) {
 			"go": {
 				Type:        resource.InstallTypeDownload,
 				Version:     "1.25.6",
-				InstallPath: filepath.Join(home, ".local/share/toto/runtimes/go/1.25.6"),
+				InstallPath: filepath.Join(home, ".local/share/tomei/runtimes/go/1.25.6"),
 				BinDir:      filepath.Join(home, "go/bin"),
 				ToolBinPath: filepath.Join(home, "go/bin"),
 				Env: map[string]string{
-					"GOROOT": filepath.Join(home, ".local/share/toto/runtimes/go/1.25.6"),
+					"GOROOT": filepath.Join(home, ".local/share/tomei/runtimes/go/1.25.6"),
 					"GOBIN":  filepath.Join(home, "go/bin"),
 				},
 			},

--- a/tests/installer_repository_test.go
+++ b/tests/installer_repository_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	repository "github.com/terassyi/toto/internal/installer/repository"
-	"github.com/terassyi/toto/internal/resource"
+	repository "github.com/terassyi/tomei/internal/installer/repository"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // TestInstallerRepository_Delegation tests the real repository Installer

--- a/tests/resource_test.go
+++ b/tests/resource_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/terassyi/toto/internal/config"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/config"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 func TestLoadAndStore(t *testing.T) {
@@ -19,7 +19,7 @@ func TestLoadAndStore(t *testing.T) {
 
 	// Create CUE files with multiple resource types
 	toolCue := `
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Tool"
 metadata: {
 	name: "ripgrep"
@@ -33,7 +33,7 @@ spec: {
 }
 `
 	runtimeCue := `
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Runtime"
 metadata: name: "go"
 spec: {
@@ -48,7 +48,7 @@ spec: {
 }
 `
 	installerCue := `
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Installer"
 metadata: name: "aqua"
 spec: {
@@ -56,7 +56,7 @@ spec: {
 }
 `
 	toolSetCue := `
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "ToolSet"
 metadata: name: "cli-tools"
 spec: {
@@ -165,7 +165,7 @@ func TestSpecValidation(t *testing.T) {
 	dir := t.TempDir()
 
 	toolCue := `
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Tool"
 metadata: name: "ripgrep"
 spec: {
@@ -202,7 +202,7 @@ func TestDependencyResolution(t *testing.T) {
 
 	// Tool depends on Installer and Runtime
 	toolCue := `
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Tool"
 metadata: name: "golangci-lint"
 spec: {
@@ -214,7 +214,7 @@ spec: {
 `
 	// Installer depends on Runtime
 	installerCue := `
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Installer"
 metadata: name: "go"
 spec: {
@@ -227,7 +227,7 @@ spec: {
 }
 `
 	runtimeCue := `
-apiVersion: "toto.terassyi.net/v1beta1"
+apiVersion: "tomei.terassyi.net/v1beta1"
 kind: "Runtime"
 metadata: name: "go"
 spec: {

--- a/tests/runtime_delegation_test.go
+++ b/tests/runtime_delegation_test.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/terassyi/toto/internal/installer/download"
-	"github.com/terassyi/toto/internal/installer/runtime"
-	"github.com/terassyi/toto/internal/resource"
+	"github.com/terassyi/tomei/internal/installer/download"
+	"github.com/terassyi/tomei/internal/installer/runtime"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 // TestRuntimeDelegation_Install tests the real runtime Installer with the delegation pattern

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/terassyi/toto/internal/resource"
-	"github.com/terassyi/toto/internal/state"
+	"github.com/terassyi/tomei/internal/resource"
+	"github.com/terassyi/tomei/internal/state"
 )
 
 // TestState_Persistence tests that state is correctly persisted and loaded.
@@ -39,11 +39,11 @@ func TestState_Persistence(t *testing.T) {
 			"go": {
 				Type:        resource.InstallTypeDownload,
 				Version:     "1.25.5",
-				InstallPath: "/home/user/.local/share/toto/runtimes/go/1.25.5",
+				InstallPath: "/home/user/.local/share/tomei/runtimes/go/1.25.5",
 				Binaries:    []string{"go", "gofmt"},
 				ToolBinPath: "/home/user/go/bin",
 				Env: map[string]string{
-					"GOROOT": "/home/user/.local/share/toto/runtimes/go/1.25.5",
+					"GOROOT": "/home/user/.local/share/tomei/runtimes/go/1.25.5",
 				},
 				UpdatedAt: time.Now().Truncate(time.Second),
 			},
@@ -192,7 +192,7 @@ func TestState_Taint(t *testing.T) {
 			"go": {
 				Type:        resource.InstallTypeDownload,
 				Version:     "1.25.5",
-				InstallPath: "/home/user/.local/share/toto/runtimes/go/1.25.5",
+				InstallPath: "/home/user/.local/share/tomei/runtimes/go/1.25.5",
 				Binaries:    []string{"go", "gofmt"},
 			},
 		},


### PR DESCRIPTION
Rename the project from toto to tomei across the entire codebase:

- Go module: github.com/terassyi/toto -> github.com/terassyi/tomei
- CUE API group: toto.terassyi.net -> tomei.terassyi.net
- CLI binary: toto -> tomei
- ProjectName constant: toto -> tomei
- Config paths: ~/.config/toto -> ~/.config/tomei
- Data paths: ~/.local/share/toto -> ~/.local/share/tomei
- Cache paths: ~/.cache/toto -> ~/.cache/tomei
- Docker: toto-dev -> tomei-dev, toto-e2e-ubuntu -> tomei-e2e-ubuntu
- Environment variables: TOTO_E2E_* -> TOMEI_E2E_*
- GitHub Actions: build-toto -> build-tomei
- Directory: cmd/toto/ -> cmd/tomei/
- All documentation, tests, and CUE manifests updated

136 files changed, 1108 insertions(+), 1108 deletions(-)
