### PR TITLE
feat: add CUE schema validation with binary embedding and LSP support

### DIFF
--- a/cmd/tomei/apply.go
+++ b/cmd/tomei/apply.go
@@ -86,10 +86,15 @@ func runUserApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 		return fmt.Errorf("failed to expand sets: %w", err)
 	}
 
-	// Load config from fixed path (~/.config/toto/config.cue)
+	// Load config from fixed path (~/.config/tomei/config.cue)
 	appCfg, err := config.LoadConfig(config.DefaultConfigDir)
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	// Sync schema.cue if it exists on disk
+	if err := config.SyncSchema(appCfg, config.DefaultConfigDir); err != nil {
+		return fmt.Errorf("failed to sync schema: %w", err)
 	}
 
 	// Setup paths from config

--- a/cmd/tomei/validate.go
+++ b/cmd/tomei/validate.go
@@ -36,6 +36,13 @@ func runValidate(cmd *cobra.Command, args []string) error {
 		color.NoColor = true
 	}
 
+	// Sync schema.cue if it exists on disk
+	if cfg, err := config.LoadConfig(config.DefaultConfigDir); err == nil {
+		if err := config.SyncSchema(cfg, config.DefaultConfigDir); err != nil {
+			return fmt.Errorf("failed to sync schema: %w", err)
+		}
+	}
+
 	style := ui.NewStyle()
 
 	cmd.Println("Validating configuration...")

--- a/e2e/scenario.md
+++ b/e2e/scenario.md
@@ -16,6 +16,7 @@ This document describes the scenarios verified by tomei's E2E tests.
 | Suite | Tests | Description |
 |-------|-------|-------------|
 | tomei on Ubuntu | 33 | Basic commands, installation, env export, idempotency, doctor, runtime upgrade, resource removal |
+| Schema Validation | 9 | Schema placement, invalid manifest rejection (validate/apply), error message quality |
 | State Backup and Diff | 13 | Backup creation, diff (text/JSON), idempotent diff, upgrade diff, removal diff, backup overwrite |
 | Aqua Registry | 10 | Registry initialization, tool installation via aqua registry, OS/arch resolution |
 | Delegation Runtime | 9 | Rust runtime installation via delegation, cargo install tool, idempotency |
@@ -96,7 +97,17 @@ flowchart TD
         S5_1 --> S5_2 --> S5_2_1 --> S5_2_2 --> S5_3 --> S5_4 --> S5_5
     end
 
-    S1 --> S1b --> S2 --> S3 --> S4 --> S5
+    subgraph S1a["1a. Schema Validation"]
+        direction TB
+        S1a_1["1a.1 Init Schema Placement<br/>default / --schema-dir custom"]
+        S1a_2["1a.2 Validate Rejects Invalid<br/>apiVersion / URL / name / source / checksum"]
+        S1a_3["1a.3 Apply Rejects Invalid<br/>HTTP URL → fail, state unchanged"]
+        S1a_4["1a.4 Error Message Quality<br/>resource name in error"]
+
+        S1a_1 --> S1a_2 --> S1a_3 --> S1a_4
+    end
+
+    S1 --> S1a --> S1b --> S2 --> S3 --> S4 --> S5
 ```
 
 ### Dependency Graph Patterns
@@ -345,6 +356,69 @@ graph LR
    - `~/go/bin/go` symlink no longer exists
    - `~/go/bin/gopls` binary no longer exists
    - state.json does not contain `"go"` or `"gopls"`
+
+---
+
+## 1a. Schema Validation
+
+### 1a.1 Init Schema Placement
+
+#### Default Location
+- `tomei init --yes` places `schema.cue` at `~/.config/tomei/schema.cue`
+- File contains key CUE definitions:
+  - `package tomei`
+  - `#APIVersion`
+  - `#Resource`
+  - `#HTTPSURL`
+  - `#Metadata`
+
+#### Custom Directory (`--schema-dir`)
+1. Create custom directory: `~/custom-schema-dir/`
+2. Run `tomei init --yes --force --schema-dir ~/custom-schema-dir`
+3. Verify `~/custom-schema-dir/schema.cue` exists and contains `#APIVersion`, `#Resource`
+4. Cleanup custom directory
+5. Re-initialize with default settings for subsequent tests
+
+### 1a.2 Validate Rejects Invalid Manifests
+
+All tests write an inline CUE manifest to `~/schema-test/` and run `tomei validate` against it.
+
+#### Wrong apiVersion
+- `apiVersion: "wrong/v1"` (not `"tomei.terassyi.net/v1beta1"`)
+- `tomei validate` fails with "validation failed"
+
+#### Non-HTTPS URL
+- `source.url: "http://example.com/tool.tar.gz"` (HTTP, not HTTPS)
+- `tomei validate` fails with "validation failed"
+
+#### Invalid Metadata Name
+- `metadata.name: "INVALID_NAME"` (uppercase, underscore — violates regex)
+- `tomei validate` fails with "validation failed"
+
+#### Runtime Download Without Source
+- `kind: "Runtime"`, `spec.type: "download"`, no `source` field
+- CUE conditional constraint: `if type == "download" { source: #DownloadSource }`
+- `tomei validate` fails with "validation failed"
+
+#### Invalid Checksum Format
+- `checksum.value: "md5:abc123"` (not `sha256:<64 hex chars>`)
+- `tomei validate` fails with "validation failed"
+
+### 1a.3 Apply Rejects Invalid Manifests
+
+#### State Preservation on Failure
+1. Record `state.json` content before apply
+2. Write manifest with non-HTTPS URL
+3. Run `tomei apply` — fails with "failed to load resources"
+4. Verify `state.json` content is unchanged (byte-for-byte equal)
+
+### 1a.4 Error Message Quality
+
+#### Resource Name in Error
+1. Create directory `~/schema-test/bad-dir/` with `package tomei` manifest
+2. Define named field `badTool:` containing a Tool with non-HTTPS URL
+3. Run `tomei validate ~/schema-test/bad-dir/`
+4. Error contains "schema validation failed" and "badTool"
 
 ---
 

--- a/e2e/schema_validation_test.go
+++ b/e2e/schema_validation_test.go
@@ -1,0 +1,233 @@
+//go:build e2e
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func schemaValidationTests() {
+
+	BeforeAll(func() {
+		// Ensure tomei is initialized (may already be from Basic tests)
+		_, _ = testExec.Exec("tomei", "init", "--yes")
+		// Create temp directory for invalid manifests
+		_, err := testExec.ExecBash("mkdir -p ~/schema-test")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterAll(func() {
+		_, _ = testExec.ExecBash("rm -rf ~/schema-test")
+	})
+
+	Context("tomei init Schema Placement", func() {
+		It("places schema.cue at default config directory", func() {
+			By("Verifying schema.cue was created by init")
+			output, err := testExec.ExecBash("cat ~/.config/tomei/schema.cue")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Checking schema contains key definitions")
+			Expect(output).To(ContainSubstring("package tomei"))
+			Expect(output).To(ContainSubstring("#APIVersion"))
+			Expect(output).To(ContainSubstring("#Resource"))
+			Expect(output).To(ContainSubstring("#HTTPSURL"))
+			Expect(output).To(ContainSubstring("#Metadata"))
+		})
+
+		It("places schema.cue in custom directory with --schema-dir", func() {
+			By("Creating custom schema directory")
+			_, err := testExec.ExecBash("mkdir -p ~/custom-schema-dir")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Running tomei init with --schema-dir")
+			output, err := testExec.Exec("tomei", "init", "--yes", "--force", "--schema-dir", "~/custom-schema-dir")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(ContainSubstring("Initialization complete"))
+
+			By("Verifying schema.cue exists in custom directory")
+			output, err = testExec.ExecBash("cat ~/custom-schema-dir/schema.cue")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(ContainSubstring("#APIVersion"))
+			Expect(output).To(ContainSubstring("#Resource"))
+
+			By("Cleaning up custom directory")
+			_, _ = testExec.ExecBash("rm -rf ~/custom-schema-dir")
+
+			By("Re-initializing with default settings for subsequent tests")
+			_, err = testExec.Exec("tomei", "init", "--yes", "--force")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("tomei validate Rejects Invalid Manifests", func() {
+		It("rejects wrong apiVersion", func() {
+			By("Writing manifest with wrong apiVersion")
+			_, err := testExec.ExecBash(`cat > ~/schema-test/wrong-api.cue << 'EOF'
+apiVersion: "wrong/v1"
+kind:       "Tool"
+metadata: name: "test"
+spec: {
+    installerRef: "download"
+    version:      "1.0.0"
+}
+EOF`)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Running tomei validate")
+			output, err := testExec.Exec("tomei", "validate", "~/schema-test/wrong-api.cue")
+			Expect(err).To(HaveOccurred())
+			Expect(output).To(ContainSubstring("validation failed"))
+		})
+
+		It("rejects non-HTTPS URL in source", func() {
+			By("Writing manifest with HTTP URL")
+			_, err := testExec.ExecBash(`cat > ~/schema-test/http-url.cue << 'EOF'
+apiVersion: "tomei.terassyi.net/v1beta1"
+kind:       "Tool"
+metadata: name: "test"
+spec: {
+    installerRef: "download"
+    version:      "1.0.0"
+    source: {
+        url: "http://example.com/tool.tar.gz"
+    }
+}
+EOF`)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Running tomei validate")
+			output, err := testExec.Exec("tomei", "validate", "~/schema-test/http-url.cue")
+			Expect(err).To(HaveOccurred())
+			Expect(output).To(ContainSubstring("validation failed"))
+		})
+
+		It("rejects invalid metadata name", func() {
+			By("Writing manifest with uppercase name")
+			_, err := testExec.ExecBash(`cat > ~/schema-test/bad-name.cue << 'EOF'
+apiVersion: "tomei.terassyi.net/v1beta1"
+kind:       "Tool"
+metadata: name: "INVALID_NAME"
+spec: {
+    installerRef: "download"
+    version:      "1.0.0"
+}
+EOF`)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Running tomei validate")
+			output, err := testExec.Exec("tomei", "validate", "~/schema-test/bad-name.cue")
+			Expect(err).To(HaveOccurred())
+			Expect(output).To(ContainSubstring("validation failed"))
+		})
+
+		It("rejects Runtime download type without source", func() {
+			By("Writing manifest with download type but no source")
+			_, err := testExec.ExecBash(`cat > ~/schema-test/no-source.cue << 'EOF'
+apiVersion: "tomei.terassyi.net/v1beta1"
+kind:       "Runtime"
+metadata: name: "go"
+spec: {
+    type:        "download"
+    version:     "1.25.6"
+    toolBinPath: "~/go/bin"
+}
+EOF`)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Running tomei validate")
+			output, err := testExec.Exec("tomei", "validate", "~/schema-test/no-source.cue")
+			Expect(err).To(HaveOccurred())
+			Expect(output).To(ContainSubstring("validation failed"))
+		})
+
+		It("rejects invalid checksum format", func() {
+			By("Writing manifest with md5 checksum")
+			_, err := testExec.ExecBash(`cat > ~/schema-test/bad-checksum.cue << 'EOF'
+apiVersion: "tomei.terassyi.net/v1beta1"
+kind:       "Tool"
+metadata: name: "test"
+spec: {
+    installerRef: "download"
+    version:      "1.0.0"
+    source: {
+        url: "https://example.com/tool.tar.gz"
+        checksum: {
+            value: "md5:abc123"
+        }
+    }
+}
+EOF`)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Running tomei validate")
+			output, err := testExec.Exec("tomei", "validate", "~/schema-test/bad-checksum.cue")
+			Expect(err).To(HaveOccurred())
+			Expect(output).To(ContainSubstring("validation failed"))
+		})
+	})
+
+	Context("tomei apply Rejects Invalid Manifests", func() {
+		It("rejects schema-invalid manifest and does not modify state", func() {
+			By("Recording state.json before apply attempt")
+			stateBefore, err := testExec.ExecBash("cat ~/.local/share/tomei/state.json")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Writing manifest with HTTP URL")
+			_, err = testExec.ExecBash(`cat > ~/schema-test/apply-invalid.cue << 'EOF'
+apiVersion: "tomei.terassyi.net/v1beta1"
+kind:       "Tool"
+metadata: name: "test"
+spec: {
+    installerRef: "download"
+    version:      "1.0.0"
+    source: {
+        url: "http://example.com/tool.tar.gz"
+    }
+}
+EOF`)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Running tomei apply - should fail")
+			output, err := testExec.Exec("tomei", "apply", "~/schema-test/apply-invalid.cue")
+			Expect(err).To(HaveOccurred())
+			Expect(output).To(ContainSubstring("failed to load resources"))
+
+			By("Verifying state.json was not modified")
+			stateAfter, err := testExec.ExecBash("cat ~/.local/share/tomei/state.json")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stateAfter).To(Equal(stateBefore))
+		})
+	})
+
+	Context("Error Message Quality", func() {
+		It("includes resource name in schema validation error", func() {
+			By("Creating directory with named resource that has invalid URL")
+			_, err := testExec.ExecBash("mkdir -p ~/schema-test/bad-dir")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = testExec.ExecBash(`cat > ~/schema-test/bad-dir/bad.cue << 'EOF'
+package tomei
+
+badTool: {
+    apiVersion: "tomei.terassyi.net/v1beta1"
+    kind:       "Tool"
+    metadata: name: "test"
+    spec: {
+        installerRef: "download"
+        version:      "1.0.0"
+        source: {
+            url: "http://insecure.example.com/tool.tar.gz"
+        }
+    }
+}
+EOF`)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Running tomei validate on directory")
+			output, err := testExec.Exec("tomei", "validate", "~/schema-test/bad-dir/")
+			Expect(err).To(HaveOccurred())
+			Expect(output).To(ContainSubstring("schema validation failed"))
+			Expect(output).To(ContainSubstring("badTool"))
+		})
+	})
+}

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -36,6 +36,7 @@ var _ = AfterSuite(func() {
 // Single top-level Describe with Ordered to guarantee execution order across all contexts.
 var _ = Describe("tomei E2E", Ordered, func() {
 	Context("Basic", basicTests)
+	Context("Schema Validation", schemaValidationTests)
 	Context("State Backup and Diff", stateBackupDiffTests)
 	Context("ToolSet", toolsetTests)
 	Context("Aqua Registry", registryTests)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,13 +3,16 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/cue/format"
 	"cuelang.org/go/cue/load"
+	"github.com/terassyi/tomei/internal/config/schema"
 )
 
 // Default path constants
@@ -18,13 +21,15 @@ const (
 	DefaultDataDir   = "~/.local/share/tomei"
 	DefaultBinDir    = "~/.local/bin"
 	DefaultEnvDir    = "~/.config/tomei"
+	SchemaFileName   = "schema.cue"
 )
 
 // Config represents tomei configuration.
 type Config struct {
-	DataDir string `json:"dataDir"`
-	BinDir  string `json:"binDir"`
-	EnvDir  string `json:"envDir"`
+	DataDir   string `json:"dataDir"`
+	BinDir    string `json:"binDir"`
+	EnvDir    string `json:"envDir"`
+	SchemaDir string `json:"schemaDir,omitempty"`
 }
 
 // DefaultConfig returns the default configuration.
@@ -103,4 +108,54 @@ func (c *Config) ToCue() ([]byte, error) {
 	}
 
 	return append([]byte("package tomei\n\n"), b...), nil
+}
+
+// expandHome expands ~ to the user's home directory.
+// This is a local copy to avoid circular imports with internal/path.
+func expandHome(p string) (string, error) {
+	if strings.HasPrefix(p, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, p[2:]), nil
+	}
+	if p == "~" {
+		return os.UserHomeDir()
+	}
+	return p, nil
+}
+
+// SyncSchema compares the embedded schema with the schema file on disk
+// and updates the file if they differ. The schema directory is determined
+// from config.SchemaDir (if set) or falls back to the config directory.
+// If the schema file does not exist yet (init not run), it returns nil.
+func SyncSchema(cfg *Config, configDir string) error {
+	dir := configDir
+	if cfg.SchemaDir != "" {
+		dir = cfg.SchemaDir
+	}
+
+	expanded, err := expandHome(dir)
+	if err != nil {
+		return fmt.Errorf("failed to expand schema directory: %w", err)
+	}
+
+	schemaFile := filepath.Join(expanded, SchemaFileName)
+	existing, err := os.ReadFile(schemaFile)
+	if err != nil {
+		// File doesn't exist yet; skip (init places it)
+		return nil
+	}
+
+	if string(existing) == schema.SchemaCUE {
+		return nil // already up to date
+	}
+
+	if err := os.WriteFile(schemaFile, []byte(schema.SchemaCUE), 0644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", schemaFile, err)
+	}
+
+	slog.Info("schema.cue updated", "path", schemaFile)
+	return nil
 }

--- a/internal/config/schema/embed.go
+++ b/internal/config/schema/embed.go
@@ -1,0 +1,6 @@
+package schema
+
+import _ "embed"
+
+//go:embed schema.cue
+var SchemaCUE string

--- a/internal/config/schema/schema.cue
+++ b/internal/config/schema/schema.cue
@@ -1,0 +1,201 @@
+package tomei
+
+// ==========================================================================
+// Environment variables (type + enum constraints only; concrete values
+// are injected by the Go loader at runtime)
+// ==========================================================================
+_env: {
+	os:       "linux" | "darwin"
+	arch:     "amd64" | "arm64"
+	headless: bool
+	platform: {
+		os: {go: "linux" | "darwin", apple: "Linux" | "macOS"}
+		arch: {go: "amd64" | "arm64", gnu: "x86_64" | "aarch64"}
+	}
+}
+
+// ==========================================================================
+// Common definitions
+// ==========================================================================
+
+#APIVersion: "tomei.terassyi.net/v1beta1"
+
+#Metadata: {
+	name: string & =~"^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$"
+	labels?: {[string]: string}
+}
+
+#HTTPSURL: string & =~"^https://"
+
+#Checksum: {
+	value?:       string & =~"^sha256:[a-f0-9]{64}$"
+	url?:         #HTTPSURL
+	filePattern?: string
+}
+
+#DownloadSource: {
+	url:          #HTTPSURL
+	checksum?:    #Checksum
+	archiveType?: "tar.gz" | "zip" | "raw"
+	asset?:       string
+}
+
+#CommandSet: {
+	install: string & !=""
+	check?:  string
+	remove?: string
+}
+
+// RuntimeBootstrap extends CommandSet with version resolution support.
+#RuntimeBootstrap: {
+	install:         string & !=""
+	check?:          string
+	remove?:         string
+	resolveVersion?: string
+}
+
+// Package accepts both string ("owner/repo" or module path) and object form.
+#Package: string | {
+	owner?: string
+	repo?:  string
+	name?:  string
+}
+
+// ==========================================================================
+// Resource definitions
+// ==========================================================================
+
+#Runtime: {
+	apiVersion: #APIVersion
+	kind:       "Runtime"
+	metadata:   #Metadata
+	spec: {
+		type:        "download" | "delegation"
+		version:     string & !=""
+		toolBinPath: string & !=""
+		source?:     #DownloadSource
+		bootstrap?:  #RuntimeBootstrap
+		binaries?: [...string]
+		binDir?:   string
+		commands?: #CommandSet
+		env?: {[string]: string}
+
+		// Conditional required fields
+		if type == "download" {
+			source: #DownloadSource
+		}
+		if type == "delegation" {
+			bootstrap: #RuntimeBootstrap & {
+				install: string & !=""
+				check:   string & !=""
+			}
+		}
+	}
+}
+
+#Installer: {
+	apiVersion: #APIVersion
+	kind:       "Installer"
+	metadata:   #Metadata
+	spec: {
+		type:        "download" | "delegation"
+		runtimeRef?: string
+		toolRef?:    string
+		bootstrap?:  #CommandSet
+		commands?:   #CommandSet
+
+		// Conditional required fields
+		if type == "delegation" {
+			commands: #CommandSet
+		}
+	}
+}
+
+#InstallerRepository: {
+	apiVersion: #APIVersion
+	kind:       "InstallerRepository"
+	metadata:   #Metadata
+	spec: {
+		installerRef: string & !=""
+		source: {
+			type:      "delegation" | "git"
+			url?:      #HTTPSURL
+			commands?: #CommandSet
+
+			// Conditional required fields
+			if type == "delegation" {
+				commands: #CommandSet
+			}
+			if type == "git" {
+				url: #HTTPSURL
+			}
+		}
+	}
+}
+
+#Tool: {
+	apiVersion: #APIVersion
+	kind:       "Tool"
+	metadata:   #Metadata
+	spec: {
+		installerRef?:  string
+		runtimeRef?:    string
+		repositoryRef?: string
+		version?:       string
+		enabled?:       bool
+		source?:        #DownloadSource
+		package?:       #Package
+	}
+}
+
+#ToolSet: {
+	apiVersion: #APIVersion
+	kind:       "ToolSet"
+	metadata:   #Metadata
+	spec: {
+		installerRef?:  string
+		runtimeRef?:    string
+		repositoryRef?: string
+		tools: {[string]: {
+			version?: string
+			enabled?: bool
+			source?:  #DownloadSource
+			package?: #Package
+		}}
+	}
+}
+
+#SystemInstaller: {
+	apiVersion: #APIVersion
+	kind:       "SystemInstaller"
+	metadata:   #Metadata
+	spec: {
+		pattern:    string & !=""
+		privileged: bool
+		commands: {...}
+	}
+}
+
+#SystemPackageRepository: {
+	apiVersion: #APIVersion
+	kind:       "SystemPackageRepository"
+	metadata:   #Metadata
+	spec: {
+		installerRef: string & !=""
+		source: {url: #HTTPSURL, ...}
+	}
+}
+
+#SystemPackageSet: {
+	apiVersion: #APIVersion
+	kind:       "SystemPackageSet"
+	metadata:   #Metadata
+	spec: {
+		installerRef:   string & !=""
+		repositoryRef?: string
+		packages: [...string]
+	}
+}
+
+#Resource: #Runtime | #Installer | #InstallerRepository | #Tool | #ToolSet |
+	#SystemInstaller | #SystemPackageRepository | #SystemPackageSet

--- a/internal/config/schema/schema_test.go
+++ b/internal/config/schema/schema_test.go
@@ -1,0 +1,554 @@
+package schema
+
+import (
+	"testing"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// compileSchemaWithEnv compiles the schema with concrete _env values injected,
+// mimicking what the loader does at runtime.
+func compileSchemaWithEnv(t *testing.T) cue.Value {
+	t.Helper()
+	ctx := cuecontext.New()
+	env := `
+_env: {
+	os:       "linux"
+	arch:     "amd64"
+	headless: false
+	platform: {
+		os: {go: "linux", apple: "Linux"}
+		arch: {go: "amd64", gnu: "x86_64"}
+	}
+}
+`
+	v := ctx.CompileString(SchemaCUE + "\n" + env)
+	require.NoError(t, v.Err(), "schema must compile without error")
+	return v
+}
+
+func TestSchema_Compiles(t *testing.T) {
+	compileSchemaWithEnv(t)
+}
+
+func TestSchema_Definitions_Exist(t *testing.T) {
+	v := compileSchemaWithEnv(t)
+
+	definitions := []string{
+		"#APIVersion",
+		"#Metadata",
+		"#HTTPSURL",
+		"#Checksum",
+		"#DownloadSource",
+		"#CommandSet",
+		"#Package",
+		"#Runtime",
+		"#Installer",
+		"#InstallerRepository",
+		"#Tool",
+		"#ToolSet",
+		"#SystemInstaller",
+		"#SystemPackageRepository",
+		"#SystemPackageSet",
+		"#Resource",
+	}
+
+	for _, def := range definitions {
+		t.Run(def, func(t *testing.T) {
+			d := v.LookupPath(cue.ParsePath(def))
+			assert.True(t, d.Exists(), "definition %s should exist", def)
+		})
+	}
+}
+
+func TestSchema_ValidResources(t *testing.T) {
+	v := compileSchemaWithEnv(t)
+	resourceDef := v.LookupPath(cue.ParsePath("#Resource"))
+	require.True(t, resourceDef.Exists())
+	ctx := v.Context()
+
+	tests := []struct {
+		name string
+		cue  string
+	}{
+		{
+			name: "Tool with installerRef and source",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "Tool"
+				metadata: name: "ripgrep"
+				spec: {
+					installerRef: "download"
+					version:      "14.0.0"
+					source: {
+						url: "https://github.com/BurntSushi/ripgrep/releases/download/14.0.0/ripgrep-14.0.0.tar.gz"
+					}
+				}
+			}`,
+		},
+		{
+			name: "Tool with runtimeRef and package",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "Tool"
+				metadata: name: "gopls"
+				spec: {
+					runtimeRef: "go"
+					package:    "golang.org/x/tools/gopls"
+					version:    "v0.21.0"
+				}
+			}`,
+		},
+		{
+			name: "Tool with package object",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "Tool"
+				metadata: name: "gh"
+				spec: {
+					installerRef: "aqua"
+					version:      "2.86.0"
+					package: {
+						owner: "cli"
+						repo:  "cli"
+					}
+				}
+			}`,
+		},
+		{
+			name: "Runtime download type",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "Runtime"
+				metadata: name: "go"
+				spec: {
+					type:    "download"
+					version: "1.25.6"
+					source: {
+						url: "https://go.dev/dl/go1.25.6.linux-amd64.tar.gz"
+					}
+					binaries:    ["go", "gofmt"]
+					toolBinPath: "~/go/bin"
+					commands: {
+						install: "go install {{.Package}}@{{.Version}}"
+						remove:  "rm -f {{.BinPath}}"
+					}
+					env: {
+						GOROOT: "~/.local/share/tomei/runtimes/go/1.25.6"
+					}
+				}
+			}`,
+		},
+		{
+			name: "Runtime delegation type",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "Runtime"
+				metadata: name: "rust"
+				spec: {
+					type:    "delegation"
+					version: "stable"
+					bootstrap: {
+						install: "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
+						check:   "rustc --version"
+						remove:  "rustup self uninstall -y"
+						resolveVersion: "rustc --version | grep -oP '[0-9]+\\.[0-9]+\\.[0-9]+'"
+					}
+					binaries:    ["rustc", "cargo", "rustup"]
+					toolBinPath: "~/.cargo/bin"
+				}
+			}`,
+		},
+		{
+			name: "Installer download type",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "Installer"
+				metadata: name: "download"
+				spec: {
+					type: "download"
+				}
+			}`,
+		},
+		{
+			name: "Installer delegation type",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "Installer"
+				metadata: name: "go"
+				spec: {
+					type:       "delegation"
+					runtimeRef: "go"
+					commands: {
+						install: "go install {{.Package}}@{{.Version}}"
+						check:   "go version -m {{.BinPath}}"
+						remove:  "rm {{.BinPath}}"
+					}
+				}
+			}`,
+		},
+		{
+			name: "InstallerRepository delegation",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "InstallerRepository"
+				metadata: name: "bitnami"
+				spec: {
+					installerRef: "helm"
+					source: {
+						type: "delegation"
+						commands: {
+							install: "helm repo add bitnami https://charts.bitnami.com/bitnami"
+							check:   "helm repo list | grep bitnami"
+							remove:  "helm repo remove bitnami"
+						}
+					}
+				}
+			}`,
+		},
+		{
+			name: "InstallerRepository git",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "InstallerRepository"
+				metadata: name: "custom-registry"
+				spec: {
+					installerRef: "aqua"
+					source: {
+						type: "git"
+						url:  "https://github.com/my-org/aqua-registry"
+					}
+				}
+			}`,
+		},
+		{
+			name: "ToolSet",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "ToolSet"
+				metadata: name: "go-tools"
+				spec: {
+					runtimeRef: "go"
+					tools: {
+						staticcheck: {package: "honnef.co/go/tools/cmd/staticcheck", version: "v0.6.0"}
+						godoc:       {package: "golang.org/x/tools/cmd/godoc", version: "v0.31.0"}
+					}
+				}
+			}`,
+		},
+		{
+			name: "SystemPackageSet",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "SystemPackageSet"
+				metadata: name: "cli-tools"
+				spec: {
+					installerRef: "apt"
+					packages: ["jq", "curl", "htop"]
+				}
+			}`,
+		},
+		{
+			name: "Tool with enabled false",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "Tool"
+				metadata: name: "disabled-tool"
+				spec: {
+					installerRef: "download"
+					version:      "1.0.0"
+					enabled:      false
+				}
+			}`,
+		},
+		{
+			name: "Tool with checksum value",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "Tool"
+				metadata: name: "verified-tool"
+				spec: {
+					installerRef: "download"
+					version:      "1.0.0"
+					source: {
+						url: "https://example.com/tool.tar.gz"
+						checksum: {
+							value: "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+						}
+						archiveType: "tar.gz"
+					}
+				}
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := ctx.CompileString(tt.cue)
+			require.NoError(t, res.Err(), "test CUE must compile")
+
+			unified := res.Unify(resourceDef)
+			err := unified.Validate(cue.Concrete(true))
+			assert.NoError(t, err, "valid resource should pass schema validation")
+		})
+	}
+}
+
+func TestSchema_InvalidResources(t *testing.T) {
+	v := compileSchemaWithEnv(t)
+	resourceDef := v.LookupPath(cue.ParsePath("#Resource"))
+	require.True(t, resourceDef.Exists())
+	ctx := v.Context()
+
+	tests := []struct {
+		name string
+		cue  string
+	}{
+		{
+			name: "wrong apiVersion",
+			cue: `{
+				apiVersion: "wrong/v1"
+				kind:       "Tool"
+				metadata: name: "test"
+				spec: {
+					installerRef: "download"
+					version:      "1.0.0"
+				}
+			}`,
+		},
+		{
+			name: "invalid kind",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "InvalidKind"
+				metadata: name: "test"
+				spec: {}
+			}`,
+		},
+		{
+			name: "non-HTTPS URL in source",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "Tool"
+				metadata: name: "test"
+				spec: {
+					installerRef: "download"
+					version:      "1.0.0"
+					source: {
+						url: "http://example.com/tool.tar.gz"
+					}
+				}
+			}`,
+		},
+		{
+			name: "invalid checksum format",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "Tool"
+				metadata: name: "test"
+				spec: {
+					installerRef: "download"
+					version:      "1.0.0"
+					source: {
+						url: "https://example.com/tool.tar.gz"
+						checksum: {
+							value: "md5:abc123"
+						}
+					}
+				}
+			}`,
+		},
+		{
+			name: "Runtime download without source",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "Runtime"
+				metadata: name: "go"
+				spec: {
+					type:        "download"
+					version:     "1.25.6"
+					toolBinPath: "~/go/bin"
+				}
+			}`,
+		},
+		{
+			name: "Runtime delegation without bootstrap",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "Runtime"
+				metadata: name: "rust"
+				spec: {
+					type:        "delegation"
+					version:     "stable"
+					toolBinPath: "~/.cargo/bin"
+				}
+			}`,
+		},
+		{
+			name: "Runtime empty version",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "Runtime"
+				metadata: name: "go"
+				spec: {
+					type:        "download"
+					version:     ""
+					toolBinPath: "~/go/bin"
+					source: {
+						url: "https://go.dev/dl/go.tar.gz"
+					}
+				}
+			}`,
+		},
+		{
+			name: "Installer delegation without commands",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "Installer"
+				metadata: name: "test"
+				spec: {
+					type: "delegation"
+				}
+			}`,
+		},
+		{
+			name: "InstallerRepository delegation without commands",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "InstallerRepository"
+				metadata: name: "test"
+				spec: {
+					installerRef: "helm"
+					source: {
+						type: "delegation"
+					}
+				}
+			}`,
+		},
+		{
+			name: "InstallerRepository git without url",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "InstallerRepository"
+				metadata: name: "test"
+				spec: {
+					installerRef: "aqua"
+					source: {
+						type: "git"
+					}
+				}
+			}`,
+		},
+		{
+			name: "invalid archive type",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "Tool"
+				metadata: name: "test"
+				spec: {
+					installerRef: "download"
+					version:      "1.0.0"
+					source: {
+						url:         "https://example.com/tool.gz"
+						archiveType: "gzip"
+					}
+				}
+			}`,
+		},
+		{
+			name: "invalid InstallerRepository source type",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "InstallerRepository"
+				metadata: name: "test"
+				spec: {
+					installerRef: "test"
+					source: {
+						type: "invalid"
+					}
+				}
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := ctx.CompileString(tt.cue)
+			require.NoError(t, res.Err(), "test CUE must compile")
+
+			unified := res.Unify(resourceDef)
+			err := unified.Validate(cue.Concrete(true))
+			assert.Error(t, err, "invalid resource should fail schema validation")
+		})
+	}
+}
+
+func TestSchema_EnvEnum(t *testing.T) {
+	ctx := cuecontext.New()
+
+	tests := []struct {
+		name    string
+		envCUE  string
+		wantErr bool
+	}{
+		{
+			name: "valid linux/amd64",
+			envCUE: `_env: {
+				os: "linux", arch: "amd64", headless: false
+				platform: {
+					os: {go: "linux", apple: "Linux"}
+					arch: {go: "amd64", gnu: "x86_64"}
+				}
+			}`,
+			wantErr: false,
+		},
+		{
+			name: "valid darwin/arm64",
+			envCUE: `_env: {
+				os: "darwin", arch: "arm64", headless: true
+				platform: {
+					os: {go: "darwin", apple: "macOS"}
+					arch: {go: "arm64", gnu: "aarch64"}
+				}
+			}`,
+			wantErr: false,
+		},
+		{
+			name: "invalid OS",
+			envCUE: `_env: {
+				os: "windows", arch: "amd64", headless: false
+				platform: {
+					os: {go: "windows", apple: "Windows"}
+					arch: {go: "amd64", gnu: "x86_64"}
+				}
+			}`,
+			wantErr: true,
+		},
+		{
+			name: "invalid arch",
+			envCUE: `_env: {
+				os: "linux", arch: "riscv64", headless: false
+				platform: {
+					os: {go: "linux", apple: "Linux"}
+					arch: {go: "riscv64", gnu: "riscv64"}
+				}
+			}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := ctx.CompileString(SchemaCUE + "\n" + tt.envCUE)
+			if tt.wantErr {
+				err := v.Validate(cue.Concrete(true))
+				assert.Error(t, err, "invalid env should cause validation error")
+			} else {
+				require.NoError(t, v.Err(), "schema with valid env must compile")
+			}
+		})
+	}
+}

--- a/internal/installer/engine/engine_test.go
+++ b/internal/installer/engine/engine_test.go
@@ -139,7 +139,7 @@ tool: {
 		source: {
 			url: "https://example.com/test-tool.tar.gz"
 			checksum: {
-				value: "sha256:abc123"
+				value: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 			}
 			archiveType: "tar.gz"
 		}
@@ -209,7 +209,7 @@ tool: {
 		source: {
 			url: "https://example.com/test-tool.tar.gz"
 			checksum: {
-				value: "sha256:abc123"
+				value: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 			}
 			archiveType: "tar.gz"
 		}
@@ -272,12 +272,12 @@ runtime: {
 	kind: "Runtime"
 	metadata: name: "myruntime"
 	spec: {
-		pattern: "download"
+		type: "download"
 		version: "1.0.0"
 		source: {
 			url: "https://example.com/myruntime-1.0.0.tar.gz"
 			checksum: {
-				value: "sha256:abc123"
+				value: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 			}
 		}
 		binaries: ["mybin"]
@@ -298,7 +298,7 @@ tool: {
 		source: {
 			url: "https://example.com/test-tool.tar.gz"
 			checksum: {
-				value: "sha256:def456"
+				value: "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
 			}
 			archiveType: "tar.gz"
 		}
@@ -384,12 +384,12 @@ runtime: {
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
-		pattern: "download"
+		type: "download"
 		version: "1.26.0"
 		source: {
 			url: "https://example.com/go-1.26.0.tar.gz"
 			checksum: {
-				value: "sha256:abc123"
+				value: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 			}
 		}
 		binaries: ["go", "gofmt"]
@@ -509,11 +509,11 @@ goRuntime: {
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
-		pattern: "download"
+		type: "download"
 		version: "1.23.0"
 		source: {
 			url: "https://example.com/go-1.23.0.tar.gz"
-			checksum: { value: "sha256:abc123" }
+			checksum: { value: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" }
 		}
 		binaries: ["go", "gofmt"]
 		toolBinPath: "~/go/bin"
@@ -543,7 +543,7 @@ pnpmInstaller: {
 	kind: "Installer"
 	metadata: name: "pnpm"
 	spec: {
-		pattern: "delegation"
+		type: "delegation"
 		toolRef: "pnpm"
 		commands: {
 			install: "pnpm add -g {{.Package}}@{{.Version}}"
@@ -653,7 +653,7 @@ installerA: {
 	kind: "Installer"
 	metadata: name: "installer-a"
 	spec: {
-		pattern: "delegation"
+		type: "delegation"
 		toolRef: "tool-b"
 		commands: {
 			install: "install-a {{.Package}}"
@@ -703,7 +703,7 @@ aquaInstaller: {
 	kind: "Installer"
 	metadata: name: "aqua"
 	spec: {
-		pattern: "download"
+		type: "download"
 	}
 }
 
@@ -716,7 +716,7 @@ ripgrep: {
 		version: "14.0.0"
 		source: {
 			url: "https://example.com/ripgrep.tar.gz"
-			checksum: { value: "sha256:rg" }
+			checksum: { value: "sha256:1111111111111111111111111111111111111111111111111111111111111111" }
 		}
 	}
 }
@@ -730,7 +730,7 @@ fd: {
 		version: "9.0.0"
 		source: {
 			url: "https://example.com/fd.tar.gz"
-			checksum: { value: "sha256:fd" }
+			checksum: { value: "sha256:2222222222222222222222222222222222222222222222222222222222222222" }
 		}
 	}
 }
@@ -744,7 +744,7 @@ bat: {
 		version: "0.24.0"
 		source: {
 			url: "https://example.com/bat.tar.gz"
-			checksum: { value: "sha256:bat" }
+			checksum: { value: "sha256:3333333333333333333333333333333333333333333333333333333333333333" }
 		}
 	}
 }
@@ -824,7 +824,7 @@ aquaInstaller: {
 	kind: "Installer"
 	metadata: name: "aqua"
 	spec: {
-		pattern: "download"
+		type: "download"
 	}
 }
 
@@ -837,7 +837,7 @@ ripgrep: {
 		version: "14.0.0"
 		source: {
 			url: "https://example.com/ripgrep.tar.gz"
-			checksum: { value: "sha256:rg" }
+			checksum: { value: "sha256:1111111111111111111111111111111111111111111111111111111111111111" }
 		}
 	}
 }
@@ -851,7 +851,7 @@ fd: {
 		version: "9.0.0"
 		source: {
 			url: "https://example.com/fd.tar.gz"
-			checksum: { value: "sha256:fd" }
+			checksum: { value: "sha256:2222222222222222222222222222222222222222222222222222222222222222" }
 		}
 	}
 }
@@ -865,7 +865,7 @@ bat: {
 		version: "0.24.0"
 		source: {
 			url: "https://example.com/bat.tar.gz"
-			checksum: { value: "sha256:bat" }
+			checksum: { value: "sha256:3333333333333333333333333333333333333333333333333333333333333333" }
 		}
 	}
 }
@@ -935,11 +935,11 @@ goRuntime: {
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
-		pattern: "download"
+		type: "download"
 		version: "1.25.0"
 		source: {
 			url: "https://example.com/go.tar.gz"
-			checksum: { value: "sha256:go" }
+			checksum: { value: "sha256:4444444444444444444444444444444444444444444444444444444444444444" }
 		}
 		binaries: ["go"]
 		toolBinPath: "~/go/bin"
@@ -955,7 +955,7 @@ ripgrep: {
 		version: "14.0.0"
 		source: {
 			url: "https://example.com/ripgrep.tar.gz"
-			checksum: { value: "sha256:rg" }
+			checksum: { value: "sha256:1111111111111111111111111111111111111111111111111111111111111111" }
 		}
 	}
 }
@@ -1036,11 +1036,11 @@ goRuntime: {
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
-		pattern: "download"
+		type: "download"
 		version: "1.25.0"
 		source: {
 			url: "https://example.com/go.tar.gz"
-			checksum: { value: "sha256:go" }
+			checksum: { value: "sha256:4444444444444444444444444444444444444444444444444444444444444444" }
 		}
 		binaries: ["go"]
 		toolBinPath: "~/go/bin"
@@ -1052,11 +1052,11 @@ rustRuntime: {
 	kind: "Runtime"
 	metadata: name: "rust"
 	spec: {
-		pattern: "download"
+		type: "download"
 		version: "1.80.0"
 		source: {
 			url: "https://example.com/rust.tar.gz"
-			checksum: { value: "sha256:rust" }
+			checksum: { value: "sha256:5555555555555555555555555555555555555555555555555555555555555555" }
 		}
 		binaries: ["rustc", "cargo"]
 		toolBinPath: "~/.cargo/bin"
@@ -1068,11 +1068,11 @@ nodeRuntime: {
 	kind: "Runtime"
 	metadata: name: "node"
 	spec: {
-		pattern: "download"
+		type: "download"
 		version: "22.0.0"
 		source: {
 			url: "https://example.com/node.tar.gz"
-			checksum: { value: "sha256:node" }
+			checksum: { value: "sha256:6666666666666666666666666666666666666666666666666666666666666666" }
 		}
 		binaries: ["node", "npm"]
 		toolBinPath: "~/.npm/bin"
@@ -1178,7 +1178,7 @@ aquaInstaller: {
 	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Installer"
 	metadata: name: "aqua"
-	spec: { pattern: "download" }
+	spec: { type: "download" }
 }
 `)
 	toolDefs := []struct{ cueKey, name string }{
@@ -1196,11 +1196,11 @@ aquaInstaller: {
 		version: "1.0.0"
 		source: {
 			url: "https://example.com/%s.tar.gz"
-			checksum: { value: "sha256:%s" }
+			checksum: { value: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" }
 		}
 	}
 }
-`, td.cueKey, td.name, td.name, td.name)
+`, td.cueKey, td.name, td.name)
 	}
 
 	err := os.WriteFile(cueFile, []byte(sb.String()), 0644)
@@ -1268,7 +1268,7 @@ tool: {
 		source: {
 			url: "https://example.com/test-tool.tar.gz"
 			checksum: {
-				value: "sha256:abc123"
+				value: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 			}
 			archiveType: "tar.gz"
 		}
@@ -1357,7 +1357,7 @@ tool: {
 		version: "1.0.0"
 		source: {
 			url: "https://example.com/test-tool.tar.gz"
-			checksum: { value: "sha256:abc123" }
+			checksum: { value: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" }
 		}
 	}
 }
@@ -1415,11 +1415,11 @@ runtime: {
 	kind: "Runtime"
 	metadata: name: "myruntime"
 	spec: {
-		pattern: "download"
+		type: "download"
 		version: "1.0.0"
 		source: {
 			url: "https://example.com/myruntime.tar.gz"
-			checksum: { value: "sha256:abc" }
+			checksum: { value: "sha256:7777777777777777777777777777777777777777777777777777777777777777" }
 		}
 		binaries: ["mybin"]
 		toolBinPath: "~/bin"
@@ -1435,7 +1435,7 @@ tool: {
 		version: "1.0.0"
 		source: {
 			url: "https://example.com/test-tool.tar.gz"
-			checksum: { value: "sha256:def" }
+			checksum: { value: "sha256:8888888888888888888888888888888888888888888888888888888888888888" }
 		}
 	}
 }
@@ -1481,7 +1481,7 @@ aquaInstaller: {
 	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind: "Installer"
 	metadata: name: "aqua"
-	spec: { pattern: "download" }
+	spec: { type: "download" }
 }
 `)
 	for _, name := range toolNames {
@@ -1495,11 +1495,11 @@ aquaInstaller: {
 		version: "1.0.0"
 		source: {
 			url: "https://example.com/%s.tar.gz"
-			checksum: { value: "sha256:%s" }
+			checksum: { value: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" }
 		}
 	}
 }
-`, name, name, name, name)
+`, name, name, name)
 	}
 	return sb.String()
 }
@@ -1516,17 +1516,17 @@ func generateRuntimesAndToolsCUE(runtimeNames, toolNames []string) string {
 	kind: "Runtime"
 	metadata: name: "%s"
 	spec: {
-		pattern: "download"
+		type: "download"
 		version: "1.0.0"
 		source: {
 			url: "https://example.com/%s.tar.gz"
-			checksum: { value: "sha256:%s" }
+			checksum: { value: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" }
 		}
 		binaries: ["%s"]
 		toolBinPath: "~/%s/bin"
 	}
 }
-`, name, name, name, name, name, name)
+`, name, name, name, name, name)
 	}
 
 	for _, name := range toolNames {
@@ -1540,11 +1540,11 @@ func generateRuntimesAndToolsCUE(runtimeNames, toolNames []string) string {
 		version: "1.0.0"
 		source: {
 			url: "https://example.com/%s.tar.gz"
-			checksum: { value: "sha256:%s" }
+			checksum: { value: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" }
 		}
 	}
 }
-`, name, name, name, name)
+`, name, name, name)
 	}
 
 	return sb.String()
@@ -2104,11 +2104,11 @@ runtime: {
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
-		pattern: "download"
+		type: "download"
 		version: "1.0.0"
 		source: {
 			url: "https://example.com/go.tar.gz"
-			checksum: value: "sha256:abc123"
+			checksum: value: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 		}
 		binaries: ["go"]
 		toolBinPath: "~/go/bin"
@@ -2241,11 +2241,11 @@ runtime: {
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
-		pattern: "download"
+		type: "download"
 		version: "1.0.0"
 		source: {
 			url: "https://example.com/go.tar.gz"
-			checksum: value: "sha256:abc123"
+			checksum: value: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 		}
 		binaries: ["go"]
 		toolBinPath: "~/go/bin"
@@ -2306,7 +2306,7 @@ placeholder: {
 		version: "1.0.0"
 		source: {
 			url: "https://example.com/fzf.tar.gz"
-			checksum: value: "sha256:abc123"
+			checksum: value: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 		}
 	}
 }
@@ -2454,7 +2454,7 @@ fd: {
 		version: "9.0.0"
 		source: {
 			url: "https://example.com/fd.tar.gz"
-			checksum: { value: "sha256:fd" }
+			checksum: { value: "sha256:2222222222222222222222222222222222222222222222222222222222222222" }
 		}
 	}
 }
@@ -2521,7 +2521,7 @@ rg: {
 		version: "14.0.0"
 		source: {
 			url: "https://example.com/rg.tar.gz"
-			checksum: { value: "sha256:rg" }
+			checksum: { value: "sha256:1111111111111111111111111111111111111111111111111111111111111111" }
 		}
 	}
 }
@@ -2656,7 +2656,7 @@ tool: {
 		version: "1.0.0"
 		source: {
 			url: "https://example.com/nginx.tar.gz"
-			checksum: value: "sha256:abc123"
+			checksum: value: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 			archiveType: "tar.gz"
 		}
 	}

--- a/tests/engine_test.go
+++ b/tests/engine_test.go
@@ -231,7 +231,7 @@ goRuntime: {
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
-		installerRef: "download"
+		type: "download"
 		version: "1.25.5"
 		source: {
 			url: "https://go.dev/dl/go1.25.5.linux-amd64.tar.gz"
@@ -329,7 +329,7 @@ goRuntime: {
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
-		installerRef: "download"
+		type: "download"
 		version: "1.25.5"
 		source: {
 			url: "https://go.dev/dl/go1.25.5.linux-amd64.tar.gz"
@@ -613,7 +613,7 @@ goRuntime: {
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
-		installerRef: "download"
+		type: "download"
 		version: "1.25.5"
 		source: {
 			url: "https://go.dev/dl/go1.25.5.linux-amd64.tar.gz"
@@ -762,7 +762,7 @@ goRuntime: {
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
-		installerRef: "download"
+		type: "download"
 		version: "1.25.5"
 		source: {
 			url: "https://go.dev/dl/go1.25.5.linux-amd64.tar.gz"
@@ -854,7 +854,7 @@ brewInstaller: {
 	kind: "Installer"
 	metadata: name: "brew"
 	spec: {
-		pattern: "delegation"
+		type: "delegation"
 		commands: {
 			install: "brew install {{.Package}}"
 			remove: "brew uninstall {{.Package}}"
@@ -930,7 +930,7 @@ goRuntime: {
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
-		installerRef: "download"
+		type: "download"
 		version: "1.25.5"
 		source: {
 			url: "https://go.dev/dl/go1.25.5.linux-amd64.tar.gz"
@@ -1045,7 +1045,7 @@ goRuntime: {
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
-		installerRef: "download"
+		type: "download"
 		version: "1.25.5"
 		source: {
 			url: "https://go.dev/dl/go1.25.5.linux-amd64.tar.gz"
@@ -1100,11 +1100,11 @@ runtime: {
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
-		pattern: "download"
+		type: "download"
 		version: "1.0.0"
 		source: {
 			url: "https://example.com/go.tar.gz"
-			checksum: value: "sha256:abc123"
+			checksum: value: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 		}
 		binaries: ["go"]
 		toolBinPath: "~/go/bin"
@@ -1574,7 +1574,7 @@ goRuntime: {
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
-		installerRef: "download"
+		type: "download"
 		version: "1.25.5"
 		source: { url: "https://go.dev/dl/go1.25.5.linux-amd64.tar.gz" }
 		binaries: ["go", "gofmt"]
@@ -2053,7 +2053,7 @@ goRuntime: {
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
-		installerRef: "download"
+		type: "download"
 		version: "1.25.5"
 		source: {
 			url: "https://go.dev/dl/go1.25.5.linux-amd64.tar.gz"
@@ -2158,7 +2158,7 @@ goRuntime: {
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
-		installerRef: "download"
+		type: "download"
 		version: "1.25.5"
 		source: { url: "https://go.dev/dl/go1.25.5.tar.gz" }
 		binaries: ["go", "gofmt"]
@@ -2171,7 +2171,7 @@ rustRuntime: {
 	kind: "Runtime"
 	metadata: name: "rust"
 	spec: {
-		installerRef: "download"
+		type: "download"
 		version: "1.80.0"
 		source: { url: "https://example.com/rust.tar.gz" }
 		binaries: ["rustc", "cargo"]
@@ -2184,7 +2184,7 @@ nodeRuntime: {
 	kind: "Runtime"
 	metadata: name: "node"
 	spec: {
-		installerRef: "download"
+		type: "download"
 		version: "22.0.0"
 		source: { url: "https://example.com/node.tar.gz" }
 		binaries: ["node", "npm"]
@@ -2269,7 +2269,7 @@ goRuntime: {
 	kind: "Runtime"
 	metadata: name: "go"
 	spec: {
-		installerRef: "download"
+		type: "download"
 		version: "1.25.5"
 		source: {
 			url: "https://go.dev/dl/go1.25.5.linux-amd64.tar.gz"


### PR DESCRIPTION
- Add internal/config/schema/ with schema.cue (resource type definitions,
  HTTPS URL validation, metadata regex, conditional required fields),
  embed.go (go:embed), and schema_test.go
- Modify loader.go to inject schema as overlay and validate resources
  against #Resource definition via CUE unify
- Add SchemaDir to Config, SyncSchema for schema file synchronization,
  and --schema-dir flag to tomei init
- Add SyncSchema error handling in apply/plan/validate commands
- Fix existing test manifests for schema compliance (Runtime type field,
  Installer type field, checksum format)
- Add schema validation test cases in tests/resource_test.go (17 cases)
  and internal/config/loader_test.go
- Add E2E schema validation tests (9 cases): init placement, validate
  rejection, apply state preservation, error message quality
- Update e2e/scenario.md with Schema Validation section
