### PR TITLE
feat: add aqua as builtin installer

### DIFF
--- a/cmd/tomei/plan.go
+++ b/cmd/tomei/plan.go
@@ -13,6 +13,7 @@ import (
 	"github.com/terassyi/tomei/internal/config"
 	"github.com/terassyi/tomei/internal/github"
 	"github.com/terassyi/tomei/internal/graph"
+	"github.com/terassyi/tomei/internal/installer/engine"
 	"github.com/terassyi/tomei/internal/path"
 	"github.com/terassyi/tomei/internal/registry/aqua"
 	"github.com/terassyi/tomei/internal/resource"
@@ -246,8 +247,10 @@ func resolvePlan(resources []resource.Resource) (*planResult, error) {
 		definedResources[id.String()] = struct{}{}
 	}
 
+	// Inject builtin installers into the resolver only so that dependency
+	// nodes like "Installer/aqua" are properly resolved.
 	resolver := graph.NewResolver()
-	for _, res := range resources {
+	for _, res := range engine.AppendBuiltinInstallers(resources) {
 		resolver.AddResource(res)
 	}
 

--- a/internal/installer/builtin/builtin.go
+++ b/internal/installer/builtin/builtin.go
@@ -8,6 +8,7 @@ import (
 // installers holds all builtin installer definitions.
 var installers = []*resource.Installer{
 	download.BuiltinInstaller,
+	download.BuiltinAquaInstaller,
 }
 
 // installerMap provides quick lookup by name.

--- a/internal/installer/builtin/builtin_test.go
+++ b/internal/installer/builtin/builtin_test.go
@@ -11,8 +11,8 @@ import (
 func TestInstallers(t *testing.T) {
 	installers := Installers()
 
-	// Should have at least the "download" installer
-	require.NotEmpty(t, installers)
+	// Should have both "download" and "aqua" installers
+	require.Len(t, installers, 2)
 
 	// Find "download" installer
 	var downloadInstaller *resource.Installer
@@ -37,6 +37,26 @@ func TestInstallers(t *testing.T) {
 	assert.Empty(t, downloadInstaller.InstallerSpec.ToolRef)
 	assert.Nil(t, downloadInstaller.InstallerSpec.Bootstrap)
 	assert.Nil(t, downloadInstaller.InstallerSpec.Commands)
+
+	// Find "aqua" installer
+	var aquaInstaller *resource.Installer
+	for _, i := range installers {
+		if i.Metadata.Name == "aqua" {
+			aquaInstaller = i
+			break
+		}
+	}
+
+	require.NotNil(t, aquaInstaller, "aqua installer not found")
+
+	// Verify aqua installer structure
+	assert.Equal(t, resource.GroupVersion, aquaInstaller.APIVersion)
+	assert.Equal(t, resource.KindInstaller, aquaInstaller.ResourceKind)
+	assert.Equal(t, "aqua", aquaInstaller.Metadata.Name)
+
+	// Verify spec — aqua uses download pattern
+	require.NotNil(t, aquaInstaller.InstallerSpec)
+	assert.Equal(t, resource.InstallTypeDownload, aquaInstaller.InstallerSpec.Type)
 }
 
 func TestInstallers_AllValid(t *testing.T) {
@@ -68,6 +88,11 @@ func TestGet(t *testing.T) {
 			wantNil:     false,
 		},
 		{
+			name:        "aqua installer exists",
+			installerID: "aqua",
+			wantNil:     false,
+		},
+		{
 			name:        "nonexistent installer",
 			installerID: "nonexistent",
 			wantNil:     true,
@@ -96,6 +121,11 @@ func TestIsBuiltin(t *testing.T) {
 		{
 			name:        "download is builtin",
 			installerID: "download",
+			want:        true,
+		},
+		{
+			name:        "aqua is builtin",
+			installerID: "aqua",
 			want:        true,
 		},
 		{

--- a/internal/installer/download/builtin.go
+++ b/internal/installer/download/builtin.go
@@ -13,3 +13,16 @@ var BuiltinInstaller = &resource.Installer{
 		Type: resource.InstallTypeDownload,
 	},
 }
+
+// BuiltinAquaInstaller is the builtin "aqua" installer definition.
+// Aqua uses the download pattern with aqua-registry for package resolution.
+var BuiltinAquaInstaller = &resource.Installer{
+	BaseResource: resource.BaseResource{
+		APIVersion:   resource.GroupVersion,
+		ResourceKind: resource.KindInstaller,
+		Metadata:     resource.Metadata{Name: "aqua"},
+	},
+	InstallerSpec: &resource.InstallerSpec{
+		Type: resource.InstallTypeDownload,
+	},
+}


### PR DESCRIPTION
Add aqua alongside download as a builtin installer so that
tools referencing installerRef: "aqua" have a proper DAG node
backing them. Previously, the Installer/aqua node was created by
the dependency resolver but had no corresponding resource.

Builtin installers are injected into the resolver only (not into
the resource list) to avoid persisting them to state.

Changes:
- Add BuiltinAquaInstaller in internal/installer/download/builtin.go
- Register aqua in internal/installer/builtin/builtin.go
- Add AppendBuiltinInstallers to engine for DAG resolution
- Call AppendBuiltinInstallers in both engine.Apply and plan.resolvePlan
- Add tests for builtin registration and AppendBuiltinInstallers

Signed-off-by: terashima <iscale821@gmail.com>
