### PR TITLE
feat: add TUI log panel for slog output with --log-level flag

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,5 +31,8 @@
       "Bash(*tomei *)",
       "Bash(*tomei)"
     ]
+  },
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   }
 }

--- a/internal/ui/applystyle.go
+++ b/internal/ui/applystyle.go
@@ -7,6 +7,10 @@ var (
 	failMarkStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))   // red
 	layerHeaderStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("14"))  // light cyan
 	delegationLogStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("245")) // gray
+	warnLogStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))   // yellow
+	errorLogStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))   // red
+	debugLogStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("245")) // gray
+	logSeparatorStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("245")) // gray
 	runningMark        = "=>"
 	doneMark           = doneMarkStyle.Render("✓")
 	failMark           = failMarkStyle.Render("✗")

--- a/internal/ui/loghandler.go
+++ b/internal/ui/loghandler.go
@@ -1,0 +1,88 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+// TUILogHandler is a slog.Handler that forwards log records to a Bubble Tea
+// program via Send(). Only records at or above the configured level are sent.
+type TUILogHandler struct {
+	target sender     // tea.Program (Send-capable)
+	level  slog.Level // minimum level to forward
+	attrs  []slog.Attr
+	group  string
+}
+
+// NewTUILogHandler creates a handler that sends slogMsg to the given sender.
+func NewTUILogHandler(target sender, level slog.Level) *TUILogHandler {
+	return &TUILogHandler{
+		target: target,
+		level:  level,
+	}
+}
+
+// Enabled reports whether the handler handles records at the given level.
+func (h *TUILogHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.level
+}
+
+// Handle formats the record and sends it to the TUI as a slogMsg.
+func (h *TUILogHandler) Handle(_ context.Context, r slog.Record) error {
+	var b strings.Builder
+	b.WriteString(r.Message)
+
+	// Append handler-level attrs
+	for _, a := range h.attrs {
+		fmt.Fprintf(&b, " %s=%q", h.qualifiedKey(a.Key), a.Value)
+	}
+
+	// Append record-level attrs
+	r.Attrs(func(a slog.Attr) bool {
+		fmt.Fprintf(&b, " %s=%q", h.qualifiedKey(a.Key), a.Value)
+		return true
+	})
+
+	h.target.Send(slogMsg{
+		level:   r.Level,
+		message: b.String(),
+	})
+	return nil
+}
+
+// WithAttrs returns a new handler with the given attributes.
+func (h *TUILogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	newAttrs := make([]slog.Attr, len(h.attrs)+len(attrs))
+	copy(newAttrs, h.attrs)
+	copy(newAttrs[len(h.attrs):], attrs)
+	return &TUILogHandler{
+		target: h.target,
+		level:  h.level,
+		attrs:  newAttrs,
+		group:  h.group,
+	}
+}
+
+// WithGroup returns a new handler with the given group name.
+func (h *TUILogHandler) WithGroup(name string) slog.Handler {
+	newGroup := name
+	if h.group != "" {
+		newGroup = h.group + "." + name
+	}
+	return &TUILogHandler{
+		target: h.target,
+		level:  h.level,
+		attrs:  h.attrs,
+		group:  newGroup,
+	}
+}
+
+// qualifiedKey prepends the group prefix to a key.
+func (h *TUILogHandler) qualifiedKey(key string) string {
+	if h.group == "" {
+		return key
+	}
+	return h.group + "." + key
+}

--- a/internal/ui/loghandler_test.go
+++ b/internal/ui/loghandler_test.go
@@ -1,0 +1,107 @@
+package ui
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTUILogHandler_WarnAndErrorAreSent(t *testing.T) {
+	s := &mockSender{}
+	handler := NewTUILogHandler(s, slog.LevelWarn)
+	logger := slog.New(handler)
+
+	logger.Warn("first warning")
+	logger.Error("first error")
+
+	msgs := s.messages()
+	require.Len(t, msgs, 2)
+
+	msg0 := msgs[0].(slogMsg)
+	assert.Equal(t, slog.LevelWarn, msg0.level)
+	assert.Equal(t, "first warning", msg0.message)
+
+	msg1 := msgs[1].(slogMsg)
+	assert.Equal(t, slog.LevelError, msg1.level)
+	assert.Equal(t, "first error", msg1.message)
+}
+
+func TestTUILogHandler_DebugAndInfoIgnoredAtWarnLevel(t *testing.T) {
+	s := &mockSender{}
+	handler := NewTUILogHandler(s, slog.LevelWarn)
+	logger := slog.New(handler)
+
+	logger.Debug("debug msg")
+	logger.Info("info msg")
+
+	msgs := s.messages()
+	assert.Empty(t, msgs)
+}
+
+func TestTUILogHandler_AllLevelsAtDebugLevel(t *testing.T) {
+	s := &mockSender{}
+	handler := NewTUILogHandler(s, slog.LevelDebug)
+	logger := slog.New(handler)
+
+	logger.Debug("d")
+	logger.Info("i")
+	logger.Warn("w")
+	logger.Error("e")
+
+	msgs := s.messages()
+	require.Len(t, msgs, 4)
+
+	assert.Equal(t, slog.LevelDebug, msgs[0].(slogMsg).level)
+	assert.Equal(t, slog.LevelInfo, msgs[1].(slogMsg).level)
+	assert.Equal(t, slog.LevelWarn, msgs[2].(slogMsg).level)
+	assert.Equal(t, slog.LevelError, msgs[3].(slogMsg).level)
+}
+
+func TestTUILogHandler_AttrsIncludedInMessage(t *testing.T) {
+	s := &mockSender{}
+	handler := NewTUILogHandler(s, slog.LevelWarn)
+	logger := slog.New(handler)
+
+	logger.Warn("failed to backup", "error", "permission denied", "path", "/tmp/state.json")
+
+	msgs := s.messages()
+	require.Len(t, msgs, 1)
+
+	msg := msgs[0].(slogMsg)
+	assert.Contains(t, msg.message, "failed to backup")
+	assert.Contains(t, msg.message, "permission denied")
+	assert.Contains(t, msg.message, "/tmp/state.json")
+}
+
+func TestTUILogHandler_WithAttrs(t *testing.T) {
+	s := &mockSender{}
+	handler := NewTUILogHandler(s, slog.LevelWarn)
+	child := handler.WithAttrs([]slog.Attr{slog.String("component", "engine")})
+	logger := slog.New(child)
+
+	logger.Warn("something happened")
+
+	msgs := s.messages()
+	require.Len(t, msgs, 1)
+
+	msg := msgs[0].(slogMsg)
+	assert.Contains(t, msg.message, "component")
+	assert.Contains(t, msg.message, "engine")
+}
+
+func TestTUILogHandler_WithGroup(t *testing.T) {
+	s := &mockSender{}
+	handler := NewTUILogHandler(s, slog.LevelWarn)
+	child := handler.WithGroup("installer")
+	logger := slog.New(child)
+
+	logger.Warn("download failed", "url", "https://example.com")
+
+	msgs := s.messages()
+	require.Len(t, msgs, 1)
+
+	msg := msgs[0].(slogMsg)
+	assert.Contains(t, msg.message, "installer.url")
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"log/slog"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -10,7 +11,14 @@ import (
 const (
 	tickInterval = 50 * time.Millisecond
 	maxLogLines  = 5
+	maxSlogLines = 5
 )
+
+// slogLine holds a single log line delivered from slog.
+type slogLine struct {
+	level   slog.Level
+	message string
+}
 
 // taskStatus represents the current state of a task.
 type taskStatus int
@@ -73,6 +81,9 @@ type ApplyModel struct {
 
 	// Results
 	results *ApplyResults
+
+	// Slog panel (last N log lines from slog)
+	slogLines []slogLine
 
 	// State
 	done  bool

--- a/internal/ui/msg.go
+++ b/internal/ui/msg.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"log/slog"
 	"time"
 
 	"github.com/terassyi/tomei/internal/installer/engine"
@@ -18,3 +19,9 @@ type applyDoneMsg struct {
 
 // tickMsg triggers periodic UI updates (elapsed time, spinner).
 type tickMsg time.Time
+
+// slogMsg delivers a structured log record to the TUI model.
+type slogMsg struct {
+	level   slog.Level
+	message string
+}

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -29,6 +29,9 @@ func (m *ApplyModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case engineEventMsg:
 		return m.handleEngineEvent(msg.event)
 
+	case slogMsg:
+		return m.handleSlogMsg(msg)
+
 	case applyDoneMsg:
 		return m.handleApplyDone(msg)
 	}
@@ -166,6 +169,15 @@ func (m *ApplyModel) handleError(event engine.Event) (tea.Model, tea.Cmd) {
 	m.results.Failed++
 	m.completedOrder = append(m.completedOrder, key)
 
+	return m, nil
+}
+
+// handleSlogMsg appends a slog record to the log panel, keeping at most maxSlogLines.
+func (m *ApplyModel) handleSlogMsg(msg slogMsg) (tea.Model, tea.Cmd) {
+	m.slogLines = append(m.slogLines, slogLine(msg))
+	if len(m.slogLines) > maxSlogLines {
+		m.slogLines = m.slogLines[len(m.slogLines)-maxSlogLines:]
+	}
 	return m, nil
 }
 


### PR DESCRIPTION
Route slog.Warn/Error output into a log panel at the bottom of the
AltScreen TUI instead of writing directly to stderr, which corrupted
the screen rendering. Add --log-level flag (debug/info/warn/error,
default warn) to control which log levels are displayed.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: terashima <iscale821@gmail.com>
