### PR TITLE
feat: add description field to metadata

### DIFF
--- a/docs/cue-schema.md
+++ b/docs/cue-schema.md
@@ -13,8 +13,9 @@ myResource: {
     apiVersion: "tomei.terassyi.net/v1beta1"
     kind:       "<ResourceType>"
     metadata: {
-        name: "<resource-name>"      // lowercase alphanumeric, dots, hyphens, underscores
-        labels?: {[string]: string}  // optional key-value pairs
+        name:         "<resource-name>"      // lowercase alphanumeric, dots, hyphens, underscores
+        description?: string                 // optional human-readable description
+        labels?: {[string]: string}          // optional key-value pairs
     }
     spec: { ... }
 }

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -234,6 +234,48 @@ spec: {
 	}
 }
 
+func TestLoader_LoadFile_WithDescription(t *testing.T) {
+	dir := t.TempDir()
+	cueFile := filepath.Join(dir, "tool.cue")
+
+	content := `
+apiVersion: "tomei.terassyi.net/v1beta1"
+kind: "Tool"
+metadata: {
+    name: "ripgrep"
+    description: "A fast line-oriented search tool"
+    labels: {
+        category: "search"
+    }
+}
+spec: {
+    installerRef: "aqua"
+    version: "14.0.0"
+}
+`
+	if err := os.WriteFile(cueFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	loader := NewLoader(nil)
+	resources, err := loader.LoadFile(cueFile)
+	if err != nil {
+		t.Fatalf("failed to load file: %v", err)
+	}
+
+	res := resources[0]
+	tool, ok := res.(*resource.Tool)
+	if !ok {
+		t.Fatalf("expected *resource.Tool, got %T", res)
+	}
+	if tool.Metadata.Description != "A fast line-oriented search tool" {
+		t.Errorf("expected description 'A fast line-oriented search tool', got %q", tool.Metadata.Description)
+	}
+	if res.Labels()["category"] != "search" {
+		t.Errorf("expected label category=search, got %s", res.Labels()["category"])
+	}
+}
+
 func TestLoader_Load_Directory(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/config/schema/schema.cue
+++ b/internal/config/schema/schema.cue
@@ -24,7 +24,8 @@ _env: {
 #APIVersion: "tomei.terassyi.net/v1beta1"
 
 #Metadata: {
-	name: string & =~"^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$"
+	name:         string & =~"^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$"
+	description?: string
 	labels?: {[string]: string}
 }
 

--- a/internal/config/schema/schema_test.go
+++ b/internal/config/schema/schema_test.go
@@ -252,6 +252,39 @@ func TestSchema_ValidResources(t *testing.T) {
 			}`,
 		},
 		{
+			name: "Tool with metadata description",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "Tool"
+				metadata: {
+					name:        "ripgrep"
+					description: "A fast line-oriented search tool"
+				}
+				spec: {
+					installerRef: "download"
+					version:      "14.0.0"
+				}
+			}`,
+		},
+		{
+			name: "Tool with metadata description and labels",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "Tool"
+				metadata: {
+					name:        "ripgrep"
+					description: "A fast line-oriented search tool"
+					labels: {
+						category: "search"
+					}
+				}
+				spec: {
+					installerRef: "download"
+					version:      "14.0.0"
+				}
+			}`,
+		},
+		{
 			name: "Tool with enabled false",
 			cue: `{
 				apiVersion: "tomei.terassyi.net/v1beta1"

--- a/internal/resource/types.go
+++ b/internal/resource/types.go
@@ -90,8 +90,9 @@ type Expandable interface {
 
 // Metadata holds resource identification information.
 type Metadata struct {
-	Name   string            `json:"name"`
-	Labels map[string]string `json:"labels,omitempty"`
+	Name        string            `json:"name"`
+	Description string            `json:"description,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
 }
 
 // InstallType represents the installation method for resources (Runtime, Installer).


### PR DESCRIPTION
Add an optional description field to resource metadata for
documentation purposes. Update CUE schema, Go struct, docs, and tests.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: terashima <iscale821@gmail.com>
