### PR TITLE
feat: add Rust + cargo-binstall example and build toolchain to examples

### DIFF
--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:24.04
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
+    build-essential \
     vim
 
 RUN useradd -m -s /bin/bash lipnoise

--- a/examples/minimal/rust.cue
+++ b/examples/minimal/rust.cue
@@ -1,0 +1,112 @@
+package tomei
+
+// Rust ecosystem: rustup delegation → cargo-binstall → tools via binstall
+//
+// Dependency chain:
+//   Runtime/rust → Tool/cargo-binstall (cargo install)
+//                → Installer/binstall (delegation, toolRef: cargo-binstall)
+//                    → Tool/eza, Tool/hyperfine (installerRef: binstall)
+//                → Tool/tokei (cargo install, runtimeRef: rust)
+
+// ---------------------------------------------------------------------------
+// Rust Runtime (delegation via rustup)
+// ---------------------------------------------------------------------------
+
+_rustVersion: "stable"
+
+rustRuntime: {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "Runtime"
+	metadata: name: "rust"
+	spec: {
+		type:    "delegation"
+		version: _rustVersion
+		bootstrap: {
+			install:        "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain {{.Version}}"
+			check:          "~/.cargo/bin/rustc --version"
+			remove:         "~/.cargo/bin/rustup self uninstall -y"
+			resolveVersion: "~/.cargo/bin/rustc --version 2>/dev/null | grep -oP '\\d+\\.\\d+\\.\\d+' || echo ''"
+		}
+		binaries: ["rustc", "cargo", "rustup"]
+		binDir:      "~/.cargo/bin"
+		toolBinPath: "~/.cargo/bin"
+		env: {
+			CARGO_HOME:  "~/.cargo"
+			RUSTUP_HOME: "~/.rustup"
+		}
+		commands: {
+			install: "~/.cargo/bin/cargo install {{.Package}}{{if .Version}}@{{.Version}}{{end}}"
+			remove:  "rm -f {{.BinPath}}"
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// cargo-binstall — installed via cargo install, then used as an Installer
+// ---------------------------------------------------------------------------
+
+cargoBinstall: {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "Tool"
+	metadata: name: "cargo-binstall"
+	spec: {
+		runtimeRef: "rust"
+		package:    "cargo-binstall"
+	}
+}
+
+// ---------------------------------------------------------------------------
+// binstall Installer (delegation) — depends on cargo-binstall tool
+// ---------------------------------------------------------------------------
+
+binstallInstaller: {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "Installer"
+	metadata: name: "binstall"
+	spec: {
+		type:    "delegation"
+		toolRef: "cargo-binstall"
+		commands: {
+			install: "~/.cargo/bin/cargo-binstall {{.Package}}{{if .Version}}@{{.Version}}{{end}} --no-confirm"
+			remove:  "rm -f {{.BinPath}}"
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tools installed via binstall (fast pre-built binary downloads)
+// ---------------------------------------------------------------------------
+
+eza: {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "Tool"
+	metadata: name: "eza"
+	spec: {
+		installerRef: "binstall"
+		package:      "eza"
+	}
+}
+
+hyperfine: {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "Tool"
+	metadata: name: "hyperfine"
+	spec: {
+		installerRef: "binstall"
+		package:      "hyperfine"
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tool installed via cargo install (source compilation, runtimeRef)
+// ---------------------------------------------------------------------------
+
+tokei: {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "Tool"
+	metadata: name: "tokei"
+	spec: {
+		runtimeRef: "rust"
+		package:    "tokei"
+	}
+}


### PR DESCRIPTION
Add Rust ecosystem example to examples/minimal/ demonstrating the
rustup delegation → cargo-binstall → binstall installer dependency chain.
Add build-essential to examples/Dockerfile for cargo install compilation.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: terashima <iscale821@gmail.com>
