### PR TITLE
fix: suppress state validation warnings in tomei env

### DIFF
--- a/cmd/tomei/env.go
+++ b/cmd/tomei/env.go
@@ -64,11 +64,12 @@ func runEnv(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to create paths: %w", err)
 	}
 
-	// Load state
+	// Load state (quiet: suppress warnings since stdout is eval'd by shell)
 	store, err := state.NewStore[state.UserState](paths.UserDataDir())
 	if err != nil {
 		return fmt.Errorf("failed to create state store: %w", err)
 	}
+	store.SetQuiet(true)
 
 	if err := store.Lock(); err != nil {
 		return fmt.Errorf("failed to lock state: %w", err)

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -19,6 +19,13 @@ type Store[T State] struct {
 	lockPath  string
 	fileLock  *flock.Flock
 	locked    bool
+	quiet     bool
+}
+
+// SetQuiet suppresses non-fatal validation warnings during Load.
+// Use this for commands whose stdout is consumed programmatically (e.g., tomei env).
+func (s *Store[T]) SetQuiet(q bool) {
+	s.quiet = q
 }
 
 // NewUserStore creates a Store for user state.
@@ -119,7 +126,11 @@ func (s *Store[T]) Load() (*T, error) {
 }
 
 // validate runs type-specific validation on the loaded state and logs warnings.
+// When quiet is true, warnings are suppressed.
 func (s *Store[T]) validate(st *T) {
+	if s.quiet {
+		return
+	}
 	var result *ValidationResult
 	switch v := any(st).(type) {
 	case *UserState:


### PR DESCRIPTION
tomei env output is consumed by eval, so non-fatal WARN logs on stderr
degrade UX. Add Store.SetQuiet() to skip validation warnings, and
enable it in the env command.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: terashima <iscale821@gmail.com>
