### PR TITLE
feat: resolve latest module version from OCI registry in tomei cue init

### DIFF
--- a/cmd/tomei/cue/init.go
+++ b/cmd/tomei/cue/init.go
@@ -1,7 +1,9 @@
 package cue
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -55,8 +57,19 @@ func runInit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
 
+	// Resolve latest module version from OCI registry
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	moduleVersion, err := cuemod.ResolveLatestVersion(ctx)
+	if err != nil {
+		slog.Warn("failed to resolve latest module version, using default", "error", err, "default", cuemod.DefaultModuleVer)
+		moduleVersion = cuemod.DefaultModuleVer
+	}
+
 	// Generate cue.mod/module.cue
-	moduleCue, err := cuemod.GenerateModuleCUE(initModuleName)
+	moduleCue, err := cuemod.GenerateModuleCUE(initModuleName, moduleVersion)
 	if err != nil {
 		return err
 	}

--- a/cmd/tomei/env.go
+++ b/cmd/tomei/env.go
@@ -88,7 +88,7 @@ func runEnv(cmd *cobra.Command, _ []string) error {
 	// Add CUE_REGISTRY if cue.mod/ exists and CUE_REGISTRY is not already set.
 	// Respecting an existing CUE_REGISTRY avoids overwriting user-configured
 	// registry mappings (e.g., private registries or additional mappings).
-	if _, exists := os.LookupEnv("CUE_REGISTRY"); !exists {
+	if _, exists := os.LookupEnv(config.EnvCUERegistry); !exists {
 		cwd, err := os.Getwd()
 		if err == nil {
 			if cueRegistryLine := env.GenerateCUERegistry(

--- a/e2e/cue_ecosystem_test.go
+++ b/e2e/cue_ecosystem_test.go
@@ -93,6 +93,25 @@ func cueEcosystemTests() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(content).To(ContainSubstring(`module: "myproject@v0"`))
 		})
+
+		It("resolves module version from OCI registry", func() {
+			dir := "~/cue-ecosystem-test/init-registry-version"
+			_, err := testExec.ExecBash("mkdir -p " + dir)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Running tomei cue init (should query ghcr.io for latest version)")
+			output, err := testExec.ExecBash("tomei cue init " + dir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(ContainSubstring("module.cue"))
+
+			By("Verifying module.cue contains a version resolved from the registry")
+			content, err := testExec.ExecBash("cat " + dir + "/cue.mod/module.cue")
+			Expect(err).NotTo(HaveOccurred())
+			// The version should be a real semver from the registry, not the hardcoded default.
+			// At minimum v0.0.1 is published, but the registry may have newer versions.
+			Expect(content).To(MatchRegexp(`v: "v0\.\d+\.\d+"`))
+			Expect(content).To(ContainSubstring(`"tomei.terassyi.net@v0"`))
+		})
 	})
 
 	Context("tomei env with cue.mod", func() {

--- a/e2e/scenario.md
+++ b/e2e/scenario.md
@@ -23,7 +23,7 @@ This document describes the scenarios verified by tomei's E2E tests.
 | Delegation Runtime | 9 | Rust runtime installation via delegation, cargo install tool, idempotency |
 | Installer Repository | 13 | Helm repository management via delegation, dependency chain (InstallerRepository → Tool), removal |
 | Dependency Resolution | 15 | Circular dependency detection, parallel installation, --parallel flag, dependency chains, toolRef chain |
-| CUE Ecosystem | 7 | tomei cue init, env CUE_REGISTRY, validate with cue.mod |
+| CUE Ecosystem | 8 | tomei cue init, env CUE_REGISTRY, validate with cue.mod |
 
 ## Scenario Flow
 
@@ -969,6 +969,13 @@ Reduced manifest for removal test:
 #### Custom Module Name
 1. Run `tomei cue init --module-name myproject@v0 <dir>`
 2. Verify `cue.mod/module.cue` contains `module: "myproject@v0"`
+
+#### Resolves Module Version from OCI Registry
+1. Create a target directory
+2. Run `tomei cue init <dir>` (queries ghcr.io for latest version)
+3. Verify `cue.mod/module.cue`:
+   - Contains `"tomei.terassyi.net@v0"`
+   - Dependency version matches `v: "v0.\d+.\d+"` (resolved from registry, not hardcoded)
 
 ### 6.2 `tomei env` with CUE Module
 

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/vbauerster/mpb/v8 v8.11.3
+	golang.org/x/mod v0.32.0
 	golang.org/x/sync v0.19.0
 	pgregory.net/rapid v1.2.0
 )
@@ -76,7 +77,6 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.47.0 // indirect
-	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/oauth2 v0.32.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -28,6 +28,9 @@ const (
 	// CUELanguageVersion is the CUE language version used by the tomei module.
 	CUELanguageVersion = "v0.9.0"
 
+	// EnvCUERegistry is the environment variable name for the CUE registry.
+	EnvCUERegistry = "CUE_REGISTRY"
+
 	// DefaultCUERegistry is the built-in CUE_REGISTRY mapping for tomei modules.
 	// When CUE_REGISTRY is not set, this default is used to resolve
 	// tomei.terassyi.net imports from the OCI registry on ghcr.io.
@@ -63,7 +66,7 @@ func NewLoader(env *Env) *Loader {
 // It uses the CUE_REGISTRY environment variable if set, otherwise falls back
 // to the built-in default (tomei.terassyi.net=ghcr.io/terassyi).
 func buildRegistry() (modconfig.Registry, error) {
-	cueRegistry := os.Getenv("CUE_REGISTRY")
+	cueRegistry := os.Getenv(EnvCUERegistry)
 	if cueRegistry == "" {
 		cueRegistry = DefaultCUERegistry
 	}

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -1078,9 +1078,9 @@ func TestBuildRegistry(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.cueRegistry != "" {
-				t.Setenv("CUE_REGISTRY", tt.cueRegistry)
+				t.Setenv(EnvCUERegistry, tt.cueRegistry)
 			} else {
-				t.Setenv("CUE_REGISTRY", "")
+				t.Setenv(EnvCUERegistry, "")
 			}
 
 			registry, err := buildRegistry()

--- a/internal/cuemod/init.go
+++ b/internal/cuemod/init.go
@@ -2,13 +2,18 @@ package cuemod
 
 import (
 	"bytes"
+	"context"
 	_ "embed"
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"text/template"
 
+	"cuelang.org/go/mod/modconfig"
+	"cuelang.org/go/mod/modregistry"
 	"github.com/terassyi/tomei/internal/config"
+	"golang.org/x/mod/semver"
 )
 
 //go:embed templates/module.cue.tmpl
@@ -31,7 +36,8 @@ type ModuleParams struct {
 }
 
 // GenerateModuleCUE generates the cue.mod/module.cue content from the embedded template.
-func GenerateModuleCUE(moduleName string) ([]byte, error) {
+// moduleVersion specifies the tomei module version to depend on (e.g. "v0.0.1").
+func GenerateModuleCUE(moduleName, moduleVersion string) ([]byte, error) {
 	tmpl, err := template.New("module").Parse(moduleTmpl)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse module template: %w", err)
@@ -40,13 +46,41 @@ func GenerateModuleCUE(moduleName string) ([]byte, error) {
 		ModuleName:      moduleName,
 		LanguageVersion: config.CUELanguageVersion,
 		TomeiModulePath: config.TomeiModulePath,
-		ModuleVersion:   DefaultModuleVer,
+		ModuleVersion:   moduleVersion,
 	}
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, params); err != nil {
 		return nil, fmt.Errorf("failed to execute module template: %w", err)
 	}
 	return buf.Bytes(), nil
+}
+
+// ResolveLatestVersion queries the OCI registry for the latest published
+// version of the tomei module (tomei.terassyi.net).
+func ResolveLatestVersion(ctx context.Context) (string, error) {
+	cueRegistry := os.Getenv(config.EnvCUERegistry)
+	if cueRegistry == "" {
+		cueRegistry = config.DefaultCUERegistry
+	}
+
+	resolver, err := modconfig.NewResolver(&modconfig.Config{
+		CUERegistry: cueRegistry,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to create registry resolver: %w", err)
+	}
+
+	client := modregistry.NewClientWithResolver(resolver)
+	versions, err := client.ModuleVersions(ctx, "tomei.terassyi.net")
+	if err != nil {
+		return "", fmt.Errorf("failed to query module versions: %w", err)
+	}
+	if len(versions) == 0 {
+		return "", fmt.Errorf("no published versions found for tomei.terassyi.net")
+	}
+
+	slices.SortFunc(versions, semver.Compare)
+	return versions[len(versions)-1], nil
 }
 
 // GeneratePlatformCUE generates the tomei_platform.cue content from the embedded template.

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/terassyi/tomei/internal/config"
 	"github.com/terassyi/tomei/internal/resource"
 )
 
@@ -65,7 +66,7 @@ func GenerateCUERegistry(cueModExists bool, cueRegistry string, f Formatter) str
 	if !cueModExists || cueRegistry == "" {
 		return ""
 	}
-	return f.ExportVar("CUE_REGISTRY", cueRegistry)
+	return f.ExportVar(config.EnvCUERegistry, cueRegistry)
 }
 
 // toShellPath converts an absolute path under $HOME to $HOME/... form for shell portability.


### PR DESCRIPTION
- Add ResolveLatestVersion() that queries the OCI registry for published
  versions and returns the highest semver using golang.org/x/mod/semver
- Update GenerateModuleCUE() to accept moduleVersion parameter
- Add EnvCUERegistry constant and replace all string literals
- Fallback to DefaultModuleVer with warning when registry is unreachable
- Add unit tests with mock registry (modregistrytest)
- Add integration tests for multi-version resolution and end-to-end flow
- Add E2E test verifying registry version resolution
- Update scenario.md with new test scenario

Signed-off-by: terashima <iscale821@gmail.com>
Signed-off-by: Claude Code <noreply@anthropic.com>
