### PR TITLE
test: add t.Parallel() to all unit tests for parallel execution

### DIFF
--- a/internal/checksum/checksum_test.go
+++ b/internal/checksum/checksum_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestParse(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name          string
 		value         string
@@ -50,6 +52,8 @@ func TestParse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			alg, hash, err := Parse(tt.value)
 
 			if tt.wantErr {
@@ -65,6 +69,8 @@ func TestParse(t *testing.T) {
 }
 
 func TestExtractHash(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		checksum *resource.Checksum
@@ -105,6 +111,8 @@ func TestExtractHash(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := ExtractHash(tt.checksum)
 			assert.Equal(t, tt.want, got)
 		})
@@ -112,6 +120,8 @@ func TestExtractHash(t *testing.T) {
 }
 
 func TestCalculate(t *testing.T) {
+	t.Parallel()
+
 	content := []byte("hello world")
 	expectedSHA256 := fmt.Sprintf("%x", sha256.Sum256(content))
 	expectedSHA512 := fmt.Sprintf("%x", sha512.Sum512(content))
@@ -148,6 +158,8 @@ func TestCalculate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got, err := Calculate(filePath, tt.algorithm)
 
 			if tt.wantErr {
@@ -162,6 +174,8 @@ func TestCalculate(t *testing.T) {
 }
 
 func TestCalculateFromReader(t *testing.T) {
+	t.Parallel()
+
 	content := []byte("hello world")
 	expectedSHA256 := fmt.Sprintf("%x", sha256.Sum256(content))
 
@@ -171,6 +185,8 @@ func TestCalculateFromReader(t *testing.T) {
 }
 
 func TestVerify(t *testing.T) {
+	t.Parallel()
+
 	content := []byte("hello world")
 	expectedSHA256 := fmt.Sprintf("%x", sha256.Sum256(content))
 
@@ -201,6 +217,8 @@ func TestVerify(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			err := Verify(filePath, tt.algorithm, tt.hash)
 
 			if tt.wantErr {
@@ -214,6 +232,8 @@ func TestVerify(t *testing.T) {
 }
 
 func TestDetectAlgorithm(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		hash string
@@ -238,6 +258,8 @@ func TestDetectAlgorithm(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := DetectAlgorithm(tt.hash)
 			assert.Equal(t, tt.want, got)
 		})

--- a/internal/checksum/file_test.go
+++ b/internal/checksum/file_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestDetectFileFormat(t *testing.T) {
+	t.Parallel()
+
 	sha256Hash := "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
 
 	tests := []struct {
@@ -69,6 +71,8 @@ func TestDetectFileFormat(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := DetectFileFormat(tt.content)
 			assert.Equal(t, tt.want, got)
 		})
@@ -76,6 +80,8 @@ func TestDetectFileFormat(t *testing.T) {
 }
 
 func TestParseFile_GNU(t *testing.T) {
+	t.Parallel()
+
 	sha256Hash := "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
 
 	tests := []struct {
@@ -134,6 +140,8 @@ func TestParseFile_GNU(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			algo, hash, err := ParseFile(tt.content, tt.filename)
 
 			if tt.wantErr {
@@ -152,6 +160,8 @@ func TestParseFile_GNU(t *testing.T) {
 }
 
 func TestParseFile_BSD(t *testing.T) {
+	t.Parallel()
+
 	sha256Hash := "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
 	sha512Hash := "309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f"
 
@@ -211,6 +221,8 @@ func TestParseFile_BSD(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			algo, hash, err := ParseFile(tt.content, tt.filename)
 
 			if tt.wantErr {
@@ -229,6 +241,8 @@ func TestParseFile_BSD(t *testing.T) {
 }
 
 func TestParseFile_GoJSON(t *testing.T) {
+	t.Parallel()
+
 	sha256Hash := "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
 
 	tests := []struct {
@@ -314,6 +328,8 @@ func TestParseFile_GoJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			algo, hash, err := ParseFile(tt.content, tt.filename)
 
 			if tt.wantErr {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,12 +10,16 @@ import (
 )
 
 func TestDefaultConfig(t *testing.T) {
+	t.Parallel()
+
 	cfg := DefaultConfig()
 	assert.Equal(t, DefaultDataDir, cfg.DataDir)
 	assert.Equal(t, DefaultBinDir, cfg.BinDir)
 }
 
 func TestLoadConfig_NoConfigFile(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 
 	cfg, err := LoadConfig(tmpDir)
@@ -27,6 +31,8 @@ func TestLoadConfig_NoConfigFile(t *testing.T) {
 }
 
 func TestLoadConfig_WithConfigFile(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.cue")
 
@@ -48,6 +54,8 @@ config: {
 }
 
 func TestLoadConfig_PartialConfig(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.cue")
 
@@ -70,6 +78,8 @@ config: {
 }
 
 func TestLoadConfig_NoConfigBlock(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.cue")
 
@@ -90,6 +100,8 @@ somethingElse: "value"
 }
 
 func TestLoadConfig_InvalidCue(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.cue")
 
@@ -107,6 +119,8 @@ config: {
 }
 
 func TestConfig_ToCue(t *testing.T) {
+	t.Parallel()
+
 	cfg := &Config{
 		DataDir: "~/my-data",
 		BinDir:  "~/my-bin",
@@ -128,6 +142,8 @@ func TestConfig_ToCue(t *testing.T) {
 }
 
 func TestConfig_ToCue_RoundTrip(t *testing.T) {
+	t.Parallel()
+
 	// Generate CUE from default config
 	cfg := DefaultConfig()
 	cueBytes, err := cfg.ToCue()

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -22,6 +22,8 @@ func setupMinimalCueMod(t *testing.T, dir string) {
 }
 
 func TestLoader_LoadFile_Tool(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	cueFile := filepath.Join(dir, "tool.cue")
 
@@ -76,6 +78,8 @@ spec: {
 }
 
 func TestLoader_LoadFile_ToolSet(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	cueFile := filepath.Join(dir, "toolset.cue")
 
@@ -123,6 +127,8 @@ spec: {
 }
 
 func TestLoader_LoadFile_Runtime(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	cueFile := filepath.Join(dir, "runtime.cue")
 
@@ -172,6 +178,8 @@ spec: {
 }
 
 func TestLoader_LoadFile_SystemPackageSet(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	cueFile := filepath.Join(dir, "syspkg.cue")
 
@@ -209,6 +217,8 @@ spec: {
 }
 
 func TestLoader_LoadFile_WithLabels(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	cueFile := filepath.Join(dir, "tool.cue")
 
@@ -248,6 +258,8 @@ spec: {
 }
 
 func TestLoader_LoadFile_WithDescription(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	cueFile := filepath.Join(dir, "tool.cue")
 
@@ -290,6 +302,8 @@ spec: {
 }
 
 func TestLoader_Load_Directory(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	setupMinimalCueMod(t, dir)
 
@@ -321,6 +335,8 @@ spec: {
 }
 
 func TestEnv_Detect(t *testing.T) {
+	t.Parallel()
+
 	env := DetectEnv()
 
 	// Basic sanity checks
@@ -333,6 +349,8 @@ func TestEnv_Detect(t *testing.T) {
 }
 
 func TestLoader_Tag_StringInterpolation(t *testing.T) {
+	t.Parallel()
+
 	content := `package tomei
 
 _os:   string @tag(os)
@@ -370,6 +388,8 @@ gh: {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			dir := t.TempDir()
 			setupMinimalCueMod(t, dir)
 			if err := os.WriteFile(filepath.Join(dir, "tool.cue"), []byte(content), 0644); err != nil {
@@ -391,6 +411,8 @@ gh: {
 }
 
 func TestLoader_Tag_RuntimeURL(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	setupMinimalCueMod(t, dir)
 
@@ -433,6 +455,8 @@ goRuntime: {
 }
 
 func TestLoader_Tag_Headless(t *testing.T) {
+	t.Parallel()
+
 	content := `package tomei
 
 _headless: bool @tag(headless,type=bool)
@@ -464,6 +488,8 @@ testTool: {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			dir := t.TempDir()
 			setupMinimalCueMod(t, dir)
 			if err := os.WriteFile(filepath.Join(dir, "tool.cue"), []byte(content), 0644); err != nil {
@@ -485,6 +511,8 @@ testTool: {
 }
 
 func TestLoader_Tag_DirectoryLoad(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	setupMinimalCueMod(t, dir)
 
@@ -530,6 +558,8 @@ tool: {
 }
 
 func TestLoader_LoadFile_InstallerRepository_Delegation(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	cueFile := filepath.Join(dir, "repo.cue")
 
@@ -587,6 +617,8 @@ spec: {
 }
 
 func TestLoader_LoadFile_InstallerRepository_Git(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	cueFile := filepath.Join(dir, "repo.cue")
 
@@ -629,6 +661,8 @@ spec: {
 }
 
 func TestLoader_SchemaValidation_RejectsInvalid(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		content string
@@ -716,6 +750,8 @@ spec: {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			dir := t.TempDir()
 			cueFile := filepath.Join(dir, "test.cue")
 			if err := os.WriteFile(cueFile, []byte(tt.content), 0644); err != nil {
@@ -732,6 +768,8 @@ spec: {
 }
 
 func TestLoader_SchemaValidation_DirectoryMode(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	setupMinimalCueMod(t, dir)
 
@@ -771,6 +809,8 @@ gh: {
 }
 
 func TestLoader_SchemaValidation_DirectoryRejectsInvalid(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	setupMinimalCueMod(t, dir)
 
@@ -803,6 +843,8 @@ tool: {
 }
 
 func TestLoader_Load_NoImports_StillWorks(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	setupMinimalCueMod(t, dir)
 
@@ -841,6 +883,8 @@ tool: {
 }
 
 func TestLoader_Tag_NotAvailableWithoutPackage(t *testing.T) {
+	t.Parallel()
+
 	// @tag() requires load.Instances() which needs a package declaration.
 	// Without a package, CompileString is used and tags are not resolved.
 	// When a tag value is used in string interpolation, it fails because
@@ -876,6 +920,8 @@ spec: {
 }
 
 func TestLoader_Tag_MultipleFilesShareTags(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	setupMinimalCueMod(t, dir)
 
@@ -953,6 +999,8 @@ goRuntime: {
 }
 
 func TestLoader_Tag_ConstrainedValues(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	setupMinimalCueMod(t, dir)
 
@@ -990,6 +1038,8 @@ tool: {
 }
 
 func TestLoader_SchemaValidation_NoSchemaInjection(t *testing.T) {
+	t.Parallel()
+
 	// Verify that #Resource definition is NOT injected into user CUE files.
 	// Schema validation uses the internally compiled schema instead.
 	dir := t.TempDir()
@@ -1027,6 +1077,8 @@ tool: {
 }
 
 func TestLoader_SchemaValidation_WorksWithoutPackage(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	cueFile := filepath.Join(dir, "tool.cue")
 

--- a/internal/config/loader_unit_test.go
+++ b/internal/config/loader_unit_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestScanDeclaredTags(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		sources []string
@@ -108,6 +110,8 @@ _arch: string @tag(arch)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := scanDeclaredTags(tt.sources...)
 			assert.Equal(t, tt.want, got)
 		})
@@ -115,6 +119,8 @@ _arch: string @tag(arch)
 }
 
 func TestDetectPackageName(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name   string
 		source string
@@ -159,6 +165,8 @@ func TestDetectPackageName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := detectPackageName(tt.source)
 			assert.Equal(t, tt.want, got)
 		})
@@ -166,6 +174,8 @@ func TestDetectPackageName(t *testing.T) {
 }
 
 func TestEnvTagsForSources(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		env     *Env
@@ -233,6 +243,8 @@ _headless: bool   @tag(headless,type=bool)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			loader := &Loader{env: tt.env}
 			got := loader.envTagsForSources(tt.sources...)
 			require.Equal(t, tt.want, got)

--- a/internal/config/tag_import_test.go
+++ b/internal/config/tag_import_test.go
@@ -22,6 +22,8 @@ import (
 //   - Imported packages cannot use @tag() to receive values from the caller.
 //   - Therefore, presets that need platform info accept explicit parameters.
 func TestTagImportBehavior(t *testing.T) {
+	t.Parallel()
+
 	// Build an in-memory registry module "example.com@v0" with a package
 	// "mypkg" that declares `_os: string @tag(os)`.
 	registryFS := fstest.MapFS{

--- a/internal/cuemod/init_test.go
+++ b/internal/cuemod/init_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestGenerateModuleCUE_TableDriven(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		moduleName    string
@@ -64,6 +65,7 @@ func TestGenerateModuleCUE_TableDriven(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			content, err := GenerateModuleCUE(tt.moduleName, tt.moduleVersion)
 			require.NoError(t, err)
 			for _, want := range tt.wantContains {
@@ -74,6 +76,7 @@ func TestGenerateModuleCUE_TableDriven(t *testing.T) {
 }
 
 func TestGeneratePlatformCUE_TableDriven(t *testing.T) {
+	t.Parallel()
 	content, err := GeneratePlatformCUE()
 	require.NoError(t, err)
 
@@ -90,6 +93,7 @@ func TestGeneratePlatformCUE_TableDriven(t *testing.T) {
 }
 
 func TestRelativePath(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		base   string
@@ -124,6 +128,7 @@ func TestRelativePath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := RelativePath(tt.base, tt.target)
 			assert.Equal(t, tt.want, got)
 		})
@@ -191,6 +196,7 @@ func TestResolveLatestVersion(t *testing.T) {
 }
 
 func TestWriteFileIfAllowed(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		setup     func(t *testing.T, dir string)
@@ -230,6 +236,7 @@ func TestWriteFileIfAllowed(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			dir := t.TempDir()
 			tt.setup(t, dir)
 

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestNew(t *testing.T) {
+	t.Parallel()
+
 	paths, err := path.New()
 	require.NoError(t, err)
 
@@ -29,7 +31,11 @@ func TestNew(t *testing.T) {
 }
 
 func TestDoctor_ScanForUnmanaged(t *testing.T) {
+	t.Parallel()
+
 	t.Run("detects unmanaged tools", func(t *testing.T) {
+		t.Parallel()
+
 		// Setup temp directories
 		tmpDir := t.TempDir()
 		binDir := filepath.Join(tmpDir, "bin")
@@ -58,6 +64,8 @@ func TestDoctor_ScanForUnmanaged(t *testing.T) {
 	})
 
 	t.Run("does not detect managed tools", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		binDir := filepath.Join(tmpDir, "bin")
 		require.NoError(t, os.MkdirAll(binDir, 0755))
@@ -88,6 +96,8 @@ func TestDoctor_ScanForUnmanaged(t *testing.T) {
 	})
 
 	t.Run("empty directory", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		binDir := filepath.Join(tmpDir, "bin")
 		require.NoError(t, os.MkdirAll(binDir, 0755))
@@ -106,6 +116,8 @@ func TestDoctor_ScanForUnmanaged(t *testing.T) {
 	})
 
 	t.Run("skips hidden files", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		binDir := filepath.Join(tmpDir, "bin")
 		require.NoError(t, os.MkdirAll(binDir, 0755))
@@ -128,6 +140,8 @@ func TestDoctor_ScanForUnmanaged(t *testing.T) {
 	})
 
 	t.Run("scans runtime toolBinPath", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		binDir := filepath.Join(tmpDir, "bin")
 		goBinDir := filepath.Join(tmpDir, "go", "bin")
@@ -162,6 +176,8 @@ func TestDoctor_ScanForUnmanaged(t *testing.T) {
 	})
 
 	t.Run("does not detect runtime delegation tools", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		binDir := filepath.Join(tmpDir, "bin")
 		goBinDir := filepath.Join(tmpDir, "go", "bin")
@@ -200,7 +216,11 @@ func TestDoctor_ScanForUnmanaged(t *testing.T) {
 }
 
 func TestDoctor_DetectConflicts(t *testing.T) {
+	t.Parallel()
+
 	t.Run("detects conflicts", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		binDir := filepath.Join(tmpDir, "bin")
 		goBinDir := filepath.Join(tmpDir, "go", "bin")
@@ -234,6 +254,8 @@ func TestDoctor_DetectConflicts(t *testing.T) {
 	})
 
 	t.Run("no conflicts when unique", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		binDir := filepath.Join(tmpDir, "bin")
 		goBinDir := filepath.Join(tmpDir, "go", "bin")
@@ -266,7 +288,11 @@ func TestDoctor_DetectConflicts(t *testing.T) {
 }
 
 func TestDoctor_CheckStateIntegrity(t *testing.T) {
+	t.Parallel()
+
 	t.Run("detects missing binary", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		binDir := filepath.Join(tmpDir, "bin")
 		require.NoError(t, os.MkdirAll(binDir, 0755))
@@ -295,6 +321,8 @@ func TestDoctor_CheckStateIntegrity(t *testing.T) {
 	})
 
 	t.Run("detects broken symlink", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		binDir := filepath.Join(tmpDir, "bin")
 		require.NoError(t, os.MkdirAll(binDir, 0755))
@@ -326,6 +354,8 @@ func TestDoctor_CheckStateIntegrity(t *testing.T) {
 	})
 
 	t.Run("no issues when healthy", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		binDir := filepath.Join(tmpDir, "bin")
 		toolDir := filepath.Join(tmpDir, "tools", "mytool", "1.0.0")
@@ -363,7 +393,11 @@ func TestDoctor_CheckStateIntegrity(t *testing.T) {
 }
 
 func TestDoctor_Check(t *testing.T) {
+	t.Parallel()
+
 	t.Run("full check with no issues", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		binDir := filepath.Join(tmpDir, "bin")
 		require.NoError(t, os.MkdirAll(binDir, 0755))
@@ -383,7 +417,11 @@ func TestDoctor_Check(t *testing.T) {
 }
 
 func TestResult_HasIssues(t *testing.T) {
+	t.Parallel()
+
 	t.Run("no issues", func(t *testing.T) {
+		t.Parallel()
+
 		result := &Result{
 			UnmanagedTools: make(map[string][]UnmanagedTool),
 		}
@@ -391,6 +429,8 @@ func TestResult_HasIssues(t *testing.T) {
 	})
 
 	t.Run("has unmanaged tools", func(t *testing.T) {
+		t.Parallel()
+
 		result := &Result{
 			UnmanagedTools: map[string][]UnmanagedTool{
 				"tomei": {{Name: "tool", Path: "/path"}},
@@ -400,6 +440,8 @@ func TestResult_HasIssues(t *testing.T) {
 	})
 
 	t.Run("has conflicts", func(t *testing.T) {
+		t.Parallel()
+
 		result := &Result{
 			UnmanagedTools: make(map[string][]UnmanagedTool),
 			Conflicts:      []Conflict{{Name: "tool"}},
@@ -408,6 +450,8 @@ func TestResult_HasIssues(t *testing.T) {
 	})
 
 	t.Run("has state issues", func(t *testing.T) {
+		t.Parallel()
+
 		result := &Result{
 			UnmanagedTools: make(map[string][]UnmanagedTool),
 			StateIssues:    []StateIssue{{Kind: StateIssueMissingBinary}},
@@ -417,6 +461,8 @@ func TestResult_HasIssues(t *testing.T) {
 }
 
 func TestResult_UnmanagedToolNames(t *testing.T) {
+	t.Parallel()
+
 	result := &Result{
 		UnmanagedTools: map[string][]UnmanagedTool{
 			"tomei": {{Name: "tool1", Path: "/path1"}},
@@ -431,7 +477,11 @@ func TestResult_UnmanagedToolNames(t *testing.T) {
 }
 
 func TestDoctor_IsRuntimeBinary(t *testing.T) {
+	t.Parallel()
+
 	t.Run("returns true for runtime binaries of specific runtime", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		binDir := filepath.Join(tmpDir, "bin")
 		require.NoError(t, os.MkdirAll(binDir, 0755))
@@ -457,6 +507,8 @@ func TestDoctor_IsRuntimeBinary(t *testing.T) {
 	})
 
 	t.Run("returns false for nil state", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		binDir := filepath.Join(tmpDir, "bin")
 		require.NoError(t, os.MkdirAll(binDir, 0755))
@@ -470,6 +522,8 @@ func TestDoctor_IsRuntimeBinary(t *testing.T) {
 	})
 
 	t.Run("does not report runtime binaries as unmanaged in runtime BinDir", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		binDir := filepath.Join(tmpDir, "bin")
 		goBinDir := filepath.Join(tmpDir, "go", "bin")

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestGenerate(t *testing.T) {
+	t.Parallel()
+
 	home, _ := os.UserHomeDir()
 	userBinDir := home + "/.local/bin"
 
@@ -128,6 +130,8 @@ func TestGenerate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			f := NewFormatter(tt.shell)
 			lines := Generate(tt.runtimes, userBinDir, f)
 			output := joinLines(lines)
@@ -143,6 +147,8 @@ func TestGenerate(t *testing.T) {
 }
 
 func TestToShellPath(t *testing.T) {
+	t.Parallel()
+
 	home, _ := os.UserHomeDir()
 
 	tests := []struct {
@@ -179,6 +185,8 @@ func TestToShellPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := toShellPath(tt.input)
 			assert.Equal(t, tt.want, got)
 		})
@@ -186,6 +194,8 @@ func TestToShellPath(t *testing.T) {
 }
 
 func TestDedupStrings(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name  string
 		input []string
@@ -220,6 +230,8 @@ func TestDedupStrings(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := dedupStrings(tt.input)
 			assert.Equal(t, tt.want, got)
 		})
@@ -227,6 +239,8 @@ func TestDedupStrings(t *testing.T) {
 }
 
 func TestGenerateCUERegistry(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name         string
 		cueModExists bool
@@ -266,6 +280,8 @@ func TestGenerateCUERegistry(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			f := NewFormatter(tt.shell)
 			got := GenerateCUERegistry(tt.cueModExists, tt.cueRegistry, f)
 			assert.Equal(t, tt.want, got)

--- a/internal/env/shell_test.go
+++ b/internal/env/shell_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestParseShellType(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		input   string
@@ -53,6 +55,8 @@ func TestParseShellType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got, err := ParseShellType(tt.input)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -66,42 +70,60 @@ func TestParseShellType(t *testing.T) {
 }
 
 func TestPosixFormatter(t *testing.T) {
+	t.Parallel()
+
 	f := posixFormatter{}
 
 	t.Run("ExportVar", func(t *testing.T) {
+		t.Parallel()
+
 		got := f.ExportVar("GOROOT", "$HOME/.local/share/tomei/runtimes/go/1.25.6")
 		assert.Equal(t, `export GOROOT="$HOME/.local/share/tomei/runtimes/go/1.25.6"`, got)
 	})
 
 	t.Run("ExportPath", func(t *testing.T) {
+		t.Parallel()
+
 		got := f.ExportPath([]string{"$HOME/.local/bin", "$HOME/go/bin"})
 		assert.Equal(t, `export PATH="$HOME/.local/bin:$HOME/go/bin:$PATH"`, got)
 	})
 
 	t.Run("Ext", func(t *testing.T) {
+		t.Parallel()
+
 		assert.Equal(t, ".sh", f.Ext())
 	})
 }
 
 func TestFishFormatter(t *testing.T) {
+	t.Parallel()
+
 	f := fishFormatter{}
 
 	t.Run("ExportVar", func(t *testing.T) {
+		t.Parallel()
+
 		got := f.ExportVar("GOROOT", "$HOME/.local/share/tomei/runtimes/go/1.25.6")
 		assert.Equal(t, `set -gx GOROOT "$HOME/.local/share/tomei/runtimes/go/1.25.6"`, got)
 	})
 
 	t.Run("ExportPath", func(t *testing.T) {
+		t.Parallel()
+
 		got := f.ExportPath([]string{"$HOME/.local/bin", "$HOME/go/bin"})
 		assert.Equal(t, `fish_add_path "$HOME/.local/bin" "$HOME/go/bin"`, got)
 	})
 
 	t.Run("Ext", func(t *testing.T) {
+		t.Parallel()
+
 		assert.Equal(t, ".fish", f.Ext())
 	})
 }
 
 func TestNewFormatter(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		shellType ShellType
@@ -121,6 +143,8 @@ func TestNewFormatter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			f := NewFormatter(tt.shellType)
 			assert.Equal(t, tt.wantType, f.Ext())
 		})

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestError_Error(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		err      *Error
@@ -38,12 +40,16 @@ func TestError_Error(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			assert.Equal(t, tt.expected, tt.err.Error())
 		})
 	}
 }
 
 func TestError_Unwrap(t *testing.T) {
+	t.Parallel()
+
 	cause := errors.New("underlying error")
 	err := &Error{
 		Category: CategoryInstall,
@@ -56,6 +62,8 @@ func TestError_Unwrap(t *testing.T) {
 }
 
 func TestError_WithMethods(t *testing.T) {
+	t.Parallel()
+
 	err := New(CategoryConfig, "test error")
 
 	_ = err.WithHint("try this").
@@ -68,7 +76,11 @@ func TestError_WithMethods(t *testing.T) {
 }
 
 func TestDependencyError(t *testing.T) {
+	t.Parallel()
+
 	t.Run("cycle error", func(t *testing.T) {
+		t.Parallel()
+
 		cycle := []string{"A", "B", "C", "A"}
 		err := NewCycleError(cycle)
 
@@ -79,6 +91,8 @@ func TestDependencyError(t *testing.T) {
 	})
 
 	t.Run("missing dependency error", func(t *testing.T) {
+		t.Parallel()
+
 		err := NewMissingDependencyError("Tool/gopls", []string{"Runtime/go"})
 
 		assert.False(t, err.IsCycle())
@@ -88,6 +102,8 @@ func TestDependencyError(t *testing.T) {
 	})
 
 	t.Run("unwrap", func(t *testing.T) {
+		t.Parallel()
+
 		cause := errors.New("original error")
 		err := &DependencyError{
 			Base: Error{
@@ -103,7 +119,11 @@ func TestDependencyError(t *testing.T) {
 }
 
 func TestConfigError(t *testing.T) {
+	t.Parallel()
+
 	t.Run("basic", func(t *testing.T) {
+		t.Parallel()
+
 		cause := errors.New("syntax error")
 		err := NewConfigError("failed to load config", cause)
 
@@ -112,6 +132,8 @@ func TestConfigError(t *testing.T) {
 	})
 
 	t.Run("with location", func(t *testing.T) {
+		t.Parallel()
+
 		err := NewConfigErrorAt("config.cue", 10, 5, "invalid field", nil)
 
 		assert.Equal(t, "config.cue", err.File)
@@ -120,6 +142,8 @@ func TestConfigError(t *testing.T) {
 	})
 
 	t.Run("with methods", func(t *testing.T) {
+		t.Parallel()
+
 		err := NewConfigError("error", nil).
 			WithFile("test.cue").
 			WithLocation(15, 3).
@@ -133,6 +157,8 @@ func TestConfigError(t *testing.T) {
 }
 
 func TestValidationError(t *testing.T) {
+	t.Parallel()
+
 	err := NewValidationError("Tool/rg", "version", "string", "number")
 
 	assert.Equal(t, CodeValidationFailed, err.Base.Code)
@@ -143,6 +169,8 @@ func TestValidationError(t *testing.T) {
 }
 
 func TestInstallError(t *testing.T) {
+	t.Parallel()
+
 	cause := errors.New("download failed")
 	err := NewInstallError("Tool/gh", "install", cause).
 		WithVersion("2.86.0").
@@ -157,6 +185,8 @@ func TestInstallError(t *testing.T) {
 }
 
 func TestChecksumError(t *testing.T) {
+	t.Parallel()
+
 	err := NewChecksumError("Tool/rg", "https://example.com/rg.tar.gz", "sha256:abc", "sha256:def")
 
 	assert.Equal(t, CodeChecksumMismatch, err.Base.Code)
@@ -167,7 +197,11 @@ func TestChecksumError(t *testing.T) {
 }
 
 func TestNetworkError(t *testing.T) {
+	t.Parallel()
+
 	t.Run("basic", func(t *testing.T) {
+		t.Parallel()
+
 		cause := errors.New("connection refused")
 		err := NewNetworkError("https://example.com", cause)
 
@@ -177,6 +211,8 @@ func TestNetworkError(t *testing.T) {
 	})
 
 	t.Run("HTTP error", func(t *testing.T) {
+		t.Parallel()
+
 		err := NewHTTPError("https://example.com/file.tar.gz", 404)
 
 		assert.Equal(t, CodeHTTPError, err.Base.Code)
@@ -186,7 +222,11 @@ func TestNetworkError(t *testing.T) {
 }
 
 func TestStateError(t *testing.T) {
+	t.Parallel()
+
 	t.Run("basic", func(t *testing.T) {
+		t.Parallel()
+
 		cause := errors.New("file not found")
 		err := NewStateError("failed to load state", cause)
 
@@ -195,6 +235,8 @@ func TestStateError(t *testing.T) {
 	})
 
 	t.Run("lock error", func(t *testing.T) {
+		t.Parallel()
+
 		err := NewLockError("/tmp/state.lock", 12345)
 
 		assert.Equal(t, CodeStateLocked, err.Base.Code)
@@ -205,6 +247,8 @@ func TestStateError(t *testing.T) {
 }
 
 func TestRegistryError(t *testing.T) {
+	t.Parallel()
+
 	cause := errors.New("404 not found")
 	err := NewRegistryError("aqua", "package not found", cause).
 		WithPackage("cli/cli").
@@ -218,7 +262,11 @@ func TestRegistryError(t *testing.T) {
 }
 
 func TestErrorsIs(t *testing.T) {
+	t.Parallel()
+
 	t.Run("same code matches", func(t *testing.T) {
+		t.Parallel()
+
 		err1 := NewCycleError([]string{"A", "B", "A"})
 		err2 := NewCycleError([]string{"X", "Y", "X"})
 
@@ -226,6 +274,8 @@ func TestErrorsIs(t *testing.T) {
 	})
 
 	t.Run("different code does not match", func(t *testing.T) {
+		t.Parallel()
+
 		cycleErr := NewCycleError([]string{"A", "B", "A"})
 		missingErr := NewMissingDependencyError("Tool/x", []string{"Runtime/y"})
 
@@ -233,6 +283,8 @@ func TestErrorsIs(t *testing.T) {
 	})
 
 	t.Run("different types do not match", func(t *testing.T) {
+		t.Parallel()
+
 		depErr := NewCycleError([]string{"A", "B", "A"})
 		configErr := NewConfigError("test", nil)
 
@@ -240,6 +292,8 @@ func TestErrorsIs(t *testing.T) {
 	})
 
 	t.Run("base error Is", func(t *testing.T) {
+		t.Parallel()
+
 		err1 := &Error{Code: CodeInstallFailed, Message: "install failed"}
 		err2 := &Error{Code: CodeInstallFailed, Message: "different message"}
 
@@ -247,6 +301,8 @@ func TestErrorsIs(t *testing.T) {
 	})
 
 	t.Run("network error codes", func(t *testing.T) {
+		t.Parallel()
+
 		err1 := NewHTTPError("https://a.com", 404)
 		err2 := NewHTTPError("https://b.com", 500)
 
@@ -255,6 +311,8 @@ func TestErrorsIs(t *testing.T) {
 	})
 
 	t.Run("network vs install does not match", func(t *testing.T) {
+		t.Parallel()
+
 		netErr := NewNetworkError("https://example.com", nil)
 		installErr := NewInstallError("Tool/x", "install", nil)
 
@@ -263,8 +321,12 @@ func TestErrorsIs(t *testing.T) {
 }
 
 func TestErrorsAs(t *testing.T) {
+	t.Parallel()
+
 	// Test that errors.As works correctly with our error types
 	t.Run("DependencyError", func(t *testing.T) {
+		t.Parallel()
+
 		var err error = NewCycleError([]string{"A", "B", "A"})
 
 		var depErr *DependencyError
@@ -273,6 +335,8 @@ func TestErrorsAs(t *testing.T) {
 	})
 
 	t.Run("ConfigError", func(t *testing.T) {
+		t.Parallel()
+
 		var err error = NewConfigError("test", nil)
 
 		var configErr *ConfigError
@@ -281,6 +345,8 @@ func TestErrorsAs(t *testing.T) {
 	})
 
 	t.Run("wrapped error", func(t *testing.T) {
+		t.Parallel()
+
 		original := NewInstallError("Tool/gh", "install", nil)
 		wrapped := Wrap(CategoryInstall, "operation failed", original)
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestNewRepository(t *testing.T) {
+	t.Parallel()
+
 	repo := NewRepository("octocat", "Hello-World")
 
 	assert.Equal(t, "octocat", repo.Owner)
@@ -19,12 +21,18 @@ func TestNewRepository(t *testing.T) {
 }
 
 func TestRepository_URL(t *testing.T) {
+	t.Parallel()
+
 	t.Run("default host", func(t *testing.T) {
+		t.Parallel()
+
 		repo := NewRepository("octocat", "Hello-World")
 		assert.Equal(t, "https://github.com/octocat/Hello-World.git", repo.URL())
 	})
 
 	t.Run("custom host", func(t *testing.T) {
+		t.Parallel()
+
 		repo := &Repository{
 			Owner: "user",
 			Name:  "repo",
@@ -34,6 +42,8 @@ func TestRepository_URL(t *testing.T) {
 	})
 
 	t.Run("empty host defaults to github.com", func(t *testing.T) {
+		t.Parallel()
+
 		repo := &Repository{
 			Owner: "user",
 			Name:  "repo",
@@ -44,10 +54,14 @@ func TestRepository_URL(t *testing.T) {
 }
 
 func TestRepository_Clone(t *testing.T) {
+	t.Parallel()
+
 	// Use a small, stable public repository for testing
 	repo := NewRepository("octocat", "Hello-World")
 
 	t.Run("clone repository", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		destPath := filepath.Join(tmpDir, "hello-world")
 
@@ -64,6 +78,8 @@ func TestRepository_Clone(t *testing.T) {
 	})
 
 	t.Run("clone with shallow depth", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		destPath := filepath.Join(tmpDir, "hello-world-shallow")
 
@@ -78,6 +94,8 @@ func TestRepository_Clone(t *testing.T) {
 	})
 
 	t.Run("clone with branch", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		destPath := filepath.Join(tmpDir, "hello-world-branch")
 
@@ -93,6 +111,8 @@ func TestRepository_Clone(t *testing.T) {
 	})
 
 	t.Run("clone already exists error", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		destPath := filepath.Join(tmpDir, "hello-world")
 
@@ -107,6 +127,8 @@ func TestRepository_Clone(t *testing.T) {
 	})
 
 	t.Run("clone invalid repository", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		destPath := filepath.Join(tmpDir, "invalid")
 
@@ -116,6 +138,8 @@ func TestRepository_Clone(t *testing.T) {
 	})
 
 	t.Run("clone context canceled", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		destPath := filepath.Join(tmpDir, "canceled")
 
@@ -128,9 +152,13 @@ func TestRepository_Clone(t *testing.T) {
 }
 
 func TestRepository_Pull(t *testing.T) {
+	t.Parallel()
+
 	repo := NewRepository("octocat", "Hello-World")
 
 	t.Run("pull existing repository", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		destPath := filepath.Join(tmpDir, "hello-world")
 
@@ -144,6 +172,8 @@ func TestRepository_Pull(t *testing.T) {
 	})
 
 	t.Run("pull non-existent repository", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		destPath := filepath.Join(tmpDir, "nonexistent")
 
@@ -154,9 +184,13 @@ func TestRepository_Pull(t *testing.T) {
 }
 
 func TestExists(t *testing.T) {
+	t.Parallel()
+
 	repo := NewRepository("octocat", "Hello-World")
 
 	t.Run("exists returns true for git repository", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		destPath := filepath.Join(tmpDir, "hello-world")
 
@@ -167,19 +201,27 @@ func TestExists(t *testing.T) {
 	})
 
 	t.Run("exists returns false for non-repository", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		assert.False(t, Exists(tmpDir))
 	})
 
 	t.Run("exists returns false for non-existent path", func(t *testing.T) {
+		t.Parallel()
+
 		assert.False(t, Exists("/nonexistent/path"))
 	})
 }
 
 func TestRepository_CloneOrPull(t *testing.T) {
+	t.Parallel()
+
 	repo := NewRepository("octocat", "Hello-World")
 
 	t.Run("clone when not exists", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		destPath := filepath.Join(tmpDir, "hello-world")
 
@@ -190,6 +232,8 @@ func TestRepository_CloneOrPull(t *testing.T) {
 	})
 
 	t.Run("pull when exists", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		destPath := filepath.Join(tmpDir, "hello-world")
 
@@ -215,6 +259,8 @@ func TestRepository_CloneOrPull(t *testing.T) {
 	})
 
 	t.Run("creates parent directory", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		destPath := filepath.Join(tmpDir, "nested", "dir", "hello-world")
 

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -49,6 +49,8 @@ func TestTokenFromEnv(t *testing.T) {
 }
 
 func TestIsGitHubHost(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		host string
 		want bool
@@ -68,12 +70,16 @@ func TestIsGitHubHost(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.host, func(t *testing.T) {
+			t.Parallel()
+
 			assert.Equal(t, tt.want, isGitHubHost(tt.host))
 		})
 	}
 }
 
 func TestTokenTransport(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		token    string
@@ -114,6 +120,8 @@ func TestTokenTransport(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			var gotAuth string
 			transport := &tokenTransport{
 				token: tt.token,
@@ -134,7 +142,11 @@ func TestTokenTransport(t *testing.T) {
 }
 
 func TestNewHTTPClient(t *testing.T) {
+	t.Parallel()
+
 	t.Run("with token", func(t *testing.T) {
+		t.Parallel()
+
 		client := NewHTTPClient("my-token")
 		assert.NotNil(t, client)
 		assert.Equal(t, defaultTimeout, client.Timeout)
@@ -145,6 +157,8 @@ func TestNewHTTPClient(t *testing.T) {
 	})
 
 	t.Run("with empty token", func(t *testing.T) {
+		t.Parallel()
+
 		client := NewHTTPClient("")
 		assert.NotNil(t, client)
 

--- a/internal/graph/dag_test.go
+++ b/internal/graph/dag_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestNewNodeID(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		kind     resource.Kind
 		name     string
@@ -21,6 +22,7 @@ func TestNewNodeID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.expected.String(), func(t *testing.T) {
+			t.Parallel()
 			got := NewNodeID(tt.kind, tt.name)
 			assert.Equal(t, tt.expected, got)
 		})
@@ -28,6 +30,7 @@ func TestNewNodeID(t *testing.T) {
 }
 
 func TestDAG_AddNode(t *testing.T) {
+	t.Parallel()
 	d := newDAG()
 
 	d.addNode(resource.KindRuntime, "go")
@@ -42,6 +45,7 @@ func TestDAG_AddNode(t *testing.T) {
 }
 
 func TestDAG_AddEdge(t *testing.T) {
+	t.Parallel()
 	d := newDAG()
 
 	goplsNode := d.addNode(resource.KindTool, "gopls")
@@ -56,6 +60,7 @@ func TestDAG_AddEdge(t *testing.T) {
 }
 
 func TestDAG_AddEdge_PanicOnNilNode(t *testing.T) {
+	t.Parallel()
 	d := newDAG()
 	node := d.addNode(resource.KindTool, "test")
 
@@ -69,6 +74,7 @@ func TestDAG_AddEdge_PanicOnNilNode(t *testing.T) {
 }
 
 func TestDAG_AddEdge_PanicOnNonExistentNode(t *testing.T) {
+	t.Parallel()
 	d := newDAG()
 	node := d.addNode(resource.KindTool, "test")
 	fakeNode := &Node{ID: "Tool/fake", Kind: resource.KindTool, Name: "fake"}
@@ -79,6 +85,7 @@ func TestDAG_AddEdge_PanicOnNonExistentNode(t *testing.T) {
 }
 
 func TestDAG_DetectCycle_NoCycle(t *testing.T) {
+	t.Parallel()
 	d := newDAG()
 
 	// Runtime -> Installer -> Tool (no cycle)
@@ -94,6 +101,7 @@ func TestDAG_DetectCycle_NoCycle(t *testing.T) {
 }
 
 func TestDAG_DetectCycle_SimpleCycle(t *testing.T) {
+	t.Parallel()
 	d := newDAG()
 
 	// A -> B -> A (cycle)
@@ -109,6 +117,7 @@ func TestDAG_DetectCycle_SimpleCycle(t *testing.T) {
 }
 
 func TestDAG_DetectCycle_ComplexCycle(t *testing.T) {
+	t.Parallel()
 	d := newDAG()
 
 	// A -> B -> C -> A (3-node cycle)
@@ -126,6 +135,7 @@ func TestDAG_DetectCycle_ComplexCycle(t *testing.T) {
 }
 
 func TestDAG_TopologicalSort_Simple(t *testing.T) {
+	t.Parallel()
 	d := newDAG()
 
 	// Runtime <- Installer <- Tool
@@ -154,6 +164,7 @@ func TestDAG_TopologicalSort_Simple(t *testing.T) {
 }
 
 func TestDAG_TopologicalSort_Diamond(t *testing.T) {
+	t.Parallel()
 	d := newDAG()
 
 	//     A
@@ -191,6 +202,7 @@ func TestDAG_TopologicalSort_Diamond(t *testing.T) {
 }
 
 func TestDAG_TopologicalSort_MultiLayer(t *testing.T) {
+	t.Parallel()
 	d := newDAG()
 
 	// Tool chain: Runtime(rust) <- Installer(cargo) <- Tool(cargo-binstall) <- Installer(binstall) <- Tool(ripgrep)
@@ -218,6 +230,7 @@ func TestDAG_TopologicalSort_MultiLayer(t *testing.T) {
 }
 
 func TestDAG_TopologicalSort_WithCycle(t *testing.T) {
+	t.Parallel()
 	d := newDAG()
 
 	a := d.addNode(resource.KindTool, "a")
@@ -233,6 +246,7 @@ func TestDAG_TopologicalSort_WithCycle(t *testing.T) {
 }
 
 func TestDAG_TopologicalSort_ParallelNodes(t *testing.T) {
+	t.Parallel()
 	d := newDAG()
 
 	// Multiple independent tools
@@ -259,7 +273,9 @@ func TestDAG_TopologicalSort_ParallelNodes(t *testing.T) {
 }
 
 func TestDAG_TopologicalSort_KindPriority(t *testing.T) {
+	t.Parallel()
 	t.Run("same layer sorted by kind priority", func(t *testing.T) {
+		t.Parallel()
 		d := newDAG()
 
 		// All independent nodes (no dependencies) - should be in same layer
@@ -291,6 +307,7 @@ func TestDAG_TopologicalSort_KindPriority(t *testing.T) {
 	})
 
 	t.Run("mixed layer with dependencies", func(t *testing.T) {
+		t.Parallel()
 		d := newDAG()
 
 		// Layer 0: go runtime and aqua installer (independent)
@@ -320,6 +337,7 @@ func TestDAG_TopologicalSort_KindPriority(t *testing.T) {
 	})
 
 	t.Run("installer with tool dependency in same potential layer", func(t *testing.T) {
+		t.Parallel()
 		d := newDAG()
 
 		// Independent nodes that would be in layer 0
@@ -362,6 +380,7 @@ func TestDAG_TopologicalSort_KindPriority(t *testing.T) {
 }
 
 func TestKindPriority(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		kind     resource.Kind
 		expected int
@@ -375,6 +394,7 @@ func TestKindPriority(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(string(tt.kind), func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tt.expected, kindPriority(tt.kind))
 		})
 	}
@@ -387,6 +407,7 @@ func TestKindPriority(t *testing.T) {
 }
 
 func TestSortNodesByKind(t *testing.T) {
+	t.Parallel()
 	nodes := []*Node{
 		{ID: "Tool/ripgrep", Kind: resource.KindTool, Name: "ripgrep"},
 		{ID: "Runtime/go", Kind: resource.KindRuntime, Name: "go"},

--- a/internal/graph/property_test.go
+++ b/internal/graph/property_test.go
@@ -267,6 +267,7 @@ func cyclicManifestGenerator() *rapid.Generator[*testResolver] {
 // TestProperty_Manifest_TopologicalOrder verifies that dependencies are always
 // resolved before their dependents when using actual manifest structures.
 func TestProperty_Manifest_TopologicalOrder(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		tr := manifestGenerator().Draw(t, "manifest")
 
@@ -303,6 +304,7 @@ func TestProperty_Manifest_TopologicalOrder(t *testing.T) {
 // TestProperty_Manifest_AllNodesIncluded verifies that all resources appear
 // exactly once in the execution plan.
 func TestProperty_Manifest_AllNodesIncluded(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		tr := manifestGenerator().Draw(t, "manifest")
 
@@ -333,6 +335,7 @@ func TestProperty_Manifest_AllNodesIncluded(t *testing.T) {
 // TestProperty_Manifest_LayerParallelism verifies that resources in the same
 // layer have no dependencies between them (safe for parallel execution).
 func TestProperty_Manifest_LayerParallelism(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		tr := manifestGenerator().Draw(t, "manifest")
 
@@ -361,6 +364,7 @@ func TestProperty_Manifest_LayerParallelism(t *testing.T) {
 // TestProperty_ToolChain_ExecutionOrder verifies execution order for
 // tool-as-installer patterns (e.g., cargo-binstall -> binstall -> ripgrep).
 func TestProperty_ToolChain_ExecutionOrder(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		tr := toolChainGenerator().Draw(t, "toolChain")
 
@@ -398,6 +402,7 @@ func TestProperty_ToolChain_ExecutionOrder(t *testing.T) {
 // TestProperty_CycleDetection_Consistency verifies that Validate() and Resolve()
 // are consistent in cycle detection when using actual manifests.
 func TestProperty_CycleDetection_Consistency(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		tr := cyclicManifestGenerator().Draw(t, "manifest")
 
@@ -419,6 +424,7 @@ func TestProperty_CycleDetection_Consistency(t *testing.T) {
 
 // TestProperty_Manifest_LayerCount verifies layer count bounds.
 func TestProperty_Manifest_LayerCount(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		tr := manifestGenerator().Draw(t, "manifest")
 
@@ -443,6 +449,7 @@ func TestProperty_Manifest_LayerCount(t *testing.T) {
 // TestProperty_Manifest_RuntimesFirst verifies that runtimes with no dependencies
 // are always in the first layer.
 func TestProperty_Manifest_RuntimesFirst(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		tr := manifestGenerator().Draw(t, "manifest")
 
@@ -478,6 +485,7 @@ func TestProperty_Manifest_RuntimesFirst(t *testing.T) {
 // TestProperty_Manifest_KindOrderWithinLayer verifies that nodes within each layer
 // are sorted by Kind priority: Runtime -> Installer -> Tool.
 func TestProperty_Manifest_KindOrderWithinLayer(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		tr := manifestGenerator().Draw(t, "manifest")
 
@@ -534,7 +542,9 @@ func kindPriorityForTest(kind resource.Kind) int {
 
 // TestProperty_KnownStructures tests layer count for known manifest structures.
 func TestProperty_KnownStructures(t *testing.T) {
+	t.Parallel()
 	t.Run("single runtime", func(t *testing.T) {
+		t.Parallel()
 		resolver := NewResolver()
 		resolver.AddResource(createRuntimeWithPattern("go", resource.InstallTypeDownload))
 
@@ -544,6 +554,7 @@ func TestProperty_KnownStructures(t *testing.T) {
 	})
 
 	t.Run("runtime with tools", func(t *testing.T) {
+		t.Parallel()
 		resolver := NewResolver()
 		resolver.AddResource(createRuntimeWithPattern("go", resource.InstallTypeDownload))
 		resolver.AddResource(createToolWithRuntime("gopls", "go"))
@@ -557,6 +568,7 @@ func TestProperty_KnownStructures(t *testing.T) {
 	})
 
 	t.Run("tool chain", func(t *testing.T) {
+		t.Parallel()
 		resolver := NewResolver()
 		// Runtime -> Tool -> Installer -> Tool
 		resolver.AddResource(createRuntimeWithPattern("rust", resource.InstallTypeDelegation))
@@ -570,6 +582,7 @@ func TestProperty_KnownStructures(t *testing.T) {
 	})
 
 	t.Run("multiple independent chains", func(t *testing.T) {
+		t.Parallel()
 		resolver := NewResolver()
 		// Go chain
 		resolver.AddResource(createRuntimeWithPattern("go", resource.InstallTypeDownload))

--- a/internal/graph/resolver_test.go
+++ b/internal/graph/resolver_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestResolver_AddResource_Runtime(t *testing.T) {
+	t.Parallel()
 	resolver := NewResolver()
 
 	runtime := &resource.Runtime{
@@ -29,6 +30,7 @@ func TestResolver_AddResource_Runtime(t *testing.T) {
 }
 
 func TestResolver_AddResource_ToolWithRuntimeRef(t *testing.T) {
+	t.Parallel()
 	resolver := NewResolver()
 
 	tool := &resource.Tool{
@@ -51,6 +53,7 @@ func TestResolver_AddResource_ToolWithRuntimeRef(t *testing.T) {
 }
 
 func TestResolver_AddResource_InstallerWithToolRef(t *testing.T) {
+	t.Parallel()
 	resolver := NewResolver()
 
 	installer := &resource.Installer{
@@ -75,6 +78,7 @@ func TestResolver_AddResource_InstallerWithToolRef(t *testing.T) {
 }
 
 func TestResolver_AddResource_ToolWithInstallerRef(t *testing.T) {
+	t.Parallel()
 	resolver := NewResolver()
 
 	tool := &resource.Tool{
@@ -96,6 +100,7 @@ func TestResolver_AddResource_ToolWithInstallerRef(t *testing.T) {
 }
 
 func TestResolver_Resolve_ToolChain(t *testing.T) {
+	t.Parallel()
 	resolver := NewResolver()
 
 	// Build: Runtime(rust) <- Tool(cargo-binstall) <- Installer(binstall) <- Tool(ripgrep)
@@ -179,6 +184,7 @@ func TestResolver_Resolve_ToolChain(t *testing.T) {
 }
 
 func TestResolver_Validate_CircularDependency(t *testing.T) {
+	t.Parallel()
 	resolver := NewResolver()
 
 	// Create circular dependency: tool A depends on installer B, installer B depends on tool A
@@ -218,6 +224,7 @@ func TestResolver_Validate_CircularDependency(t *testing.T) {
 }
 
 func TestResolver_Resolve_ParallelTools(t *testing.T) {
+	t.Parallel()
 	resolver := NewResolver()
 
 	aquaInstaller := &resource.Installer{

--- a/internal/graph/scenario_test.go
+++ b/internal/graph/scenario_test.go
@@ -17,6 +17,7 @@ import (
 // TestResolver_ComplexManifest_MultipleRuntimeChains tests a realistic scenario
 // with multiple runtimes and their tool chains.
 func TestResolver_ComplexManifest_MultipleRuntimeChains(t *testing.T) {
+	t.Parallel()
 	resolver := NewResolver()
 
 	// Go runtime chain
@@ -86,6 +87,7 @@ func TestResolver_ComplexManifest_MultipleRuntimeChains(t *testing.T) {
 // TestResolver_ComplexManifest_DeepChain tests a deep dependency chain
 // to ensure correct layer assignment.
 func TestResolver_ComplexManifest_DeepChain(t *testing.T) {
+	t.Parallel()
 	resolver := NewResolver()
 
 	// Create a deep chain: Runtime -> Tool1 -> Installer1 -> Tool2 -> Installer2 -> Tool3
@@ -123,6 +125,7 @@ func TestResolver_ComplexManifest_DeepChain(t *testing.T) {
 
 // TestResolver_ComplexManifest_WideDependencies tests wide (fan-out) dependencies.
 func TestResolver_ComplexManifest_WideDependencies(t *testing.T) {
+	t.Parallel()
 	resolver := NewResolver()
 
 	// One runtime with many direct tool dependencies
@@ -149,6 +152,7 @@ func TestResolver_ComplexManifest_WideDependencies(t *testing.T) {
 
 // TestResolver_ComplexManifest_DiamondDependency tests diamond dependency patterns.
 func TestResolver_ComplexManifest_DiamondDependency(t *testing.T) {
+	t.Parallel()
 	resolver := NewResolver()
 
 	// Diamond pattern:
@@ -215,6 +219,7 @@ func TestResolver_ComplexManifest_DiamondDependency(t *testing.T) {
 
 // TestResolver_CycleDetection_SelfReference tests self-referential dependency.
 func TestResolver_CycleDetection_SelfReference(t *testing.T) {
+	t.Parallel()
 	// Note: This would be caught at CUE validation level,
 	// but we test the graph layer anyway.
 	d := newDAG()
@@ -227,6 +232,7 @@ func TestResolver_CycleDetection_SelfReference(t *testing.T) {
 
 // TestResolver_CycleDetection_TwoNodeCycle tests A -> B -> A cycle.
 func TestResolver_CycleDetection_TwoNodeCycle(t *testing.T) {
+	t.Parallel()
 	resolver := NewResolver()
 
 	toolA := &resource.Tool{
@@ -270,6 +276,7 @@ func TestResolver_CycleDetection_TwoNodeCycle(t *testing.T) {
 
 // TestResolver_CycleDetection_ThreeNodeCycle tests A -> B -> C -> A cycle.
 func TestResolver_CycleDetection_ThreeNodeCycle(t *testing.T) {
+	t.Parallel()
 	resolver := NewResolver()
 
 	toolA := &resource.Tool{
@@ -338,6 +345,7 @@ func TestResolver_CycleDetection_ThreeNodeCycle(t *testing.T) {
 
 // TestResolver_CycleDetection_LongCycle tests a longer cycle (5 nodes).
 func TestResolver_CycleDetection_LongCycle(t *testing.T) {
+	t.Parallel()
 	d := newDAG()
 
 	// Create a cycle: 1 -> 2 -> 3 -> 4 -> 5 -> 1
@@ -358,6 +366,7 @@ func TestResolver_CycleDetection_LongCycle(t *testing.T) {
 
 // TestResolver_CycleDetection_CycleInSubgraph tests cycle detection in a subgraph.
 func TestResolver_CycleDetection_CycleInSubgraph(t *testing.T) {
+	t.Parallel()
 	d := newDAG()
 
 	// Independent chain: A -> B -> C
@@ -401,6 +410,7 @@ func TestResolver_CycleDetection_CycleInSubgraph(t *testing.T) {
 
 // TestResolver_EdgeCase_EmptyManifest tests empty manifest handling.
 func TestResolver_EdgeCase_EmptyManifest(t *testing.T) {
+	t.Parallel()
 	resolver := NewResolver()
 
 	layers, err := resolver.Resolve()
@@ -410,6 +420,7 @@ func TestResolver_EdgeCase_EmptyManifest(t *testing.T) {
 
 // TestResolver_EdgeCase_SingleNode tests single node handling.
 func TestResolver_EdgeCase_SingleNode(t *testing.T) {
+	t.Parallel()
 	resolver := NewResolver()
 	resolver.AddResource(createRuntime("go", resource.InstallTypeDownload))
 
@@ -421,6 +432,7 @@ func TestResolver_EdgeCase_SingleNode(t *testing.T) {
 
 // TestResolver_EdgeCase_DisconnectedComponents tests multiple disconnected components.
 func TestResolver_EdgeCase_DisconnectedComponents(t *testing.T) {
+	t.Parallel()
 	resolver := NewResolver()
 
 	// Component 1: Go chain
@@ -456,6 +468,7 @@ func TestResolver_EdgeCase_DisconnectedComponents(t *testing.T) {
 
 // TestResolver_EdgeCase_DuplicateResources tests duplicate resource handling.
 func TestResolver_EdgeCase_DuplicateResources(t *testing.T) {
+	t.Parallel()
 	resolver := NewResolver()
 
 	runtime := createRuntime("go", resource.InstallTypeDownload)
@@ -473,6 +486,7 @@ func TestResolver_EdgeCase_DuplicateResources(t *testing.T) {
 
 // TestResolver_Stress_LargeGraph tests performance with large graphs.
 func TestResolver_Stress_LargeGraph(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping stress test in short mode")
 	}
@@ -508,6 +522,7 @@ func TestResolver_Stress_LargeGraph(t *testing.T) {
 
 // TestResolver_Stress_DeepGraph tests performance with deep dependency chains.
 func TestResolver_Stress_DeepGraph(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Skipping stress test in short mode")
 	}
@@ -556,6 +571,7 @@ func TestResolver_Stress_DeepGraph(t *testing.T) {
 // TestResolver_Determinism_SameOutput verifies that the resolver produces
 // deterministic output for the same input.
 func TestResolver_Determinism_SameOutput(t *testing.T) {
+	t.Parallel()
 	for range 10 {
 		resolver1 := NewResolver()
 		resolver2 := NewResolver()

--- a/internal/installer/builtin/builtin_test.go
+++ b/internal/installer/builtin/builtin_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestInstallers(t *testing.T) {
+	t.Parallel()
 	installers := Installers()
 
 	// Should have both "download" and "aqua" installers
@@ -60,10 +61,12 @@ func TestInstallers(t *testing.T) {
 }
 
 func TestInstallers_AllValid(t *testing.T) {
+	t.Parallel()
 	installers := Installers()
 
 	for _, inst := range installers {
 		t.Run(inst.Metadata.Name, func(t *testing.T) {
+			t.Parallel()
 			// Verify required fields
 			assert.NotEmpty(t, inst.APIVersion)
 			assert.NotEmpty(t, inst.Metadata.Name)
@@ -77,6 +80,7 @@ func TestInstallers_AllValid(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		installerID string
@@ -101,6 +105,7 @@ func TestGet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			inst := Get(tt.installerID)
 			if tt.wantNil {
 				assert.Nil(t, inst)
@@ -113,6 +118,7 @@ func TestGet(t *testing.T) {
 }
 
 func TestIsBuiltin(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		installerID string
@@ -142,6 +148,7 @@ func TestIsBuiltin(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := IsBuiltin(tt.installerID)
 			assert.Equal(t, tt.want, got)
 		})

--- a/internal/installer/command/executor_test.go
+++ b/internal/installer/command/executor_test.go
@@ -12,12 +12,14 @@ import (
 )
 
 func TestNewExecutor(t *testing.T) {
+	t.Parallel()
 	e := NewExecutor("/tmp")
 	assert.NotNil(t, e)
 	assert.Equal(t, "/tmp", e.workDir)
 }
 
 func TestExecutor_expand(t *testing.T) {
+	t.Parallel()
 	e := NewExecutor("")
 
 	tests := []struct {
@@ -63,6 +65,7 @@ func TestExecutor_expand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result, err := e.expand(tt.cmdStr, tt.vars)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
@@ -71,15 +74,18 @@ func TestExecutor_expand(t *testing.T) {
 }
 
 func TestExecutor_Execute(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	t.Run("successful command", func(t *testing.T) {
+		t.Parallel()
 		e := NewExecutor("")
 		err := e.Execute(ctx, "echo hello", Vars{})
 		require.NoError(t, err)
 	})
 
 	t.Run("command with variables", func(t *testing.T) {
+		t.Parallel()
 		tmpDir := t.TempDir()
 		testFile := filepath.Join(tmpDir, "test.txt")
 
@@ -93,6 +99,7 @@ func TestExecutor_Execute(t *testing.T) {
 	})
 
 	t.Run("failing command", func(t *testing.T) {
+		t.Parallel()
 		e := NewExecutor("")
 		err := e.Execute(ctx, "exit 1", Vars{})
 		require.Error(t, err)
@@ -100,6 +107,7 @@ func TestExecutor_Execute(t *testing.T) {
 	})
 
 	t.Run("with working directory", func(t *testing.T) {
+		t.Parallel()
 		tmpDir := t.TempDir()
 		e := NewExecutor(tmpDir)
 		err := e.Execute(ctx, "pwd > output.txt", Vars{})
@@ -112,10 +120,12 @@ func TestExecutor_Execute(t *testing.T) {
 }
 
 func TestExecutor_ExecuteWithEnv(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	tmpDir := t.TempDir()
 
 	t.Run("with environment variables", func(t *testing.T) {
+		t.Parallel()
 		e := NewExecutor("")
 		testFile := filepath.Join(tmpDir, "env_test.txt")
 
@@ -133,20 +143,24 @@ func TestExecutor_ExecuteWithEnv(t *testing.T) {
 }
 
 func TestExecutor_Check(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	e := NewExecutor("")
 
 	t.Run("successful check", func(t *testing.T) {
+		t.Parallel()
 		result := e.Check(ctx, "true", Vars{}, nil)
 		assert.True(t, result)
 	})
 
 	t.Run("failing check", func(t *testing.T) {
+		t.Parallel()
 		result := e.Check(ctx, "false", Vars{}, nil)
 		assert.False(t, result)
 	})
 
 	t.Run("check with command -v", func(t *testing.T) {
+		t.Parallel()
 		// sh should exist on all systems
 		result := e.Check(ctx, "command -v sh", Vars{}, nil)
 		assert.True(t, result)
@@ -157,6 +171,7 @@ func TestExecutor_Check(t *testing.T) {
 	})
 
 	t.Run("check with variables", func(t *testing.T) {
+		t.Parallel()
 		result := e.Check(ctx, "test {{.Name}} = gopls", Vars{Name: "gopls"}, nil)
 		assert.True(t, result)
 
@@ -166,6 +181,7 @@ func TestExecutor_Check(t *testing.T) {
 }
 
 func TestExecutor_ContextCancellation(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 
@@ -175,10 +191,12 @@ func TestExecutor_ContextCancellation(t *testing.T) {
 }
 
 func TestExecutor_ExecuteWithOutput(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	e := NewExecutor("")
 
 	t.Run("streams output lines", func(t *testing.T) {
+		t.Parallel()
 		var lines []string
 		callback := func(line string) {
 			lines = append(lines, line)
@@ -190,6 +208,7 @@ func TestExecutor_ExecuteWithOutput(t *testing.T) {
 	})
 
 	t.Run("captures stderr", func(t *testing.T) {
+		t.Parallel()
 		var mu sync.Mutex
 		var lines []string
 		callback := func(line string) {
@@ -205,6 +224,7 @@ func TestExecutor_ExecuteWithOutput(t *testing.T) {
 	})
 
 	t.Run("with variables", func(t *testing.T) {
+		t.Parallel()
 		var lines []string
 		callback := func(line string) {
 			lines = append(lines, line)
@@ -216,6 +236,7 @@ func TestExecutor_ExecuteWithOutput(t *testing.T) {
 	})
 
 	t.Run("with environment variables", func(t *testing.T) {
+		t.Parallel()
 		var lines []string
 		callback := func(line string) {
 			lines = append(lines, line)
@@ -228,11 +249,13 @@ func TestExecutor_ExecuteWithOutput(t *testing.T) {
 	})
 
 	t.Run("nil callback drains output", func(t *testing.T) {
+		t.Parallel()
 		err := e.ExecuteWithOutput(ctx, "echo hello", Vars{}, nil, nil)
 		require.NoError(t, err)
 	})
 
 	t.Run("failing command", func(t *testing.T) {
+		t.Parallel()
 		var mu sync.Mutex
 		var lines []string
 		callback := func(line string) {
@@ -249,28 +272,33 @@ func TestExecutor_ExecuteWithOutput(t *testing.T) {
 }
 
 func TestExecutor_ExecuteCapture(t *testing.T) {
+	t.Parallel()
 	e := NewExecutor("")
 	ctx := context.Background()
 
 	t.Run("captures stdout", func(t *testing.T) {
+		t.Parallel()
 		result, err := e.ExecuteCapture(ctx, "echo hello", Vars{}, nil)
 		require.NoError(t, err)
 		assert.Equal(t, "hello", result)
 	})
 
 	t.Run("trims whitespace", func(t *testing.T) {
+		t.Parallel()
 		result, err := e.ExecuteCapture(ctx, "echo '  1.83.0  '", Vars{}, nil)
 		require.NoError(t, err)
 		assert.Equal(t, "1.83.0", result)
 	})
 
 	t.Run("with variables", func(t *testing.T) {
+		t.Parallel()
 		result, err := e.ExecuteCapture(ctx, "echo {{.Version}}", Vars{Version: "stable"}, nil)
 		require.NoError(t, err)
 		assert.Equal(t, "stable", result)
 	})
 
 	t.Run("with environment", func(t *testing.T) {
+		t.Parallel()
 		env := map[string]string{"MY_VER": "2.0.0"}
 		result, err := e.ExecuteCapture(ctx, "echo $MY_VER", Vars{}, env)
 		require.NoError(t, err)
@@ -278,12 +306,14 @@ func TestExecutor_ExecuteCapture(t *testing.T) {
 	})
 
 	t.Run("failing command", func(t *testing.T) {
+		t.Parallel()
 		_, err := e.ExecuteCapture(ctx, "exit 1", Vars{}, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "command failed")
 	})
 
 	t.Run("stderr not captured in result", func(t *testing.T) {
+		t.Parallel()
 		result, err := e.ExecuteCapture(ctx, "echo stdout; echo stderr >&2", Vars{}, nil)
 		require.NoError(t, err)
 		assert.Equal(t, "stdout", result)

--- a/internal/installer/download/callback_test.go
+++ b/internal/installer/download/callback_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestCallbackFromContext_Progress(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		setup   func(ctx context.Context) context.Context
@@ -29,6 +30,7 @@ func TestCallbackFromContext_Progress(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ctx := tt.setup(context.Background())
 			cb := CallbackFromContext[ProgressCallback](ctx)
 			if tt.wantNil {
@@ -41,6 +43,7 @@ func TestCallbackFromContext_Progress(t *testing.T) {
 }
 
 func TestCallbackFromContext_Output(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		setup   func(ctx context.Context) context.Context
@@ -62,6 +65,7 @@ func TestCallbackFromContext_Output(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ctx := tt.setup(context.Background())
 			cb := CallbackFromContext[OutputCallback](ctx)
 			if tt.wantNil {
@@ -74,6 +78,7 @@ func TestCallbackFromContext_Output(t *testing.T) {
 }
 
 func TestCallbackFromContext_ProgressInvocable(t *testing.T) {
+	t.Parallel()
 	var called bool
 	var gotDownloaded, gotTotal int64
 
@@ -93,6 +98,7 @@ func TestCallbackFromContext_ProgressInvocable(t *testing.T) {
 }
 
 func TestCallbackFromContext_OutputInvocable(t *testing.T) {
+	t.Parallel()
 	var called bool
 	var gotLine string
 
@@ -110,6 +116,7 @@ func TestCallbackFromContext_OutputInvocable(t *testing.T) {
 }
 
 func TestCallbackFromContext_TypeIsolation(t *testing.T) {
+	t.Parallel()
 	ctx := WithCallback(context.Background(), ProgressCallback(func(downloaded, total int64) {}))
 
 	// ProgressCallback is set, but OutputCallback should be nil

--- a/internal/installer/download/downloader_test.go
+++ b/internal/installer/download/downloader_test.go
@@ -17,11 +17,13 @@ import (
 )
 
 func TestNewDownloader(t *testing.T) {
+	t.Parallel()
 	d := NewDownloader()
 	assert.NotNil(t, d)
 }
 
 func TestDownloader_Download(t *testing.T) {
+	t.Parallel()
 	testContent := []byte("hello world")
 
 	tests := []struct {
@@ -58,6 +60,7 @@ func TestDownloader_Download(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			server := httptest.NewServer(tt.handler)
 			defer server.Close()
 
@@ -88,6 +91,7 @@ func TestDownloader_Download(t *testing.T) {
 }
 
 func TestDownloader_Download_ContextCanceled(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		<-r.Context().Done()
 	}))
@@ -107,6 +111,7 @@ func TestDownloader_Download_ContextCanceled(t *testing.T) {
 }
 
 func TestDownloader_Verify_NilChecksum(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	filePath := filepath.Join(tmpDir, "testfile")
 	err := os.WriteFile(filePath, []byte("hello world"), 0644)
@@ -119,6 +124,7 @@ func TestDownloader_Verify_NilChecksum(t *testing.T) {
 }
 
 func TestDownloader_Verify_DirectValue(t *testing.T) {
+	t.Parallel()
 	testContent := []byte("hello world")
 	sha256sum := fmt.Sprintf("%x", sha256.Sum256(testContent))
 	sha512sum := fmt.Sprintf("%x", sha512.Sum512(testContent))
@@ -171,6 +177,7 @@ func TestDownloader_Verify_DirectValue(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			tmpDir := t.TempDir()
 			filePath := filepath.Join(tmpDir, "testfile")
 			err := os.WriteFile(filePath, testContent, 0644)
@@ -193,6 +200,7 @@ func TestDownloader_Verify_DirectValue(t *testing.T) {
 }
 
 func TestDownloader_Verify_URLChecksum(t *testing.T) {
+	t.Parallel()
 	testContent := []byte("hello world")
 	sha256sum := fmt.Sprintf("%x", sha256.Sum256(testContent))
 
@@ -264,6 +272,7 @@ func TestDownloader_Verify_URLChecksum(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			server := httptest.NewServer(tt.handler)
 			defer server.Close()
 
@@ -294,6 +303,7 @@ func TestDownloader_Verify_URLChecksum(t *testing.T) {
 }
 
 func TestDownloader_Verify_GoJSONChecksum(t *testing.T) {
+	t.Parallel()
 	testContent := []byte("hello world")
 	sha256sum := fmt.Sprintf("%x", sha256.Sum256(testContent))
 
@@ -386,6 +396,7 @@ func TestDownloader_Verify_GoJSONChecksum(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			server := httptest.NewServer(tt.handler)
 			defer server.Close()
 
@@ -415,6 +426,7 @@ func TestDownloader_Verify_GoJSONChecksum(t *testing.T) {
 }
 
 func TestDownloader_Verify_EmptyChecksum(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	filePath := filepath.Join(tmpDir, "testfile")
 	err := os.WriteFile(filePath, []byte("hello world"), 0644)
@@ -430,6 +442,7 @@ func TestDownloader_Verify_EmptyChecksum(t *testing.T) {
 }
 
 func TestDownloader_Verify_FileNotFound(t *testing.T) {
+	t.Parallel()
 	checksum := &resource.Checksum{
 		Value: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
 	}

--- a/internal/installer/engine/engine_test.go
+++ b/internal/installer/engine/engine_test.go
@@ -112,6 +112,7 @@ func (m *mockInstallerRepositoryInstaller) Remove(ctx context.Context, st *resou
 func (m *mockInstallerRepositoryInstaller) SetToolBinPaths(_ map[string]string) {}
 
 func TestNewEngine(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	store, err := state.NewStore[state.UserState](tmpDir)
 	require.NoError(t, err)
@@ -124,6 +125,7 @@ func TestNewEngine(t *testing.T) {
 }
 
 func TestEngine_Apply(t *testing.T) {
+	t.Parallel()
 	// Create test config directory with CUE file
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "tools.cue")
@@ -194,6 +196,7 @@ tool: {
 }
 
 func TestEngine_Apply_NoChanges(t *testing.T) {
+	t.Parallel()
 	// Create test config directory with CUE file
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "tools.cue")
@@ -262,6 +265,7 @@ tool: {
 }
 
 func TestEngine_Apply_WithRuntime(t *testing.T) {
+	t.Parallel()
 	// Create test config directory with CUE file
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "resources.cue")
@@ -373,6 +377,7 @@ tool: {
 }
 
 func TestEngine_TaintDependentTools(t *testing.T) {
+	t.Parallel()
 	// Create test config directory with CUE file
 	// Include both runtime and dependent tool - tool should be tainted when runtime is upgraded
 	configDir := t.TempDir()
@@ -497,6 +502,7 @@ tool: {
 }
 
 func TestEngine_Apply_DependencyOrder(t *testing.T) {
+	t.Parallel()
 	// Test that DAG-based execution respects dependency order:
 	// Runtime(go) -> Tool(pnpm) -> Installer(pnpm) -> Tool(biome)
 	// Tool can directly reference Runtime via runtimeRef
@@ -643,6 +649,7 @@ biomeTool: {
 }
 
 func TestEngine_Apply_CircularDependency(t *testing.T) {
+	t.Parallel()
 	// Test that circular dependencies are detected and rejected
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "resources.cue")
@@ -693,6 +700,7 @@ toolB: {
 }
 
 func TestEngine_Apply_ParallelExecution(t *testing.T) {
+	t.Parallel()
 	// Test that independent tools are executed in parallel
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "resources.cue")
@@ -814,6 +822,7 @@ bat: {
 }
 
 func TestEngine_Apply_ParallelExecution_CancelOnError(t *testing.T) {
+	t.Parallel()
 	// Test that when one tool fails in a parallel layer, other tools are canceled
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "resources.cue")
@@ -925,6 +934,7 @@ bat: {
 }
 
 func TestEngine_Apply_RuntimeBeforeTool_SameLayer(t *testing.T) {
+	t.Parallel()
 	// Test that Runtime nodes always execute before Tool nodes even in the same layer
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "resources.cue")
@@ -1026,6 +1036,7 @@ ripgrep: {
 }
 
 func TestEngine_Apply_ParallelRuntimeExecution(t *testing.T) {
+	t.Parallel()
 	// Test that multiple independent runtimes are executed in parallel
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "resources.cue")
@@ -1138,6 +1149,7 @@ nodeRuntime: {
 }
 
 func TestEngine_SetParallelism(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input int
@@ -1154,6 +1166,7 @@ func TestEngine_SetParallelism(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			stateDir := t.TempDir()
 			store, err := state.NewStore[state.UserState](stateDir)
 			require.NoError(t, err)
@@ -1166,6 +1179,7 @@ func TestEngine_SetParallelism(t *testing.T) {
 }
 
 func TestEngine_Apply_ParallelismLimit(t *testing.T) {
+	t.Parallel()
 	// Test that parallelism is limited to the configured value
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "resources.cue")
@@ -1252,6 +1266,7 @@ aquaInstaller: {
 }
 
 func TestEngine_ResolverConfigurer(t *testing.T) {
+	t.Parallel()
 	// Test that ResolverConfigurer callback is called after state is loaded
 	// but before any installation happens
 	configDir := t.TempDir()
@@ -1343,6 +1358,7 @@ tool: {
 }
 
 func TestEngine_ResolverConfigurer_NilRegistry(t *testing.T) {
+	t.Parallel()
 	// Test that ResolverConfigurer handles nil registry gracefully
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "tools.cue")
@@ -1405,6 +1421,7 @@ tool: {
 }
 
 func TestEngine_PlanAll(t *testing.T) {
+	t.Parallel()
 	// Create test config directory with CUE file
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "resources.cue")
@@ -1567,6 +1584,7 @@ func newStoreForRapid(t *rapid.T) *state.Store[state.UserState] {
 // --- Property-Based Tests ---
 
 func TestEngine_Property_ParallelSafety(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		n := rapid.IntRange(2, 15).Draw(t, "numTools")
 		toolNames := make([]string, n)
@@ -1641,6 +1659,7 @@ func TestEngine_Property_ParallelSafety(t *testing.T) {
 }
 
 func TestEngine_Property_RuntimeBeforeTool(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		nRuntimes := rapid.IntRange(1, 5).Draw(t, "numRuntimes")
 		nTools := rapid.IntRange(1, 5).Draw(t, "numTools")
@@ -1733,6 +1752,7 @@ func TestEngine_Property_RuntimeBeforeTool(t *testing.T) {
 }
 
 func TestEngine_Property_ParallelismLimit(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		nTools := rapid.IntRange(2, 20).Draw(t, "numTools")
 		parallelism := rapid.IntRange(1, 10).Draw(t, "parallelism")
@@ -1800,6 +1820,7 @@ func TestEngine_Property_ParallelismLimit(t *testing.T) {
 }
 
 func TestEngine_Property_CancelOnError(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		n := rapid.IntRange(2, 10).Draw(t, "numTools")
 		failIdx := rapid.IntRange(0, n-1).Draw(t, "failIdx")
@@ -1886,6 +1907,7 @@ func TestEngine_Property_CancelOnError(t *testing.T) {
 }
 
 func TestEngine_Apply_ToolSet(t *testing.T) {
+	t.Parallel()
 	stateDir := t.TempDir()
 	store, err := state.NewStore[state.UserState](stateDir)
 	require.NoError(t, err)
@@ -1948,6 +1970,7 @@ func TestEngine_Apply_ToolSet(t *testing.T) {
 }
 
 func TestEngine_Apply_ToolSet_DisabledItem(t *testing.T) {
+	t.Parallel()
 	stateDir := t.TempDir()
 	store, err := state.NewStore[state.UserState](stateDir)
 	require.NoError(t, err)
@@ -1999,6 +2022,7 @@ func TestEngine_Apply_ToolSet_DisabledItem(t *testing.T) {
 }
 
 func TestEngine_Apply_ToolSet_NameConflict(t *testing.T) {
+	t.Parallel()
 	stateDir := t.TempDir()
 	store, err := state.NewStore[state.UserState](stateDir)
 	require.NoError(t, err)
@@ -2029,6 +2053,7 @@ func TestEngine_Apply_ToolSet_NameConflict(t *testing.T) {
 }
 
 func TestCheckRemovalDependencies(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name            string
 		runtimeRemovals []string
@@ -2081,6 +2106,7 @@ func TestCheckRemovalDependencies(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			err := checkRemovalDependencies(tt.runtimeRemovals, tt.remainingTools)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -2093,6 +2119,7 @@ func TestCheckRemovalDependencies(t *testing.T) {
 }
 
 func TestEngine_Apply_RemoveRuntimeWithDependentTool(t *testing.T) {
+	t.Parallel()
 	configDir := t.TempDir()
 	stateDir := t.TempDir()
 
@@ -2176,6 +2203,7 @@ gopls: {
 }
 
 func TestEngine_PlanAll_RemoveRuntimeWithDependentTool(t *testing.T) {
+	t.Parallel()
 	configDir := t.TempDir()
 	stateDir := t.TempDir()
 
@@ -2230,6 +2258,7 @@ gopls: {
 }
 
 func TestEngine_Apply_RemoveRuntimeAndDependentTool(t *testing.T) {
+	t.Parallel()
 	configDir := t.TempDir()
 	stateDir := t.TempDir()
 
@@ -2323,6 +2352,7 @@ placeholder: {
 }
 
 func TestEngine_SyncMode_TaintLatestTools(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		tools          map[string]*resource.ToolState
@@ -2402,6 +2432,7 @@ func TestEngine_SyncMode_TaintLatestTools(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			stateDir := t.TempDir()
 			store, err := state.NewStore[state.UserState](stateDir)
 			require.NoError(t, err)
@@ -2438,6 +2469,7 @@ func TestEngine_SyncMode_TaintLatestTools(t *testing.T) {
 }
 
 func TestEngine_SyncMode_Apply(t *testing.T) {
+	t.Parallel()
 	// End-to-end: sync mode triggers reinstall of latest-specified tool
 	configDir := t.TempDir()
 	stateDir := t.TempDir()
@@ -2505,6 +2537,7 @@ fd: {
 }
 
 func TestEngine_SyncMode_ExactVersionNotReinstalled(t *testing.T) {
+	t.Parallel()
 	// Sync mode should NOT reinstall tools with exact version
 	configDir := t.TempDir()
 	stateDir := t.TempDir()
@@ -2566,6 +2599,7 @@ rg: {
 }
 
 func TestEngine_Apply_InstallerRepository(t *testing.T) {
+	t.Parallel()
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "resources.cue")
 	cueContent := `package tomei
@@ -2623,6 +2657,7 @@ repo: {
 }
 
 func TestEngine_Apply_InstallerRepositoryWithTool(t *testing.T) {
+	t.Parallel()
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "resources.cue")
 	cueContent := `package tomei
@@ -2712,6 +2747,7 @@ tool: {
 }
 
 func TestEngine_Apply_InstallerRepository_Remove(t *testing.T) {
+	t.Parallel()
 	stateDir := t.TempDir()
 	store, err := state.NewStore[state.UserState](stateDir)
 	require.NoError(t, err)
@@ -2745,6 +2781,7 @@ func TestEngine_Apply_InstallerRepository_Remove(t *testing.T) {
 }
 
 func TestEngine_PlanAll_InstallerRepository(t *testing.T) {
+	t.Parallel()
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "resources.cue")
 	cueContent := `package tomei
@@ -2790,7 +2827,9 @@ repo: {
 }
 
 func TestAppendBuiltinInstallers(t *testing.T) {
+	t.Parallel()
 	t.Run("adds download and aqua when absent", func(t *testing.T) {
+		t.Parallel()
 		resources := []resource.Resource{
 			&resource.Tool{
 				BaseResource: resource.BaseResource{
@@ -2818,6 +2857,7 @@ func TestAppendBuiltinInstallers(t *testing.T) {
 	})
 
 	t.Run("does not duplicate existing installer", func(t *testing.T) {
+		t.Parallel()
 		existing := &resource.Installer{
 			BaseResource: resource.BaseResource{
 				APIVersion:   resource.GroupVersion,
@@ -2844,6 +2884,7 @@ func TestAppendBuiltinInstallers(t *testing.T) {
 }
 
 func TestEngine_Apply_EventLayerStart(t *testing.T) {
+	t.Parallel()
 	// Setup CUE config with runtime and tool (2 layers: runtime first, then tool)
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "resources.cue")
@@ -2963,6 +3004,7 @@ tool: {
 }
 
 func TestEngine_Apply_EventComplete_InstallPath(t *testing.T) {
+	t.Parallel()
 	configDir := t.TempDir()
 	cueFile := filepath.Join(configDir, "resources.cue")
 	cueContent := `package tomei

--- a/internal/installer/executor/executor_test.go
+++ b/internal/installer/executor/executor_test.go
@@ -71,6 +71,7 @@ func (s *mockStateStore) Delete(name string) error {
 }
 
 func TestNew(t *testing.T) {
+	t.Parallel()
 	mock := &mockInstaller{}
 	store := newMockStateStore()
 
@@ -79,6 +80,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestExecutor_Execute_Install(t *testing.T) {
+	t.Parallel()
 	mock := &mockInstaller{
 		installFunc: func(ctx context.Context, res *resource.Tool, name string) (*resource.ToolState, error) {
 			return &resource.ToolState{
@@ -113,6 +115,7 @@ func TestExecutor_Execute_Install(t *testing.T) {
 }
 
 func TestExecutor_Execute_Upgrade(t *testing.T) {
+	t.Parallel()
 	mock := &mockInstaller{
 		installFunc: func(ctx context.Context, res *resource.Tool, name string) (*resource.ToolState, error) {
 			return &resource.ToolState{
@@ -152,6 +155,7 @@ func TestExecutor_Execute_Upgrade(t *testing.T) {
 }
 
 func TestExecutor_Execute_Remove(t *testing.T) {
+	t.Parallel()
 	removed := false
 	mock := &mockInstaller{
 		removeFunc: func(ctx context.Context, st *resource.ToolState, name string) error {
@@ -183,6 +187,7 @@ func TestExecutor_Execute_Remove(t *testing.T) {
 }
 
 func TestExecutor_Execute_InstallError(t *testing.T) {
+	t.Parallel()
 	mock := &mockInstaller{
 		installFunc: func(ctx context.Context, res *resource.Tool, name string) (*resource.ToolState, error) {
 			return nil, errors.New("download failed")
@@ -209,6 +214,7 @@ func TestExecutor_Execute_InstallError(t *testing.T) {
 }
 
 func TestExecutor_Execute_UnsupportedActionType(t *testing.T) {
+	t.Parallel()
 	mock := &mockInstaller{}
 	store := newMockStateStore()
 

--- a/internal/installer/executor/store_test.go
+++ b/internal/installer/executor/store_test.go
@@ -50,6 +50,7 @@ func newStateCacheRapid(t *rapid.T) *StateCache {
 // --- StateCache Tests ---
 
 func TestStateCache_InitAndFlush(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	store, err := state.NewStore[state.UserState](dir)
 	require.NoError(t, err)
@@ -76,6 +77,7 @@ func TestStateCache_InitAndFlush(t *testing.T) {
 }
 
 func TestStateCache_FlushOnlyWhenDirty(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	store, err := state.NewStore[state.UserState](dir)
 	require.NoError(t, err)
@@ -90,6 +92,7 @@ func TestStateCache_FlushOnlyWhenDirty(t *testing.T) {
 }
 
 func TestStateCache_Snapshot(t *testing.T) {
+	t.Parallel()
 	sc := newStateCache(t)
 	ts := NewToolStore(sc)
 
@@ -100,6 +103,7 @@ func TestStateCache_Snapshot(t *testing.T) {
 }
 
 func TestStateCache_ConcurrentSaveThenFlush(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	store, err := state.NewStore[state.UserState](dir)
 	require.NoError(t, err)
@@ -132,6 +136,7 @@ func TestStateCache_ConcurrentSaveThenFlush(t *testing.T) {
 }
 
 func TestCachedStore_markDirtyViaSave(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	store, err := state.NewStore[state.UserState](dir)
 	require.NoError(t, err)
@@ -157,6 +162,7 @@ func TestCachedStore_markDirtyViaSave(t *testing.T) {
 // --- cachedStore Integration Tests ---
 
 func TestToolStore_SaveAndLoad(t *testing.T) {
+	t.Parallel()
 	sc := newStateCache(t)
 	ts := NewToolStore(sc)
 
@@ -176,6 +182,7 @@ func TestToolStore_SaveAndLoad(t *testing.T) {
 }
 
 func TestToolStore_Delete(t *testing.T) {
+	t.Parallel()
 	sc := newStateCache(t)
 	ts := NewToolStore(sc)
 
@@ -188,6 +195,7 @@ func TestToolStore_Delete(t *testing.T) {
 }
 
 func TestToolStore_LoadNotFound(t *testing.T) {
+	t.Parallel()
 	sc := newStateCache(t)
 	ts := NewToolStore(sc)
 
@@ -197,6 +205,7 @@ func TestToolStore_LoadNotFound(t *testing.T) {
 }
 
 func TestRuntimeStore_SaveAndLoad(t *testing.T) {
+	t.Parallel()
 	sc := newStateCache(t)
 	rs := NewRuntimeStore(sc)
 
@@ -215,6 +224,7 @@ func TestRuntimeStore_SaveAndLoad(t *testing.T) {
 }
 
 func TestRuntimeStore_Delete(t *testing.T) {
+	t.Parallel()
 	sc := newStateCache(t)
 	rs := NewRuntimeStore(sc)
 
@@ -229,6 +239,7 @@ func TestRuntimeStore_Delete(t *testing.T) {
 // --- Concurrency Integration Tests ---
 
 func TestToolStore_ConcurrentSave(t *testing.T) {
+	t.Parallel()
 	sc := newStateCache(t)
 	ts := NewToolStore(sc)
 
@@ -262,6 +273,7 @@ func TestToolStore_ConcurrentSave(t *testing.T) {
 }
 
 func TestRuntimeStore_ConcurrentSave(t *testing.T) {
+	t.Parallel()
 	sc := newStateCache(t)
 	rs := NewRuntimeStore(sc)
 
@@ -295,6 +307,7 @@ func TestRuntimeStore_ConcurrentSave(t *testing.T) {
 }
 
 func TestToolAndRuntimeStore_ConcurrentMixed(t *testing.T) {
+	t.Parallel()
 	sc := newStateCache(t)
 	ts := NewToolStore(sc)
 	rs := NewRuntimeStore(sc)
@@ -350,6 +363,7 @@ func TestToolAndRuntimeStore_ConcurrentMixed(t *testing.T) {
 // --- Property-Based Tests ---
 
 func TestToolStore_Property_ConcurrentSavePreservesAll(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		sc := newStateCacheRapid(t)
 		ts := NewToolStore(sc)
@@ -394,6 +408,7 @@ func TestToolStore_Property_ConcurrentSavePreservesAll(t *testing.T) {
 }
 
 func TestToolStore_Property_SaveDeleteConsistency(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		sc := newStateCacheRapid(t)
 		ts := NewToolStore(sc)
@@ -447,6 +462,7 @@ func TestToolStore_Property_SaveDeleteConsistency(t *testing.T) {
 // --- InstallerRepository Store Tests ---
 
 func TestInstallerRepositoryStore_SaveAndLoad(t *testing.T) {
+	t.Parallel()
 	sc := newStateCache(t)
 	irs := NewInstallerRepositoryStore(sc)
 
@@ -466,6 +482,7 @@ func TestInstallerRepositoryStore_SaveAndLoad(t *testing.T) {
 }
 
 func TestInstallerRepositoryStore_Delete(t *testing.T) {
+	t.Parallel()
 	sc := newStateCache(t)
 	irs := NewInstallerRepositoryStore(sc)
 
@@ -478,6 +495,7 @@ func TestInstallerRepositoryStore_Delete(t *testing.T) {
 }
 
 func TestInstallerRepositoryStore_LoadNotFound(t *testing.T) {
+	t.Parallel()
 	sc := newStateCache(t)
 	irs := NewInstallerRepositoryStore(sc)
 
@@ -487,6 +505,7 @@ func TestInstallerRepositoryStore_LoadNotFound(t *testing.T) {
 }
 
 func TestInstallerRepositoryStore_ConcurrentSave(t *testing.T) {
+	t.Parallel()
 	sc := newStateCache(t)
 	irs := NewInstallerRepositoryStore(sc)
 
@@ -518,6 +537,7 @@ func TestInstallerRepositoryStore_ConcurrentSave(t *testing.T) {
 }
 
 func TestToolStore_Property_ConcurrentSameTool_LastWriteWins(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		sc := newStateCacheRapid(t)
 		ts := NewToolStore(sc)
@@ -553,6 +573,7 @@ func TestToolStore_Property_ConcurrentSameTool_LastWriteWins(t *testing.T) {
 // --- StateCache Property Tests ---
 
 func TestStateCache_Property_ConcurrentSaveThenFlush(t *testing.T) {
+	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
 		sc := newStateCacheRapid(t)
 		ts := NewToolStore(sc)

--- a/internal/installer/extract/extractor_test.go
+++ b/internal/installer/extract/extractor_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestDetectArchiveType(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string
@@ -65,6 +66,7 @@ func TestDetectArchiveType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := DetectArchiveType(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})
@@ -72,6 +74,7 @@ func TestDetectArchiveType(t *testing.T) {
 }
 
 func TestNewExtractor(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		archiveType ArchiveType
@@ -103,6 +106,7 @@ func TestNewExtractor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			extractor, err := NewExtractor(tt.archiveType)
 
 			if tt.wantErr {
@@ -121,6 +125,7 @@ func TestNewExtractor(t *testing.T) {
 }
 
 func TestExtractor_Extract_TarGz_Stream(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		createData func(t *testing.T) io.Reader
@@ -149,6 +154,7 @@ func TestExtractor_Extract_TarGz_Stream(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			tmpDir := t.TempDir()
 			destDir := filepath.Join(tmpDir, "dest")
 
@@ -180,6 +186,7 @@ func TestExtractor_Extract_TarGz_Stream(t *testing.T) {
 }
 
 func TestExtractor_Extract_Zip_File(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		setup      func(t *testing.T, archivePath string)
@@ -201,6 +208,7 @@ func TestExtractor_Extract_Zip_File(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			tmpDir := t.TempDir()
 			archivePath := filepath.Join(tmpDir, "archive.zip")
 			destDir := filepath.Join(tmpDir, "dest")
@@ -239,6 +247,7 @@ func TestExtractor_Extract_Zip_File(t *testing.T) {
 }
 
 func TestExtractor_TarGz_PreservesExecutablePermission(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	destDir := filepath.Join(tmpDir, "dest")
 
@@ -257,6 +266,7 @@ func TestExtractor_TarGz_PreservesExecutablePermission(t *testing.T) {
 }
 
 func TestExtractor_InvalidStream(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	destDir := filepath.Join(tmpDir, "dest")
 
@@ -278,6 +288,7 @@ func (p *pureReader) Read(b []byte) (int, error) {
 }
 
 func TestExtractor_Zip_RequiresReaderAt(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	destDir := filepath.Join(tmpDir, "dest")
 
@@ -294,6 +305,7 @@ func TestExtractor_Zip_RequiresReaderAt(t *testing.T) {
 }
 
 func TestExtractor_Extract_Raw(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		destDirName string // final component of destDir becomes binary name
@@ -316,6 +328,7 @@ func TestExtractor_Extract_Raw(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			tmpDir := t.TempDir()
 			destDir := filepath.Join(tmpDir, tt.destDirName)
 
@@ -347,6 +360,7 @@ func TestExtractor_Extract_Raw(t *testing.T) {
 }
 
 func TestExtractor_Raw_CreatesParentDirectory(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	destDir := filepath.Join(tmpDir, "nested", "path", "toolname")
 

--- a/internal/installer/place/placer_test.go
+++ b/internal/installer/place/placer_test.go
@@ -12,11 +12,13 @@ import (
 )
 
 func TestNewPlacer(t *testing.T) {
+	t.Parallel()
 	p := NewPlacer("/tools", "/bin")
 	assert.NotNil(t, p)
 }
 
 func TestValidateAction_String(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		action ValidateAction
 		want   string
@@ -29,12 +31,14 @@ func TestValidateAction_String(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.want, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tt.want, tt.action.String())
 		})
 	}
 }
 
 func TestPlacer_Validate(t *testing.T) {
+	t.Parallel()
 	content := []byte("binary content")
 	contentHash := sha256Hash(content)
 
@@ -86,6 +90,7 @@ func TestPlacer_Validate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			tmpDir := t.TempDir()
 			toolsDir := filepath.Join(tmpDir, "tools")
 			binDir := filepath.Join(tmpDir, "bin")
@@ -107,6 +112,7 @@ func TestPlacer_Validate(t *testing.T) {
 }
 
 func TestPlacer_Place(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		setup      func(t *testing.T, srcDir string)
@@ -163,6 +169,7 @@ func TestPlacer_Place(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			tmpDir := t.TempDir()
 			srcDir := filepath.Join(tmpDir, "src")
 			toolsDir := filepath.Join(tmpDir, "tools")
@@ -198,6 +205,7 @@ func TestPlacer_Place(t *testing.T) {
 }
 
 func TestPlacer_Symlink(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		setup      func(t *testing.T, toolsDir string, target Target)
@@ -254,6 +262,7 @@ func TestPlacer_Symlink(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			tmpDir := t.TempDir()
 			toolsDir := filepath.Join(tmpDir, "tools")
 			binDir := filepath.Join(tmpDir, "bin")
@@ -298,6 +307,7 @@ func TestPlacer_Symlink(t *testing.T) {
 }
 
 func TestPlacer_Cleanup(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		setup   func(t *testing.T, tmpDir string) string
@@ -336,6 +346,7 @@ func TestPlacer_Cleanup(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			tmpDir := t.TempDir()
 			path := tt.setup(t, tmpDir)
 

--- a/internal/installer/reconciler/installer_repository_test.go
+++ b/internal/installer/reconciler/installer_repository_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestInstallerRepositoryReconciler_Install(t *testing.T) {
+	t.Parallel()
 	repos := []*resource.InstallerRepository{
 		{
 			BaseResource: resource.BaseResource{
@@ -40,6 +41,7 @@ func TestInstallerRepositoryReconciler_Install(t *testing.T) {
 }
 
 func TestInstallerRepositoryReconciler_NoChange(t *testing.T) {
+	t.Parallel()
 	repos := []*resource.InstallerRepository{
 		{
 			BaseResource: resource.BaseResource{
@@ -71,6 +73,7 @@ func TestInstallerRepositoryReconciler_NoChange(t *testing.T) {
 }
 
 func TestInstallerRepositoryReconciler_Upgrade_URLChanged(t *testing.T) {
+	t.Parallel()
 	repos := []*resource.InstallerRepository{
 		{
 			BaseResource: resource.BaseResource{
@@ -107,6 +110,7 @@ func TestInstallerRepositoryReconciler_Upgrade_URLChanged(t *testing.T) {
 }
 
 func TestInstallerRepositoryReconciler_Upgrade_TypeChanged(t *testing.T) {
+	t.Parallel()
 	repos := []*resource.InstallerRepository{
 		{
 			BaseResource: resource.BaseResource{
@@ -142,6 +146,7 @@ func TestInstallerRepositoryReconciler_Upgrade_TypeChanged(t *testing.T) {
 }
 
 func TestInstallerRepositoryReconciler_Remove(t *testing.T) {
+	t.Parallel()
 	repos := []*resource.InstallerRepository{} // empty spec
 
 	states := map[string]*resource.InstallerRepositoryState{

--- a/internal/installer/reconciler/reconciler_test.go
+++ b/internal/installer/reconciler/reconciler_test.go
@@ -11,11 +11,13 @@ import (
 )
 
 func TestNew(t *testing.T) {
+	t.Parallel()
 	r := NewToolReconciler()
 	assert.NotNil(t, r)
 }
 
 func TestReconciler_Reconcile_Install(t *testing.T) {
+	t.Parallel()
 	// Tool exists in spec but not in state -> Install
 	tools := []*resource.Tool{
 		{
@@ -43,6 +45,7 @@ func TestReconciler_Reconcile_Install(t *testing.T) {
 }
 
 func TestReconciler_Reconcile_Upgrade(t *testing.T) {
+	t.Parallel()
 	// Tool exists in both but version differs -> Upgrade
 	tools := []*resource.Tool{
 		{
@@ -80,6 +83,7 @@ func TestReconciler_Reconcile_Upgrade(t *testing.T) {
 }
 
 func TestReconciler_Reconcile_Skip(t *testing.T) {
+	t.Parallel()
 	// Tool exists in both with same version -> Skip (no action)
 	tools := []*resource.Tool{
 		{
@@ -114,6 +118,7 @@ func TestReconciler_Reconcile_Skip(t *testing.T) {
 }
 
 func TestReconciler_Reconcile_Remove(t *testing.T) {
+	t.Parallel()
 	// Tool exists in state but not in spec -> Remove
 	tools := []*resource.Tool{} // Empty spec
 
@@ -139,6 +144,7 @@ func TestReconciler_Reconcile_Remove(t *testing.T) {
 }
 
 func TestReconciler_Reconcile_MultipleTools(t *testing.T) {
+	t.Parallel()
 	// Multiple tools with different actions
 	tools := []*resource.Tool{
 		{
@@ -203,6 +209,7 @@ func TestReconciler_Reconcile_MultipleTools(t *testing.T) {
 }
 
 func TestReconciler_Reconcile_Tainted(t *testing.T) {
+	t.Parallel()
 	// Tool is tainted -> Reinstall (upgrade action)
 	tools := []*resource.Tool{
 		{
@@ -244,6 +251,7 @@ func TestReconciler_Reconcile_Tainted(t *testing.T) {
 // --- specVersionChanged unit tests ---
 
 func TestSpecVersionChanged(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name             string
 		specVersion      string
@@ -341,6 +349,7 @@ func TestSpecVersionChanged(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := specVersionChanged(tt.specVersion, tt.stateVersionKind, tt.stateVersion, tt.stateSpecVersion)
 			assert.Equal(t, tt.want, got)
 		})
@@ -350,6 +359,7 @@ func TestSpecVersionChanged(t *testing.T) {
 // --- ToolComparator tests with VersionKind ---
 
 func TestToolComparator_VersionKind(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		specVersion string
@@ -435,6 +445,7 @@ func TestToolComparator_VersionKind(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			comparator := ToolComparator()
 
 			res := &resource.Tool{
@@ -468,6 +479,7 @@ func TestToolComparator_VersionKind(t *testing.T) {
 // --- RuntimeComparator tests with VersionKind ---
 
 func TestRuntimeComparator_VersionKind(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		specVersion string
@@ -524,6 +536,7 @@ func TestRuntimeComparator_VersionKind(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			comparator := RuntimeComparator()
 
 			res := &resource.Runtime{
@@ -554,6 +567,7 @@ func TestRuntimeComparator_VersionKind(t *testing.T) {
 
 // Property: VersionExact with same spec and state version → always false
 func TestSpecVersionChanged_Property_ExactSameVersion(t *testing.T) {
+	t.Parallel()
 	f := func(version string) bool {
 		if version == "" {
 			return true // skip: empty is VersionLatest, not VersionExact
@@ -567,6 +581,7 @@ func TestSpecVersionChanged_Property_ExactSameVersion(t *testing.T) {
 
 // Property: VersionExact with different spec and state version → always true
 func TestSpecVersionChanged_Property_ExactDifferentVersion(t *testing.T) {
+	t.Parallel()
 	f := func(specVersion, stateVersion string) bool {
 		if specVersion == stateVersion {
 			return true // skip: same version
@@ -580,6 +595,7 @@ func TestSpecVersionChanged_Property_ExactDifferentVersion(t *testing.T) {
 
 // Property: VersionLatest with empty spec → always false (updates driven by --sync)
 func TestSpecVersionChanged_Property_LatestStaysEmpty(t *testing.T) {
+	t.Parallel()
 	f := func(stateVersion string) bool {
 		return !specVersionChanged("", resource.VersionLatest, stateVersion, "")
 	}
@@ -590,6 +606,7 @@ func TestSpecVersionChanged_Property_LatestStaysEmpty(t *testing.T) {
 
 // Property: VersionLatest with non-empty spec → always true (spec changed from latest to explicit)
 func TestSpecVersionChanged_Property_LatestToExplicit(t *testing.T) {
+	t.Parallel()
 	f := func(specVersion, stateVersion string) bool {
 		if specVersion == "" {
 			return true // skip: still latest
@@ -603,6 +620,7 @@ func TestSpecVersionChanged_Property_LatestToExplicit(t *testing.T) {
 
 // Property: VersionAlias with same alias → always false
 func TestSpecVersionChanged_Property_AliasSameAlias(t *testing.T) {
+	t.Parallel()
 	f := func(alias, resolvedVersion string) bool {
 		if alias == "" {
 			return true // skip: empty alias is meaningless
@@ -616,6 +634,7 @@ func TestSpecVersionChanged_Property_AliasSameAlias(t *testing.T) {
 
 // Property: VersionAlias with different spec → always true
 func TestSpecVersionChanged_Property_AliasDifferentSpec(t *testing.T) {
+	t.Parallel()
 	f := func(specVersion, stateSpecVersion, stateVersion string) bool {
 		if specVersion == stateSpecVersion {
 			return true // skip: same alias

--- a/internal/installer/repository/installer_test.go
+++ b/internal/installer/repository/installer_test.go
@@ -77,6 +77,7 @@ func (m *mockGitRunner) Exists(_ string) bool {
 // --- delegation tests ---
 
 func TestInstaller_Install_Delegation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		checkResult bool
@@ -119,6 +120,7 @@ func TestInstaller_Install_Delegation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			cmd := &mockCommandRunner{
 				checkResult: tt.checkResult,
 				executeErr:  tt.executeErr,
@@ -186,6 +188,7 @@ func TestInstaller_Install_Delegation(t *testing.T) {
 }
 
 func TestInstaller_Remove_Delegation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		removeCmd   string
@@ -214,6 +217,7 @@ func TestInstaller_Remove_Delegation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			cmd := &mockCommandRunner{executeErr: tt.executeErr}
 			git := &mockGitRunner{}
 			inst := newInstallerWithRunners(t.TempDir(), cmd, git)
@@ -246,7 +250,9 @@ func TestInstaller_Remove_Delegation(t *testing.T) {
 // --- git tests ---
 
 func TestInstaller_Install_Git(t *testing.T) {
+	t.Parallel()
 	t.Run("fresh clone", func(t *testing.T) {
+		t.Parallel()
 		dir := t.TempDir()
 		cmd := &mockCommandRunner{}
 		git := &mockGitRunner{}
@@ -281,6 +287,7 @@ func TestInstaller_Install_Git(t *testing.T) {
 	})
 
 	t.Run("already cloned - pulls", func(t *testing.T) {
+		t.Parallel()
 		dir := t.TempDir()
 		localPath := filepath.Join(dir, "aqua", "custom-registry")
 
@@ -311,6 +318,7 @@ func TestInstaller_Install_Git(t *testing.T) {
 	})
 
 	t.Run("pull fails - continues with existing", func(t *testing.T) {
+		t.Parallel()
 		dir := t.TempDir()
 		localPath := filepath.Join(dir, "aqua", "custom-registry")
 
@@ -338,6 +346,7 @@ func TestInstaller_Install_Git(t *testing.T) {
 	})
 
 	t.Run("clone fails", func(t *testing.T) {
+		t.Parallel()
 		dir := t.TempDir()
 		cmd := &mockCommandRunner{}
 		git := &mockGitRunner{cloneErr: fmt.Errorf("clone failed: repository not found")}
@@ -365,6 +374,7 @@ func TestInstaller_Install_Git(t *testing.T) {
 }
 
 func TestInstaller_Remove_Git(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		localPath string
@@ -387,6 +397,7 @@ func TestInstaller_Remove_Git(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			dir := t.TempDir()
 			localPath := tt.localPath
 			if localPath == "to-be-set" {
@@ -426,11 +437,13 @@ func TestInstaller_Remove_Git(t *testing.T) {
 // --- unsupported source type ---
 
 func TestInstaller_UnsupportedSourceType(t *testing.T) {
+	t.Parallel()
 	cmd := &mockCommandRunner{}
 	git := &mockGitRunner{}
 	inst := newInstallerWithRunners(t.TempDir(), cmd, git)
 
 	t.Run("install", func(t *testing.T) {
+		t.Parallel()
 		repo := &resource.InstallerRepository{
 			InstallerRepositorySpec: &resource.InstallerRepositorySpec{
 				Source: resource.InstallerRepositorySourceSpec{
@@ -444,6 +457,7 @@ func TestInstaller_UnsupportedSourceType(t *testing.T) {
 	})
 
 	t.Run("remove", func(t *testing.T) {
+		t.Parallel()
 		st := &resource.InstallerRepositoryState{
 			SourceType: "unknown",
 		}

--- a/internal/installer/runtime/installer_test.go
+++ b/internal/installer/runtime/installer_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestNewInstaller(t *testing.T) {
+	t.Parallel()
 	downloader := download.NewDownloader()
 	installer := NewInstaller(downloader, "/runtimes")
 
@@ -31,6 +32,7 @@ func TestNewInstaller(t *testing.T) {
 }
 
 func TestInstaller_Install(t *testing.T) {
+	t.Parallel()
 	// Create a mock runtime tarball with a top-level directory
 	binContent := []byte("#!/bin/sh\necho 'mock runtime'\n")
 	tarGzContent := createRuntimeTarGz(t, "myruntime", []mockBinary{
@@ -184,6 +186,7 @@ func TestInstaller_Install(t *testing.T) {
 	})
 
 	t.Run("delegation basic", func(t *testing.T) {
+		t.Parallel()
 		tmpDir := t.TempDir()
 		binDir := filepath.Join(tmpDir, "bin")
 
@@ -232,6 +235,7 @@ func TestInstaller_Install(t *testing.T) {
 	})
 
 	t.Run("delegation with ResolveVersion", func(t *testing.T) {
+		t.Parallel()
 		tmpDir := t.TempDir()
 		binDir := filepath.Join(tmpDir, "bin")
 
@@ -273,6 +277,7 @@ func TestInstaller_Install(t *testing.T) {
 	})
 
 	t.Run("delegation check fails", func(t *testing.T) {
+		t.Parallel()
 		tmpDir := t.TempDir()
 
 		runner := &mockCommandRunner{
@@ -300,6 +305,7 @@ func TestInstaller_Install(t *testing.T) {
 	})
 
 	t.Run("delegation ResolveVersion fails", func(t *testing.T) {
+		t.Parallel()
 		tmpDir := t.TempDir()
 
 		runner := &mockCommandRunner{
@@ -328,6 +334,7 @@ func TestInstaller_Install(t *testing.T) {
 	})
 
 	t.Run("delegation install command fails", func(t *testing.T) {
+		t.Parallel()
 		tmpDir := t.TempDir()
 
 		runner := &mockCommandRunner{
@@ -355,6 +362,7 @@ func TestInstaller_Install(t *testing.T) {
 	})
 
 	t.Run("delegation missing bootstrap", func(t *testing.T) {
+		t.Parallel()
 		tmpDir := t.TempDir()
 		installer := NewInstaller(download.NewDownloader(), tmpDir)
 
@@ -372,6 +380,7 @@ func TestInstaller_Install(t *testing.T) {
 	})
 
 	t.Run("missing source URL", func(t *testing.T) {
+		t.Parallel()
 		tmpDir := t.TempDir()
 		installer := NewInstaller(download.NewDownloader(), tmpDir)
 
@@ -391,7 +400,9 @@ func TestInstaller_Install(t *testing.T) {
 }
 
 func TestInstaller_Remove(t *testing.T) {
+	t.Parallel()
 	t.Run("successful remove with BinDir", func(t *testing.T) {
+		t.Parallel()
 		tmpDir := t.TempDir()
 		runtimesDir := filepath.Join(tmpDir, "runtimes")
 		binDir := filepath.Join(tmpDir, "bin")
@@ -423,6 +434,7 @@ func TestInstaller_Remove(t *testing.T) {
 	})
 
 	t.Run("delegation remove with command", func(t *testing.T) {
+		t.Parallel()
 		tmpDir := t.TempDir()
 
 		runner := &mockCommandRunner{}
@@ -444,6 +456,7 @@ func TestInstaller_Remove(t *testing.T) {
 	})
 
 	t.Run("delegation remove without command", func(t *testing.T) {
+		t.Parallel()
 		tmpDir := t.TempDir()
 
 		runner := &mockCommandRunner{}
@@ -460,6 +473,7 @@ func TestInstaller_Remove(t *testing.T) {
 	})
 
 	t.Run("delegation remove command fails", func(t *testing.T) {
+		t.Parallel()
 		tmpDir := t.TempDir()
 
 		runner := &mockCommandRunner{
@@ -479,6 +493,7 @@ func TestInstaller_Remove(t *testing.T) {
 	})
 
 	t.Run("successful remove without BinDir", func(t *testing.T) {
+		t.Parallel()
 		tmpDir := t.TempDir()
 		runtimesDir := filepath.Join(tmpDir, "runtimes")
 
@@ -505,7 +520,9 @@ func TestInstaller_Remove(t *testing.T) {
 }
 
 func TestFindExtractedRoot(t *testing.T) {
+	t.Parallel()
 	t.Run("single directory", func(t *testing.T) {
+		t.Parallel()
 		tmpDir := t.TempDir()
 		subDir := filepath.Join(tmpDir, "myruntime")
 		require.NoError(t, os.MkdirAll(subDir, 0755))
@@ -516,6 +533,7 @@ func TestFindExtractedRoot(t *testing.T) {
 	})
 
 	t.Run("multiple entries", func(t *testing.T) {
+		t.Parallel()
 		tmpDir := t.TempDir()
 		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "dir1"), 0755))
 		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "dir2"), 0755))
@@ -526,6 +544,7 @@ func TestFindExtractedRoot(t *testing.T) {
 	})
 
 	t.Run("hidden files ignored", func(t *testing.T) {
+		t.Parallel()
 		tmpDir := t.TempDir()
 		subDir := filepath.Join(tmpDir, "myruntime")
 		require.NoError(t, os.MkdirAll(subDir, 0755))
@@ -538,6 +557,7 @@ func TestFindExtractedRoot(t *testing.T) {
 }
 
 func TestFindBinary(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 
 	// Create bin/mybin
@@ -549,16 +569,19 @@ func TestFindBinary(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "rootbin"), []byte("binary"), 0755))
 
 	t.Run("find in bin directory", func(t *testing.T) {
+		t.Parallel()
 		path := findBinary(tmpDir, "mybin")
 		assert.Equal(t, filepath.Join(tmpDir, "bin", "mybin"), path)
 	})
 
 	t.Run("find in root directory", func(t *testing.T) {
+		t.Parallel()
 		path := findBinary(tmpDir, "rootbin")
 		assert.Equal(t, filepath.Join(tmpDir, "rootbin"), path)
 	})
 
 	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
 		path := findBinary(tmpDir, "notexist")
 		assert.Empty(t, path)
 	})
@@ -691,6 +714,7 @@ func (m *mockRuntimeDownloader) Verify(_ context.Context, _ string, _ *resource.
 }
 
 func TestRuntimeInstaller_ProgressCallback_Priority(t *testing.T) {
+	t.Parallel()
 	binContent := []byte("#!/bin/sh\necho 'mock runtime'\n")
 	archiveData := createRuntimeTarGz(t, "myruntime", []mockBinary{
 		{name: "mybin", content: binContent},
@@ -747,6 +771,7 @@ func TestRuntimeInstaller_ProgressCallback_Priority(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			tmpDir := t.TempDir()
 			runtimesDir := filepath.Join(tmpDir, "runtimes")
 

--- a/internal/installer/tool/installer_test.go
+++ b/internal/installer/tool/installer_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestNewInstaller(t *testing.T) {
+	t.Parallel()
 	downloader := download.NewDownloader()
 	placer := place.NewPlacer("/tools", "/bin")
 
@@ -31,6 +32,7 @@ func TestNewInstaller(t *testing.T) {
 }
 
 func TestToolInstaller_Install(t *testing.T) {
+	t.Parallel()
 	// Create test server
 	binaryContent := []byte("#!/bin/sh\necho hello")
 	tarGzContent := createTarGzContent(t, "ripgrep", binaryContent)
@@ -132,6 +134,7 @@ func TestToolInstaller_Install(t *testing.T) {
 }
 
 func TestToolInstaller_Install_Skip(t *testing.T) {
+	t.Parallel()
 	binaryContent := []byte("#!/bin/sh\necho hello")
 
 	tmpDir := t.TempDir()
@@ -204,6 +207,7 @@ func sha256Hash(data []byte) string {
 }
 
 func TestToolInstaller_InstallFromRegistry(t *testing.T) {
+	t.Parallel()
 	// Create test binary content
 	binaryContent := []byte("#!/bin/sh\necho hello from registry")
 	tarGzContent := createTarGzContent(t, "mytool", binaryContent)
@@ -284,6 +288,7 @@ func TestToolInstaller_InstallFromRegistry(t *testing.T) {
 }
 
 func TestToolInstaller_InstallFromRegistry_NoResolver(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	toolsDir := filepath.Join(tmpDir, "tools")
 	binDir := filepath.Join(tmpDir, "bin")
@@ -314,6 +319,7 @@ func TestToolInstaller_InstallFromRegistry_NoResolver(t *testing.T) {
 }
 
 func TestToolInstaller_InstallFromRegistry_NoRegistryRef(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	toolsDir := filepath.Join(tmpDir, "tools")
 	binDir := filepath.Join(tmpDir, "bin")
@@ -411,6 +417,7 @@ func (m *mockPlacer) Cleanup(_ string) error {
 }
 
 func TestToolInstaller_ProgressCallback_Priority(t *testing.T) {
+	t.Parallel()
 	archiveData := createTarGzContent(t, "mytool", []byte("#!/bin/sh\necho hello"))
 
 	makeTool := func() *resource.Tool {
@@ -462,6 +469,7 @@ func TestToolInstaller_ProgressCallback_Priority(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			dl := &mockDownloader{archiveData: archiveData}
 			installer := NewInstaller(dl, &mockPlacer{})
 

--- a/internal/log/reader_test.go
+++ b/internal/log/reader_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 func TestListSessions(t *testing.T) {
+	t.Parallel()
 	t.Run("returns sessions sorted newest first", func(t *testing.T) {
+		t.Parallel()
 		tmpDir := t.TempDir()
 
 		dirs := []string{"20260201T100000", "20260203T100000", "20260202T100000"}
@@ -31,6 +33,7 @@ func TestListSessions(t *testing.T) {
 	})
 
 	t.Run("skips non-session directories", func(t *testing.T) {
+		t.Parallel()
 		tmpDir := t.TempDir()
 
 		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "20260201T100000"), 0755))
@@ -44,12 +47,14 @@ func TestListSessions(t *testing.T) {
 	})
 
 	t.Run("returns nil for nonexistent directory", func(t *testing.T) {
+		t.Parallel()
 		sessions, err := ListSessions("/nonexistent/path")
 		require.NoError(t, err)
 		assert.Nil(t, sessions)
 	})
 
 	t.Run("returns nil for empty directory", func(t *testing.T) {
+		t.Parallel()
 		tmpDir := t.TempDir()
 
 		sessions, err := ListSessions(tmpDir)
@@ -59,7 +64,9 @@ func TestListSessions(t *testing.T) {
 }
 
 func TestReadSessionLogs(t *testing.T) {
+	t.Parallel()
 	t.Run("reads log files", func(t *testing.T) {
+		t.Parallel()
 		tmpDir := t.TempDir()
 
 		// Filenames use resource.Kind values (capitalized: Tool, Runtime)
@@ -81,6 +88,7 @@ func TestReadSessionLogs(t *testing.T) {
 	})
 
 	t.Run("skips non-log files and directories", func(t *testing.T) {
+		t.Parallel()
 		tmpDir := t.TempDir()
 
 		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "Tool_foo.log"), []byte("ok"), 0644))
@@ -94,6 +102,7 @@ func TestReadSessionLogs(t *testing.T) {
 	})
 
 	t.Run("skips invalid filenames", func(t *testing.T) {
+		t.Parallel()
 		tmpDir := t.TempDir()
 
 		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "nounderscore.log"), []byte("skip"), 0644))
@@ -107,7 +116,9 @@ func TestReadSessionLogs(t *testing.T) {
 }
 
 func TestReadResourceLog(t *testing.T) {
+	t.Parallel()
 	t.Run("reads specific resource log", func(t *testing.T) {
+		t.Parallel()
 		tmpDir := t.TempDir()
 
 		content := "# tomei installation log\nsome output\n"
@@ -119,6 +130,7 @@ func TestReadResourceLog(t *testing.T) {
 	})
 
 	t.Run("returns error for missing log", func(t *testing.T) {
+		t.Parallel()
 		tmpDir := t.TempDir()
 
 		_, err := ReadResourceLog(tmpDir, resource.KindTool, "nonexistent")
@@ -128,6 +140,7 @@ func TestReadResourceLog(t *testing.T) {
 }
 
 func TestParseLogFilename(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		filename string
@@ -181,6 +194,7 @@ func TestParseLogFilename(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			kind, name, ok := parseLogFilename(tt.filename)
 			assert.Equal(t, tt.wantOK, ok)
 			assert.Equal(t, tt.wantKind, kind)

--- a/internal/log/store_test.go
+++ b/internal/log/store_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestLogStore_RecordAndFailedResources(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 
 	store, err := NewStore(tmpDir)
@@ -48,6 +49,7 @@ func TestLogStore_RecordAndFailedResources(t *testing.T) {
 }
 
 func TestLogStore_RecordComplete_DiscardsFile(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 
 	store, err := NewStore(tmpDir)
@@ -77,6 +79,7 @@ func TestLogStore_RecordComplete_DiscardsFile(t *testing.T) {
 }
 
 func TestLogStore_Flush(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 
 	store, err := NewStore(tmpDir)
@@ -120,6 +123,7 @@ func TestLogStore_Flush(t *testing.T) {
 }
 
 func TestLogStore_Flush_NoFailures(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 
 	store, err := NewStore(tmpDir)
@@ -139,6 +143,7 @@ func TestLogStore_Flush_NoFailures(t *testing.T) {
 }
 
 func TestLogStore_Cleanup(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 
 	// Create 7 fake session directories
@@ -180,6 +185,7 @@ func TestLogStore_Cleanup(t *testing.T) {
 }
 
 func TestLogStore_Cleanup_FewSessions(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 
 	// Only 2 sessions, keep 5
@@ -199,6 +205,7 @@ func TestLogStore_Cleanup_FewSessions(t *testing.T) {
 }
 
 func TestLogStore_MultipleFailures_Sorted(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 
 	store, err := NewStore(tmpDir)
@@ -226,6 +233,7 @@ func TestLogStore_MultipleFailures_Sorted(t *testing.T) {
 }
 
 func TestLogStore_Close_CleansUpTmpFiles(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 
 	store, err := NewStore(tmpDir)

--- a/internal/path/path_test.go
+++ b/internal/path/path_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestNew(t *testing.T) {
+	t.Parallel()
+
 	home, err := os.UserHomeDir()
 	require.NoError(t, err)
 
@@ -64,6 +66,8 @@ func TestNew(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			p, err := New(tt.opts...)
 			require.NoError(t, err)
 
@@ -75,6 +79,8 @@ func TestNew(t *testing.T) {
 }
 
 func TestPaths_ToolInstallDir(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name        string
 		userDataDir string
@@ -100,6 +106,8 @@ func TestPaths_ToolInstallDir(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			p, err := New(WithUserDataDir(tt.userDataDir))
 			require.NoError(t, err)
 
@@ -110,6 +118,8 @@ func TestPaths_ToolInstallDir(t *testing.T) {
 }
 
 func TestPaths_RuntimeInstallDir(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name        string
 		userDataDir string
@@ -135,6 +145,8 @@ func TestPaths_RuntimeInstallDir(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			p, err := New(WithUserDataDir(tt.userDataDir))
 			require.NoError(t, err)
 
@@ -145,6 +157,8 @@ func TestPaths_RuntimeInstallDir(t *testing.T) {
 }
 
 func TestPaths_StateFiles(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name          string
 		userDataDir   string
@@ -167,6 +181,8 @@ func TestPaths_StateFiles(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			p, err := New(
 				WithUserDataDir(tt.userDataDir),
 				WithSystemDataDir(tt.systemDataDir),
@@ -182,6 +198,8 @@ func TestPaths_StateFiles(t *testing.T) {
 }
 
 func TestEnsureDir(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		subPath string
@@ -198,6 +216,8 @@ func TestEnsureDir(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			tmpDir := t.TempDir()
 			targetDir := filepath.Join(tmpDir, tt.subPath)
 
@@ -212,6 +232,8 @@ func TestEnsureDir(t *testing.T) {
 }
 
 func TestExpand(t *testing.T) {
+	t.Parallel()
+
 	home, err := os.UserHomeDir()
 	require.NoError(t, err)
 
@@ -250,6 +272,8 @@ func TestExpand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got, err := Expand(tt.path)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -262,6 +286,8 @@ func TestExpand(t *testing.T) {
 }
 
 func TestNewFromConfig(t *testing.T) {
+	t.Parallel()
+
 	home, err := os.UserHomeDir()
 	require.NoError(t, err)
 
@@ -302,6 +328,8 @@ func TestNewFromConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			p, err := NewFromConfig(tt.cfg)
 			require.NoError(t, err)
 

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -15,6 +15,8 @@ import (
 // --- Helper / Utility tests ---
 
 func TestResolveResourceType(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		input   string
 		want    string
@@ -39,6 +41,8 @@ func TestResolveResourceType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+
 			got, err := ResolveResourceType(tt.input)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -51,6 +55,8 @@ func TestResolveResourceType(t *testing.T) {
 }
 
 func TestFormatVersionKind(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name        string
 		vk          resource.VersionKind
@@ -65,6 +71,8 @@ func TestFormatVersionKind(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := formatVersionKind(tt.vk, tt.specVersion)
 			assert.Equal(t, tt.want, got)
 		})
@@ -72,29 +80,39 @@ func TestFormatVersionKind(t *testing.T) {
 }
 
 func TestFilterMap(t *testing.T) {
+	t.Parallel()
+
 	m := map[string]*resource.ToolState{
 		"a": {Version: "1"},
 		"b": {Version: "2"},
 	}
 
 	t.Run("no filter returns all", func(t *testing.T) {
+		t.Parallel()
+
 		result := filterMap(m, "")
 		assert.Len(t, result, 2)
 	})
 
 	t.Run("filter by name", func(t *testing.T) {
+		t.Parallel()
+
 		result := filterMap(m, "a")
 		assert.Len(t, result, 1)
 		assert.Equal(t, "1", result["a"].Version)
 	})
 
 	t.Run("filter not found", func(t *testing.T) {
+		t.Parallel()
+
 		result := filterMap(m, "c")
 		assert.Nil(t, result)
 	})
 }
 
 func TestSortedKeys(t *testing.T) {
+	t.Parallel()
+
 	m := map[string]*resource.ToolState{
 		"c": {},
 		"a": {},
@@ -108,23 +126,33 @@ func TestSortedKeys(t *testing.T) {
 // --- Formatter unit tests ---
 
 func TestToolFormatter_Headers(t *testing.T) {
+	t.Parallel()
+
 	f := toolFormatter{}
 
 	t.Run("normal", func(t *testing.T) {
+		t.Parallel()
+
 		h := f.Headers(false)
 		assert.Equal(t, []string{"NAME", "VERSION", "VERSION_KIND", "INSTALLER/RUNTIME"}, h)
 	})
 
 	t.Run("wide", func(t *testing.T) {
+		t.Parallel()
+
 		h := f.Headers(true)
 		assert.Equal(t, []string{"NAME", "VERSION", "VERSION_KIND", "INSTALLER/RUNTIME", "PACKAGE", "BIN_PATH"}, h)
 	})
 }
 
 func TestToolFormatter_FormatRow(t *testing.T) {
+	t.Parallel()
+
 	f := toolFormatter{}
 
 	t.Run("installed with installerRef", func(t *testing.T) {
+		t.Parallel()
+
 		ts := &resource.ToolState{
 			Version:      "14.1.1",
 			InstallerRef: "aqua",
@@ -140,6 +168,8 @@ func TestToolFormatter_FormatRow(t *testing.T) {
 	})
 
 	t.Run("with runtimeRef", func(t *testing.T) {
+		t.Parallel()
+
 		ts := &resource.ToolState{
 			Version:     "v0.17.0",
 			RuntimeRef:  "go",
@@ -151,6 +181,8 @@ func TestToolFormatter_FormatRow(t *testing.T) {
 	})
 
 	t.Run("wide adds package and binpath", func(t *testing.T) {
+		t.Parallel()
+
 		ts := &resource.ToolState{
 			Version:      "14.1.1",
 			InstallerRef: "aqua",
@@ -166,23 +198,33 @@ func TestToolFormatter_FormatRow(t *testing.T) {
 }
 
 func TestRuntimeFormatter_Headers(t *testing.T) {
+	t.Parallel()
+
 	f := runtimeFormatter{}
 
 	t.Run("normal", func(t *testing.T) {
+		t.Parallel()
+
 		h := f.Headers(false)
 		assert.Equal(t, []string{"NAME", "VERSION", "VERSION_KIND", "TYPE"}, h)
 	})
 
 	t.Run("wide", func(t *testing.T) {
+		t.Parallel()
+
 		h := f.Headers(true)
 		assert.Equal(t, []string{"NAME", "VERSION", "VERSION_KIND", "TYPE", "INSTALL_PATH", "BINARIES"}, h)
 	})
 }
 
 func TestRuntimeFormatter_FormatRow(t *testing.T) {
+	t.Parallel()
+
 	f := runtimeFormatter{}
 
 	t.Run("download", func(t *testing.T) {
+		t.Parallel()
+
 		rs := &resource.RuntimeState{
 			Type:        resource.InstallTypeDownload,
 			Version:     "1.25.1",
@@ -193,6 +235,8 @@ func TestRuntimeFormatter_FormatRow(t *testing.T) {
 	})
 
 	t.Run("delegation with alias", func(t *testing.T) {
+		t.Parallel()
+
 		rs := &resource.RuntimeState{
 			Type:        resource.InstallTypeDelegation,
 			Version:     "1.75.0",
@@ -205,6 +249,8 @@ func TestRuntimeFormatter_FormatRow(t *testing.T) {
 	})
 
 	t.Run("wide adds install_path and binaries", func(t *testing.T) {
+		t.Parallel()
+
 		rs := &resource.RuntimeState{
 			Type:        resource.InstallTypeDownload,
 			Version:     "1.25.1",
@@ -220,15 +266,21 @@ func TestRuntimeFormatter_FormatRow(t *testing.T) {
 }
 
 func TestInstallerFormatter_FormatRow(t *testing.T) {
+	t.Parallel()
+
 	f := installerFormatter{}
 
 	t.Run("with toolRef", func(t *testing.T) {
+		t.Parallel()
+
 		is := &resource.InstallerState{Version: "v1.10.0", ToolRef: "cargo-binstall"}
 		row := f.FormatRow("binstall", is, false)
 		assert.Equal(t, []string{"binstall", "v1.10.0", "cargo-binstall"}, row)
 	})
 
 	t.Run("without toolRef", func(t *testing.T) {
+		t.Parallel()
+
 		is := &resource.InstallerState{Version: "v2.45.0"}
 		row := f.FormatRow("aqua", is, false)
 		assert.Equal(t, []string{"aqua", "v2.45.0", ""}, row)
@@ -236,6 +288,8 @@ func TestInstallerFormatter_FormatRow(t *testing.T) {
 }
 
 func TestInstallerRepoFormatter_FormatRow(t *testing.T) {
+	t.Parallel()
+
 	f := installerRepoFormatter{}
 
 	rs := &resource.InstallerRepositoryState{
@@ -250,6 +304,8 @@ func TestInstallerRepoFormatter_FormatRow(t *testing.T) {
 // --- printTable integration tests ---
 
 func TestPrintTable_Tools(t *testing.T) {
+	t.Parallel()
+
 	buf := &bytes.Buffer{}
 	tools := map[string]*resource.ToolState{
 		"ripgrep": {
@@ -288,6 +344,8 @@ func TestPrintTable_Tools(t *testing.T) {
 }
 
 func TestPrintTable_Tools_Wide(t *testing.T) {
+	t.Parallel()
+
 	buf := &bytes.Buffer{}
 	tools := map[string]*resource.ToolState{
 		"ripgrep": {
@@ -309,6 +367,8 @@ func TestPrintTable_Tools_Wide(t *testing.T) {
 }
 
 func TestPrintTable_Tools_NameFilter(t *testing.T) {
+	t.Parallel()
+
 	buf := &bytes.Buffer{}
 	tools := map[string]*resource.ToolState{
 		"ripgrep": {Version: "14.1.1", InstallerRef: "aqua", VersionKind: resource.VersionExact},
@@ -323,6 +383,8 @@ func TestPrintTable_Tools_NameFilter(t *testing.T) {
 }
 
 func TestPrintTable_Empty(t *testing.T) {
+	t.Parallel()
+
 	buf := &bytes.Buffer{}
 
 	printTable(buf, map[string]*resource.ToolState{}, "", false, toolFormatter{})
@@ -331,6 +393,8 @@ func TestPrintTable_Empty(t *testing.T) {
 }
 
 func TestPrintTable_NameFilter_NotFound(t *testing.T) {
+	t.Parallel()
+
 	buf := &bytes.Buffer{}
 	tools := map[string]*resource.ToolState{
 		"ripgrep": {Version: "14.1.1", InstallerRef: "aqua"},
@@ -342,6 +406,8 @@ func TestPrintTable_NameFilter_NotFound(t *testing.T) {
 }
 
 func TestPrintTable_Runtimes(t *testing.T) {
+	t.Parallel()
+
 	buf := &bytes.Buffer{}
 	runtimes := map[string]*resource.RuntimeState{
 		"go": {
@@ -368,6 +434,8 @@ func TestPrintTable_Runtimes(t *testing.T) {
 }
 
 func TestPrintTable_Installers(t *testing.T) {
+	t.Parallel()
+
 	buf := &bytes.Buffer{}
 	installers := map[string]*resource.InstallerState{
 		"aqua":     {Version: "v2.45.0"},
@@ -385,6 +453,8 @@ func TestPrintTable_Installers(t *testing.T) {
 }
 
 func TestPrintTable_InstallerRepositories(t *testing.T) {
+	t.Parallel()
+
 	buf := &bytes.Buffer{}
 	repos := map[string]*resource.InstallerRepositoryState{
 		"custom-registry": {
@@ -406,6 +476,8 @@ func TestPrintTable_InstallerRepositories(t *testing.T) {
 // --- printResources tests ---
 
 func TestPrintResources_JSON(t *testing.T) {
+	t.Parallel()
+
 	buf := &bytes.Buffer{}
 	tools := map[string]*resource.ToolState{
 		"ripgrep": {Version: "14.1.1", InstallerRef: "aqua", VersionKind: resource.VersionExact},
@@ -422,6 +494,8 @@ func TestPrintResources_JSON(t *testing.T) {
 }
 
 func TestPrintResources_JSON_NameFilter(t *testing.T) {
+	t.Parallel()
+
 	buf := &bytes.Buffer{}
 	tools := map[string]*resource.ToolState{
 		"ripgrep": {Version: "14.1.1", InstallerRef: "aqua"},
@@ -439,6 +513,8 @@ func TestPrintResources_JSON_NameFilter(t *testing.T) {
 }
 
 func TestPrintResources_Table(t *testing.T) {
+	t.Parallel()
+
 	buf := &bytes.Buffer{}
 	tools := map[string]*resource.ToolState{
 		"ripgrep": {Version: "14.1.1", InstallerRef: "aqua", VersionKind: resource.VersionExact},
@@ -455,6 +531,8 @@ func TestPrintResources_Table(t *testing.T) {
 // --- Run integration test ---
 
 func TestRun(t *testing.T) {
+	t.Parallel()
+
 	userState := &state.UserState{
 		Tools: map[string]*resource.ToolState{
 			"ripgrep": {Version: "14.1.1", InstallerRef: "aqua", VersionKind: resource.VersionExact},
@@ -465,6 +543,8 @@ func TestRun(t *testing.T) {
 	}
 
 	t.Run("tools table", func(t *testing.T) {
+		t.Parallel()
+
 		buf := &bytes.Buffer{}
 		err := Run(buf, userState, "tools", "", false, false)
 		require.NoError(t, err)
@@ -472,6 +552,8 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("tools json", func(t *testing.T) {
+		t.Parallel()
+
 		buf := &bytes.Buffer{}
 		err := Run(buf, userState, "tools", "", false, true)
 		require.NoError(t, err)
@@ -483,6 +565,8 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("empty runtimes", func(t *testing.T) {
+		t.Parallel()
+
 		buf := &bytes.Buffer{}
 		err := Run(buf, userState, "runtimes", "", false, false)
 		require.NoError(t, err)
@@ -490,6 +574,8 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("unknown type", func(t *testing.T) {
+		t.Parallel()
+
 		buf := &bytes.Buffer{}
 		err := Run(buf, userState, "unknown", "", false, false)
 		require.Error(t, err)

--- a/internal/registry/aqua/fetcher_test.go
+++ b/internal/registry/aqua/fetcher_test.go
@@ -32,6 +32,7 @@ func newMockResponse(statusCode int, body string) *http.Response {
 }
 
 func TestFetcher_Fetch_CacheHit(t *testing.T) {
+	t.Parallel()
 	// Setup: create a cache directory with a cached registry.yaml
 	cacheDir := t.TempDir()
 	ref := "v4.465.0"
@@ -75,6 +76,7 @@ func TestFetcher_Fetch_CacheHit(t *testing.T) {
 }
 
 func TestFetcher_Fetch_CacheMiss(t *testing.T) {
+	t.Parallel()
 	cacheDir := t.TempDir()
 	ref := "v4.465.0"
 	pkg := "cli/cli"
@@ -115,6 +117,7 @@ func TestFetcher_Fetch_CacheMiss(t *testing.T) {
 }
 
 func TestFetcher_Fetch_NotFound(t *testing.T) {
+	t.Parallel()
 	cacheDir := t.TempDir()
 	ref := "v4.465.0"
 	pkg := "nonexistent/package"
@@ -139,6 +142,7 @@ func TestFetcher_Fetch_NotFound(t *testing.T) {
 }
 
 func TestFetcher_Fetch_ServerError(t *testing.T) {
+	t.Parallel()
 	cacheDir := t.TempDir()
 	ref := "v4.465.0"
 	pkg := "cli/cli"
@@ -163,6 +167,7 @@ func TestFetcher_Fetch_ServerError(t *testing.T) {
 }
 
 func TestFetcher_cachePath(t *testing.T) {
+	t.Parallel()
 	f := newFetcher("/home/user/.cache/tomei/registry/aqua", nil)
 
 	tests := []struct {
@@ -184,6 +189,7 @@ func TestFetcher_cachePath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.pkg, func(t *testing.T) {
+			t.Parallel()
 			path, err := f.cachePath(tt.ref, tt.pkg)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, path)
@@ -192,6 +198,7 @@ func TestFetcher_cachePath(t *testing.T) {
 }
 
 func TestFetcher_writeCache_AtomicWrite(t *testing.T) {
+	t.Parallel()
 	cacheDir := t.TempDir()
 	f := newFetcher(cacheDir, nil)
 
@@ -214,6 +221,7 @@ func TestFetcher_writeCache_AtomicWrite(t *testing.T) {
 }
 
 func TestFetcher_cachePath_PathTraversal(t *testing.T) {
+	t.Parallel()
 	f := newFetcher("/home/user/.cache/tomei/registry/aqua", nil)
 
 	tests := []struct {
@@ -262,6 +270,7 @@ func TestFetcher_cachePath_PathTraversal(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			_, err := f.cachePath(tt.ref, tt.pkg)
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/internal/registry/aqua/override_test.go
+++ b/internal/registry/aqua/override_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestApplyOSOverrides(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		info   *PackageInfo
@@ -161,6 +162,7 @@ func TestApplyOSOverrides(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := applyOSOverrides(tt.info, tt.goos, tt.goarch)
 			tt.check(t, result)
 		})
@@ -168,6 +170,7 @@ func TestApplyOSOverrides(t *testing.T) {
 }
 
 func TestMatchesOS(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		override Override
@@ -228,6 +231,7 @@ func TestMatchesOS(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := matchesOS(tt.override, tt.goos, tt.goarch)
 			assert.Equal(t, tt.want, got)
 		})
@@ -235,6 +239,7 @@ func TestMatchesOS(t *testing.T) {
 }
 
 func TestApplyReplacement(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		replacements map[string]string
@@ -282,6 +287,7 @@ func TestApplyReplacement(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := applyReplacement(tt.replacements, tt.key)
 			assert.Equal(t, tt.want, got)
 		})

--- a/internal/registry/aqua/resolver_test.go
+++ b/internal/registry/aqua/resolver_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestResolver_Resolve_GitHubRelease(t *testing.T) {
+	t.Parallel()
 	// Setup: create cache with package info
 	cacheDir := t.TempDir()
 	ref := RegistryRef("v4.465.0")
@@ -51,6 +52,7 @@ func TestResolver_Resolve_GitHubRelease(t *testing.T) {
 }
 
 func TestResolver_Resolve_HTTP(t *testing.T) {
+	t.Parallel()
 	cacheDir := t.TempDir()
 	ref := RegistryRef("v4.465.0")
 	pkg := "example/tool"
@@ -75,6 +77,7 @@ func TestResolver_Resolve_HTTP(t *testing.T) {
 }
 
 func TestResolver_Resolve_WithVersionOverrides(t *testing.T) {
+	t.Parallel()
 	cacheDir := t.TempDir()
 	ref := RegistryRef("v4.465.0")
 	pkg := "cli/cli"
@@ -105,6 +108,7 @@ func TestResolver_Resolve_WithVersionOverrides(t *testing.T) {
 }
 
 func TestResolver_Resolve_WithOSOverrides(t *testing.T) {
+	t.Parallel()
 	cacheDir := t.TempDir()
 	ref := RegistryRef("v4.465.0")
 	pkg := "example/tool"
@@ -134,6 +138,7 @@ func TestResolver_Resolve_WithOSOverrides(t *testing.T) {
 }
 
 func TestResolver_Resolve_WithReplacements(t *testing.T) {
+	t.Parallel()
 	cacheDir := t.TempDir()
 	ref := RegistryRef("v4.465.0")
 	pkg := "BurntSushi/ripgrep"
@@ -162,6 +167,7 @@ func TestResolver_Resolve_WithReplacements(t *testing.T) {
 }
 
 func TestResolver_Resolve_UnsupportedEnv(t *testing.T) {
+	t.Parallel()
 	cacheDir := t.TempDir()
 	ref := RegistryRef("v4.465.0")
 	pkg := "example/tool"
@@ -191,6 +197,7 @@ func TestResolver_Resolve_UnsupportedEnv(t *testing.T) {
 }
 
 func TestResolver_Resolve_SupportedEnv(t *testing.T) {
+	t.Parallel()
 	cacheDir := t.TempDir()
 	ref := RegistryRef("v4.465.0")
 	pkg := "example/tool"
@@ -219,6 +226,7 @@ func TestResolver_Resolve_SupportedEnv(t *testing.T) {
 }
 
 func TestResolver_Resolve_PackageNotFound(t *testing.T) {
+	t.Parallel()
 	cacheDir := t.TempDir()
 
 	mockClient := &http.Client{
@@ -242,6 +250,7 @@ func TestResolver_Resolve_PackageNotFound(t *testing.T) {
 }
 
 func TestResolver_Resolve_UsesRuntimeOS(t *testing.T) {
+	t.Parallel()
 	// Test that Resolve() uses runtime.GOOS and runtime.GOARCH
 	cacheDir := t.TempDir()
 	ref := RegistryRef("v4.465.0")
@@ -269,6 +278,7 @@ func TestResolver_Resolve_UsesRuntimeOS(t *testing.T) {
 }
 
 func TestResolver_VersionClient(t *testing.T) {
+	t.Parallel()
 	cacheDir := t.TempDir()
 	resolver := NewResolver(cacheDir, nil)
 
@@ -282,6 +292,7 @@ func TestResolver_VersionClient(t *testing.T) {
 }
 
 func TestResolver_Resolve_NoChecksum(t *testing.T) {
+	t.Parallel()
 	cacheDir := t.TempDir()
 	ref := RegistryRef("v4.465.0")
 	pkg := "example/tool"
@@ -309,6 +320,7 @@ func TestResolver_Resolve_NoChecksum(t *testing.T) {
 }
 
 func TestResolver_Resolve_UnsupportedType(t *testing.T) {
+	t.Parallel()
 	cacheDir := t.TempDir()
 	ref := RegistryRef("v4.465.0")
 	pkg := "example/tool"
@@ -334,6 +346,7 @@ func TestResolver_Resolve_UnsupportedType(t *testing.T) {
 }
 
 func TestResolver_Resolve_SupportedEnvAll(t *testing.T) {
+	t.Parallel()
 	cacheDir := t.TempDir()
 	ref := RegistryRef("v4.465.0")
 	pkg := "example/tool"
@@ -362,6 +375,7 @@ func TestResolver_Resolve_SupportedEnvAll(t *testing.T) {
 }
 
 func TestIsSupportedEnv(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		supportedEnvs []string
@@ -415,6 +429,7 @@ func TestIsSupportedEnv(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := isSupportedEnv(tt.supportedEnvs, tt.goos, tt.goarch)
 			assert.Equal(t, tt.want, got)
 		})

--- a/internal/registry/aqua/template_test.go
+++ b/internal/registry/aqua/template_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestRenderTemplate(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		template string
@@ -125,6 +126,7 @@ func TestRenderTemplate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := RenderTemplate(tt.template, tt.vars)
 			if tt.wantErr {
 				require.Error(t, err)

--- a/internal/registry/aqua/types_test.go
+++ b/internal/registry/aqua/types_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestPackageInfo_YAMLParse(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		yaml     string
@@ -156,6 +157,7 @@ format: tar.gz
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var got PackageInfo
 			err := yaml.Unmarshal([]byte(tt.yaml), &got)
 
@@ -182,6 +184,7 @@ format: tar.gz
 }
 
 func TestRegistryRef_Validate(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		ref     RegistryRef
@@ -241,6 +244,7 @@ func TestRegistryRef_Validate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			err := tt.ref.Validate()
 			if tt.wantErr {
 				require.Error(t, err)
@@ -253,6 +257,7 @@ func TestRegistryRef_Validate(t *testing.T) {
 }
 
 func TestRegistryRef_IsEmpty(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		ref  RegistryRef
@@ -272,17 +277,20 @@ func TestRegistryRef_IsEmpty(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tt.want, tt.ref.IsEmpty())
 		})
 	}
 }
 
 func TestRegistryRef_String(t *testing.T) {
+	t.Parallel()
 	ref := RegistryRef("v4.465.0")
 	assert.Equal(t, "v4.465.0", ref.String())
 }
 
 func TestFileSpec_YAMLParse(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		yaml     string
@@ -310,6 +318,7 @@ src: gh_v2.0.0_linux_amd64/bin/gh
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var got FileSpec
 			err := yaml.Unmarshal([]byte(tt.yaml), &got)
 			require.NoError(t, err)
@@ -319,6 +328,7 @@ src: gh_v2.0.0_linux_amd64/bin/gh
 }
 
 func TestVersionOverride_YAMLParse(t *testing.T) {
+	t.Parallel()
 	yamlData := `
 version_constraint: semver("< 1.0.0")
 asset: old-asset-{{.Version}}.tar.gz

--- a/internal/registry/aqua/version_client_test.go
+++ b/internal/registry/aqua/version_client_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestVersionClient_GetLatestRef(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		statusCode int
@@ -39,6 +40,7 @@ func TestVersionClient_GetLatestRef(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			mockClient := &http.Client{
 				Transport: &mockRoundTripper{
 					handler: func(req *http.Request) (*http.Response, error) {
@@ -64,6 +66,7 @@ func TestVersionClient_GetLatestRef(t *testing.T) {
 }
 
 func TestVersionClient_GetLatestToolVersion(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		repoOwner  string
@@ -113,6 +116,7 @@ func TestVersionClient_GetLatestToolVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			mockClient := &http.Client{
 				Transport: &mockRoundTripper{
 					handler: func(req *http.Request) (*http.Response, error) {

--- a/internal/registry/aqua/version_test.go
+++ b/internal/registry/aqua/version_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestMatchVersionConstraint(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		constraint string
@@ -56,6 +57,7 @@ func TestMatchVersionConstraint(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := matchVersionConstraint(tt.constraint, tt.version)
 			assert.Equal(t, tt.want, got)
 		})
@@ -63,6 +65,7 @@ func TestMatchVersionConstraint(t *testing.T) {
 }
 
 func TestApplyVersionOverrides(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		info    *PackageInfo
@@ -236,6 +239,7 @@ func TestApplyVersionOverrides(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := ApplyVersionOverrides(tt.info, tt.version)
 			tt.check(t, result)
 		})

--- a/internal/resource/expand_test.go
+++ b/internal/resource/expand_test.go
@@ -11,6 +11,7 @@ import (
 func boolPtr(b bool) *bool { return &b }
 
 func TestExpandSets(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		resources []Resource
@@ -201,6 +202,7 @@ func TestExpandSets(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := ExpandSets(tt.resources)
 
 			if tt.wantErr != "" {
@@ -232,7 +234,9 @@ func TestExpandSets(t *testing.T) {
 }
 
 func TestExpandSets_InheritedFields(t *testing.T) {
+	t.Parallel()
 	t.Run("installerRef inherited", func(t *testing.T) {
+		t.Parallel()
 		resources := []Resource{
 			&ToolSet{
 				BaseResource: BaseResource{Metadata: Metadata{Name: "cli-tools"}},
@@ -256,6 +260,7 @@ func TestExpandSets_InheritedFields(t *testing.T) {
 	})
 
 	t.Run("runtimeRef inherited", func(t *testing.T) {
+		t.Parallel()
 		resources := []Resource{
 			&ToolSet{
 				BaseResource: BaseResource{Metadata: Metadata{Name: "go-tools"}},
@@ -280,6 +285,7 @@ func TestExpandSets_InheritedFields(t *testing.T) {
 	})
 
 	t.Run("source inherited", func(t *testing.T) {
+		t.Parallel()
 		src := &DownloadSource{URL: "https://example.com/fd.tar.gz"}
 		resources := []Resource{
 			&ToolSet{

--- a/internal/resource/installer_repository_test.go
+++ b/internal/resource/installer_repository_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestInstallerRepositorySpec_Validate(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		spec    InstallerRepositorySpec
@@ -114,6 +115,7 @@ func TestInstallerRepositorySpec_Validate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			err := tt.spec.Validate()
 			if tt.wantErr == "" {
 				require.NoError(t, err)
@@ -126,6 +128,7 @@ func TestInstallerRepositorySpec_Validate(t *testing.T) {
 }
 
 func TestInstallerRepositorySpec_Dependencies(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		spec InstallerRepositorySpec
@@ -149,6 +152,7 @@ func TestInstallerRepositorySpec_Dependencies(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := tt.spec.Dependencies()
 			assert.Equal(t, tt.want, got)
 		})
@@ -156,11 +160,13 @@ func TestInstallerRepositorySpec_Dependencies(t *testing.T) {
 }
 
 func TestInstallerRepository_Kind(t *testing.T) {
+	t.Parallel()
 	repo := &InstallerRepository{}
 	assert.Equal(t, KindInstallerRepository, repo.Kind())
 }
 
 func TestInstallerRepository_Spec(t *testing.T) {
+	t.Parallel()
 	spec := &InstallerRepositorySpec{
 		InstallerRef: "helm",
 		Source: InstallerRepositorySourceSpec{
@@ -181,6 +187,7 @@ func TestInstallerRepository_Spec(t *testing.T) {
 }
 
 func TestInstallerRepositoryState_IsState(t *testing.T) {
+	t.Parallel()
 	// Verify InstallerRepositoryState satisfies the State interface
 	var _ State = (*InstallerRepositoryState)(nil)
 }

--- a/internal/resource/installer_test.go
+++ b/internal/resource/installer_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestInstallerSpec_Validate(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		spec    InstallerSpec
@@ -84,6 +85,7 @@ func TestInstallerSpec_Validate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			err := tt.spec.Validate()
 			if tt.wantErr == "" {
 				if err != nil {
@@ -101,6 +103,7 @@ func TestInstallerSpec_Validate(t *testing.T) {
 }
 
 func TestInstallerSpec_Dependencies(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		spec InstallerSpec
@@ -133,6 +136,7 @@ func TestInstallerSpec_Dependencies(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := tt.spec.Dependencies()
 			if len(got) != len(tt.want) {
 				t.Errorf("Dependencies() = %v, want %v", got, tt.want)

--- a/internal/resource/tool_test.go
+++ b/internal/resource/tool_test.go
@@ -203,6 +203,7 @@ func TestPackage_Validate(t *testing.T) {
 }
 
 func TestPackage_String(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		pkg  *Package
@@ -232,12 +233,14 @@ func TestPackage_String(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tt.want, tt.pkg.String())
 		})
 	}
 }
 
 func TestPackage_IsEmpty(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		pkg  *Package
@@ -277,12 +280,14 @@ func TestPackage_IsEmpty(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tt.want, tt.pkg.IsEmpty())
 		})
 	}
 }
 
 func TestPackage_IsRegistry(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		pkg  *Package
@@ -312,12 +317,14 @@ func TestPackage_IsRegistry(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tt.want, tt.pkg.IsRegistry())
 		})
 	}
 }
 
 func TestPackage_IsName(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		pkg  *Package
@@ -347,12 +354,14 @@ func TestPackage_IsName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tt.want, tt.pkg.IsName())
 		})
 	}
 }
 
 func TestToolSpec_Dependencies(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		spec *ToolSpec
@@ -423,6 +432,7 @@ func TestToolSpec_Dependencies(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := tt.spec.Dependencies()
 			assert.Equal(t, tt.want, got)
 		})
@@ -430,6 +440,7 @@ func TestToolSpec_Dependencies(t *testing.T) {
 }
 
 func TestPackage_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		json    string
@@ -502,6 +513,7 @@ func TestPackage_UnmarshalJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var got Package
 			err := got.UnmarshalJSON([]byte(tt.json))
 			if tt.wantErr {
@@ -515,6 +527,7 @@ func TestPackage_UnmarshalJSON(t *testing.T) {
 }
 
 func TestToolSetSpec_Dependencies(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		spec *ToolSetSpec
@@ -552,6 +565,7 @@ func TestToolSetSpec_Dependencies(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := tt.spec.Dependencies()
 			assert.Equal(t, tt.want, got)
 		})
@@ -559,6 +573,7 @@ func TestToolSetSpec_Dependencies(t *testing.T) {
 }
 
 func TestToolSet_Expand_WithRepositoryRef(t *testing.T) {
+	t.Parallel()
 	ts := &ToolSet{
 		BaseResource: BaseResource{
 			APIVersion:   GroupVersion,
@@ -589,6 +604,7 @@ func TestToolSet_Expand_WithRepositoryRef(t *testing.T) {
 }
 
 func TestIsRegistryFormat(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input string
 		want  bool
@@ -624,6 +640,7 @@ func TestIsRegistryFormat(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
 			got := isRegistryFormat(tt.input)
 			assert.Equal(t, tt.want, got, "isRegistryFormat(%q)", tt.input)
 		})

--- a/internal/resource/types_test.go
+++ b/internal/resource/types_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestToolSpec_IsEnabled(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		enabled *bool
@@ -18,6 +19,7 @@ func TestToolSpec_IsEnabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			spec := &ToolSpec{Enabled: tt.enabled}
 			if got := spec.IsEnabled(); got != tt.want {
 				t.Errorf("IsEnabled() = %v, want %v", got, tt.want)
@@ -27,6 +29,7 @@ func TestToolSpec_IsEnabled(t *testing.T) {
 }
 
 func TestToolItem_IsEnabled(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		enabled *bool
@@ -39,6 +42,7 @@ func TestToolItem_IsEnabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			item := &ToolItem{Enabled: tt.enabled}
 			if got := item.IsEnabled(); got != tt.want {
 				t.Errorf("IsEnabled() = %v, want %v", got, tt.want)
@@ -48,6 +52,7 @@ func TestToolItem_IsEnabled(t *testing.T) {
 }
 
 func TestToolState_Taint(t *testing.T) {
+	t.Parallel()
 	state := &ToolState{
 		InstallerRef: "go",
 		Version:      "0.16.0",
@@ -73,6 +78,7 @@ func TestToolState_Taint(t *testing.T) {
 }
 
 func TestAction_NeedsExecution(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		actionType ActionType
@@ -88,6 +94,7 @@ func TestAction_NeedsExecution(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			action := &Action{ActionType: tt.actionType}
 			if got := action.NeedsExecution(); got != tt.want {
 				t.Errorf("NeedsExecution() = %v, want %v", got, tt.want)
@@ -97,6 +104,7 @@ func TestAction_NeedsExecution(t *testing.T) {
 }
 
 func TestNormalizeKind(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input string
@@ -122,6 +130,7 @@ func TestNormalizeKind(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, ok := NormalizeKind(tt.input)
 			if ok != tt.ok {
 				t.Errorf("NormalizeKind(%q) ok = %v, want %v", tt.input, ok, tt.ok)
@@ -134,6 +143,7 @@ func TestNormalizeKind(t *testing.T) {
 }
 
 func TestParseRef(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		input   string
@@ -194,6 +204,7 @@ func TestParseRef(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := ParseRef(tt.input)
 			if tt.wantErr {
 				if err == nil {
@@ -213,6 +224,7 @@ func TestParseRef(t *testing.T) {
 }
 
 func TestParseRefArgs(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		args    []string
@@ -273,6 +285,7 @@ func TestParseRefArgs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := ParseRefArgs(tt.args)
 			if tt.wantErr {
 				if err == nil {

--- a/internal/state/backup_test.go
+++ b/internal/state/backup_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestBackupPath(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		statePath string
@@ -31,12 +32,14 @@ func TestBackupPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tt.want, BackupPath(tt.statePath))
 		})
 	}
 }
 
 func TestCreateBackup(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		setup     func(t *testing.T, dir string)
@@ -69,6 +72,7 @@ func TestCreateBackup(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			dir := t.TempDir()
 			tt.setup(t, dir)
 
@@ -103,6 +107,7 @@ func TestCreateBackup(t *testing.T) {
 }
 
 func TestCreateBackup_AtomicWrite(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	store, err := NewStore[UserState](dir)
 	require.NoError(t, err)
@@ -122,6 +127,7 @@ func TestCreateBackup_AtomicWrite(t *testing.T) {
 }
 
 func TestLoadBackup(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		setup   func(t *testing.T, dir string) string
@@ -173,6 +179,7 @@ func TestLoadBackup(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			dir := t.TempDir()
 			statePath := tt.setup(t, dir)
 

--- a/internal/state/diff_test.go
+++ b/internal/state/diff_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestDiffUserStates(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		old         *UserState
@@ -242,6 +243,7 @@ func TestDiffUserStates(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			diff := DiffUserStates(tt.old, tt.current)
 			require.Len(t, diff.Changes, tt.wantChanges)
 			if tt.check != nil {
@@ -252,6 +254,7 @@ func TestDiffUserStates(t *testing.T) {
 }
 
 func TestDiff_HasChanges(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		diff *Diff
@@ -271,12 +274,14 @@ func TestDiff_HasChanges(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tt.want, tt.diff.HasChanges())
 		})
 	}
 }
 
 func TestDiff_Summary(t *testing.T) {
+	t.Parallel()
 	diff := &Diff{
 		Changes: []ResourceDiff{
 			{Type: DiffAdded},
@@ -293,6 +298,7 @@ func TestDiff_Summary(t *testing.T) {
 }
 
 func TestCollectKeys(t *testing.T) {
+	t.Parallel()
 	a := map[string]int{"b": 1, "a": 2}
 	b := map[string]int{"c": 3, "a": 4}
 

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestStore_LockUnlock(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	store, err := NewStore[UserState](dir)
 	if err != nil {
@@ -39,6 +40,7 @@ func TestStore_LockUnlock(t *testing.T) {
 }
 
 func TestStore_LoadSave(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	store, err := NewStore[UserState](dir)
 	if err != nil {
@@ -113,6 +115,7 @@ func TestStore_LoadSave(t *testing.T) {
 }
 
 func TestStore_LoadReadOnly(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		setup   func(t *testing.T, store *Store[UserState])
@@ -169,6 +172,7 @@ func TestStore_LoadReadOnly(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			dir := t.TempDir()
 			store, err := NewStore[UserState](dir)
 			if err != nil {
@@ -195,6 +199,7 @@ func TestStore_LoadReadOnly(t *testing.T) {
 }
 
 func TestStore_LoadWithoutLock(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	store, err := NewStore[UserState](dir)
 	if err != nil {
@@ -208,6 +213,7 @@ func TestStore_LoadWithoutLock(t *testing.T) {
 }
 
 func TestStore_SaveWithoutLock(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	store, err := NewStore[UserState](dir)
 	if err != nil {
@@ -222,6 +228,7 @@ func TestStore_SaveWithoutLock(t *testing.T) {
 }
 
 func TestStore_AtomicWrite(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	store, err := NewStore[UserState](dir)
 	if err != nil {
@@ -254,6 +261,7 @@ func TestStore_AtomicWrite(t *testing.T) {
 }
 
 func TestStore_SystemState(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	store, err := NewStore[SystemState](dir)
 	if err != nil {
@@ -299,6 +307,7 @@ func TestStore_SystemState(t *testing.T) {
 }
 
 func TestNewStore_CreatesDirectory(t *testing.T) {
+	t.Parallel()
 	dir := filepath.Join(t.TempDir(), "nested", "path")
 	_, err := NewStore[UserState](dir)
 	if err != nil {
@@ -311,6 +320,7 @@ func TestNewStore_CreatesDirectory(t *testing.T) {
 }
 
 func TestStore_LockBehavior(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		test func(t *testing.T, dir string)
@@ -398,6 +408,7 @@ func TestStore_LockBehavior(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			dir := t.TempDir()
 			tt.test(t, dir)
 		})
@@ -405,6 +416,7 @@ func TestStore_LockBehavior(t *testing.T) {
 }
 
 func TestStore_PathAccessors(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	store, err := NewStore[UserState](dir)
 	if err != nil {
@@ -430,6 +442,7 @@ func TestStore_PathAccessors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if tt.got != tt.expected {
 				t.Errorf("expected %s, got %s", tt.expected, tt.got)
 			}
@@ -438,6 +451,7 @@ func TestStore_PathAccessors(t *testing.T) {
 }
 
 func TestStore_LoadErrors(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		setup     func(store *Store[UserState]) error
@@ -468,6 +482,7 @@ func TestStore_LoadErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			dir := t.TempDir()
 			store, err := NewStore[UserState](dir)
 			if err != nil {
@@ -495,6 +510,7 @@ func TestStore_LoadErrors(t *testing.T) {
 }
 
 func TestStore_SaveAndLoadPreservesAllFields(t *testing.T) {
+	t.Parallel()
 	now := time.Now().Truncate(time.Second) // Truncate for JSON round-trip
 
 	tests := []struct {
@@ -585,6 +601,7 @@ func TestStore_SaveAndLoadPreservesAllFields(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			dir := t.TempDir()
 			store, err := NewStore[UserState](dir)
 			if err != nil {
@@ -611,6 +628,7 @@ func TestStore_SaveAndLoadPreservesAllFields(t *testing.T) {
 }
 
 func TestStore_RegistryState(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 
 	tests := []struct {
@@ -756,6 +774,7 @@ func TestStore_RegistryState(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			dir := t.TempDir()
 			store, err := NewStore[UserState](dir)
 			if err != nil {
@@ -782,6 +801,7 @@ func TestStore_RegistryState(t *testing.T) {
 }
 
 func TestStore_SetQuiet(t *testing.T) {
+	// NOTE: Not parallel — this test modifies global slog.Default().
 	// Create state with empty version fields to trigger warnings
 	stateJSON := `{
 		"version": "1",

--- a/internal/state/validator_test.go
+++ b/internal/state/validator_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestValidateUserState(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		state        *UserState
@@ -101,6 +102,7 @@ func TestValidateUserState(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := ValidateUserState(tt.state)
 			assert.Equal(t, tt.wantValid, result.IsValid())
 			assert.Len(t, result.Warnings, tt.wantWarnings)
@@ -109,6 +111,7 @@ func TestValidateUserState(t *testing.T) {
 }
 
 func TestValidateSystemState(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		state        *SystemState
@@ -137,6 +140,7 @@ func TestValidateSystemState(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := ValidateSystemState(tt.state)
 			assert.Equal(t, tt.wantValid, result.IsValid())
 			assert.Len(t, result.Warnings, tt.wantWarnings)
@@ -145,11 +149,13 @@ func TestValidateSystemState(t *testing.T) {
 }
 
 func TestValidationError_String(t *testing.T) {
+	t.Parallel()
 	e := ValidationError{Field: "version", Message: "version is empty"}
 	assert.Equal(t, "version: version is empty", e.String())
 }
 
 func TestValidationResult_HasWarnings(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		result *ValidationResult
@@ -171,6 +177,7 @@ func TestValidationResult_HasWarnings(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tt.want, tt.result.HasWarnings())
 		})
 	}

--- a/internal/ui/cmdview_test.go
+++ b/internal/ui/cmdview_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestCommandView_StartTask(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	cv := NewCommandView(&buf)
 
@@ -29,6 +30,7 @@ func TestCommandView_StartTask(t *testing.T) {
 }
 
 func TestCommandView_AddOutput(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	cv := NewCommandView(&buf)
 
@@ -39,6 +41,7 @@ func TestCommandView_AddOutput(t *testing.T) {
 }
 
 func TestCommandView_AddOutput_IgnoresUnknownTask(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	cv := NewCommandView(&buf)
 
@@ -47,6 +50,7 @@ func TestCommandView_AddOutput_IgnoresUnknownTask(t *testing.T) {
 }
 
 func TestCommandView_AddOutput_IgnoresDoneTask(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	cv := NewCommandView(&buf)
 
@@ -58,6 +62,7 @@ func TestCommandView_AddOutput_IgnoresDoneTask(t *testing.T) {
 }
 
 func TestCommandView_LastLog(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		setup    func(cv *CommandView)
@@ -94,6 +99,7 @@ func TestCommandView_LastLog(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var buf bytes.Buffer
 			cv := NewCommandView(&buf)
 			tt.setup(cv)
@@ -103,6 +109,7 @@ func TestCommandView_LastLog(t *testing.T) {
 }
 
 func TestCommandView_CompleteTask(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	cv := NewCommandView(&buf)
 
@@ -120,6 +127,7 @@ func TestCommandView_CompleteTask(t *testing.T) {
 }
 
 func TestCommandView_FailTask(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	cv := NewCommandView(&buf)
 
@@ -136,6 +144,7 @@ func TestCommandView_FailTask(t *testing.T) {
 }
 
 func TestCommandView_PrintTaskStart(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	cv := NewCommandView(&buf)
 
@@ -151,6 +160,7 @@ func TestCommandView_PrintTaskStart(t *testing.T) {
 }
 
 func TestCommandView_PrintTaskStart_HeaderOnce(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	cv := NewCommandView(&buf)
 
@@ -171,6 +181,7 @@ func TestCommandView_PrintTaskStart_HeaderOnce(t *testing.T) {
 }
 
 func TestCommandView_PrintTaskStart_NilTask(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	cv := NewCommandView(&buf)
 
@@ -180,6 +191,7 @@ func TestCommandView_PrintTaskStart_NilTask(t *testing.T) {
 }
 
 func TestCommandView_PrintOutput(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	cv := NewCommandView(&buf)
 
@@ -191,6 +203,7 @@ func TestCommandView_PrintOutput(t *testing.T) {
 }
 
 func TestCommandView_PrintTaskComplete_Success(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	cv := NewCommandView(&buf)
 
@@ -204,6 +217,7 @@ func TestCommandView_PrintTaskComplete_Success(t *testing.T) {
 }
 
 func TestCommandView_PrintTaskComplete_Error(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	cv := NewCommandView(&buf)
 
@@ -217,6 +231,7 @@ func TestCommandView_PrintTaskComplete_Error(t *testing.T) {
 }
 
 func TestCommandView_PrintTaskComplete_NilTask(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	cv := NewCommandView(&buf)
 
@@ -226,6 +241,7 @@ func TestCommandView_PrintTaskComplete_NilTask(t *testing.T) {
 }
 
 func TestTruncateLine(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		input  string
@@ -260,6 +276,7 @@ func TestTruncateLine(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := truncateLine(tt.input, tt.maxLen)
 			assert.Equal(t, tt.want, got)
 		})
@@ -267,6 +284,7 @@ func TestTruncateLine(t *testing.T) {
 }
 
 func TestCommandView_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	cv := NewCommandView(&buf)
 

--- a/internal/ui/loghandler_test.go
+++ b/internal/ui/loghandler_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestTUILogHandler_WarnAndErrorAreSent(t *testing.T) {
+	t.Parallel()
 	s := &mockSender{}
 	handler := NewTUILogHandler(s, slog.LevelWarn)
 	logger := slog.New(handler)
@@ -29,6 +30,7 @@ func TestTUILogHandler_WarnAndErrorAreSent(t *testing.T) {
 }
 
 func TestTUILogHandler_DebugAndInfoIgnoredAtWarnLevel(t *testing.T) {
+	t.Parallel()
 	s := &mockSender{}
 	handler := NewTUILogHandler(s, slog.LevelWarn)
 	logger := slog.New(handler)
@@ -41,6 +43,7 @@ func TestTUILogHandler_DebugAndInfoIgnoredAtWarnLevel(t *testing.T) {
 }
 
 func TestTUILogHandler_AllLevelsAtDebugLevel(t *testing.T) {
+	t.Parallel()
 	s := &mockSender{}
 	handler := NewTUILogHandler(s, slog.LevelDebug)
 	logger := slog.New(handler)
@@ -60,6 +63,7 @@ func TestTUILogHandler_AllLevelsAtDebugLevel(t *testing.T) {
 }
 
 func TestTUILogHandler_AttrsIncludedInMessage(t *testing.T) {
+	t.Parallel()
 	s := &mockSender{}
 	handler := NewTUILogHandler(s, slog.LevelWarn)
 	logger := slog.New(handler)
@@ -76,6 +80,7 @@ func TestTUILogHandler_AttrsIncludedInMessage(t *testing.T) {
 }
 
 func TestTUILogHandler_WithAttrs(t *testing.T) {
+	t.Parallel()
 	s := &mockSender{}
 	handler := NewTUILogHandler(s, slog.LevelWarn)
 	child := handler.WithAttrs([]slog.Attr{slog.String("component", "engine")})
@@ -92,6 +97,7 @@ func TestTUILogHandler_WithAttrs(t *testing.T) {
 }
 
 func TestTUILogHandler_WithGroup(t *testing.T) {
+	t.Parallel()
 	s := &mockSender{}
 	handler := NewTUILogHandler(s, slog.LevelWarn)
 	child := handler.WithGroup("installer")

--- a/internal/ui/progress_test.go
+++ b/internal/ui/progress_test.go
@@ -24,6 +24,7 @@ func newNonTTYProgressManager(w *bytes.Buffer) *ProgressManager {
 }
 
 func TestProgressManager_HandleEvent_DownloadStart_NonTTY(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	pm := newNonTTYProgressManager(&buf)
 
@@ -43,6 +44,7 @@ func TestProgressManager_HandleEvent_DownloadStart_NonTTY(t *testing.T) {
 }
 
 func TestProgressManager_HandleEvent_DownloadHeaderOnce_NonTTY(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	pm := newNonTTYProgressManager(&buf)
 	results := &ApplyResults{}
@@ -64,6 +66,7 @@ func TestProgressManager_HandleEvent_DownloadHeaderOnce_NonTTY(t *testing.T) {
 }
 
 func TestProgressManager_HandleEvent_CommandLifecycle_NonTTY(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	pm := newNonTTYProgressManager(&buf)
 	results := &ApplyResults{}
@@ -107,6 +110,7 @@ func TestProgressManager_HandleEvent_CommandLifecycle_NonTTY(t *testing.T) {
 }
 
 func TestProgressManager_HandleEvent_CommandError_NonTTY(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	pm := newNonTTYProgressManager(&buf)
 	results := &ApplyResults{}
@@ -132,6 +136,7 @@ func TestProgressManager_HandleEvent_CommandError_NonTTY(t *testing.T) {
 }
 
 func TestProgressManager_HandleEvent_DownloadError_NonTTY(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	pm := newNonTTYProgressManager(&buf)
 	results := &ApplyResults{}
@@ -158,6 +163,7 @@ func TestProgressManager_HandleEvent_DownloadError_NonTTY(t *testing.T) {
 }
 
 func TestProgressManager_UpdateResults(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		action    resource.ActionType
@@ -171,6 +177,7 @@ func TestProgressManager_UpdateResults(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			results := &ApplyResults{}
 			updateResults(tt.action, results)
 			switch tt.wantField {
@@ -186,6 +193,7 @@ func TestProgressManager_UpdateResults(t *testing.T) {
 }
 
 func TestProgressManager_HandleEvent_MixedDownloadAndCommand_NonTTY(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	pm := newNonTTYProgressManager(&buf)
 	results := &ApplyResults{}
@@ -235,6 +243,7 @@ func TestProgressManager_HandleEvent_MixedDownloadAndCommand_NonTTY(t *testing.T
 }
 
 func TestProgressManager_IsDownloadMethod(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		method string
 		want   bool
@@ -247,17 +256,20 @@ func TestProgressManager_IsDownloadMethod(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.method, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tt.want, isDownloadMethod(tt.method))
 		})
 	}
 }
 
 func TestProgressManager_ResourceKey(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, "Tool/rg", resourceKey(resource.KindTool, "rg"))
 	assert.Equal(t, "Runtime/go", resourceKey(resource.KindRuntime, "go"))
 }
 
 func TestPrintApplySummary_NoChanges(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	PrintApplySummary(&buf, &ApplyResults{})
 	output := buf.String()
@@ -265,6 +277,7 @@ func TestPrintApplySummary_NoChanges(t *testing.T) {
 }
 
 func TestPrintApplySummary_WithResults(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	PrintApplySummary(&buf, &ApplyResults{
 		Installed: 3,
@@ -279,6 +292,7 @@ func TestPrintApplySummary_WithResults(t *testing.T) {
 }
 
 func TestPrintApplySummary_AllSuccess(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	PrintApplySummary(&buf, &ApplyResults{
 		Installed: 2,
@@ -288,6 +302,7 @@ func TestPrintApplySummary_AllSuccess(t *testing.T) {
 }
 
 func TestProgressManager_ConcurrentHandleEvent_NonTTY(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	pm := newNonTTYProgressManager(&buf)
 	results := &ApplyResults{}
@@ -329,6 +344,7 @@ func TestProgressManager_ConcurrentHandleEvent_NonTTY(t *testing.T) {
 }
 
 func TestProgressManager_ConcurrentMixedEvents_NonTTY(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	pm := newNonTTYProgressManager(&buf)
 	results := &ApplyResults{}

--- a/internal/ui/render_test.go
+++ b/internal/ui/render_test.go
@@ -30,6 +30,7 @@ func containsANSI(s string) bool {
 }
 
 func TestFormatElapsed(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		d    time.Duration
@@ -42,12 +43,14 @@ func TestFormatElapsed(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tt.want, formatElapsed(tt.d))
 		})
 	}
 }
 
 func TestFormatSize(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		bytes int64
@@ -61,12 +64,14 @@ func TestFormatSize(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tt.want, formatSize(tt.bytes))
 		})
 	}
 }
 
 func TestFitNodeNames(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		names    []string
@@ -100,6 +105,7 @@ func TestFitNodeNames(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := fitNodeNames(tt.names, tt.maxWidth)
 			assert.Equal(t, tt.want, result)
 		})
@@ -107,6 +113,7 @@ func TestFitNodeNames(t *testing.T) {
 }
 
 func TestRenderProgressBar(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		downloaded int64
@@ -121,6 +128,7 @@ func TestRenderProgressBar(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			bar := renderProgressBar(tt.downloaded, tt.total)
 			full := strings.Count(bar, string(progressFull))
 			empty := strings.Count(bar, string(progressEmpty))
@@ -132,12 +140,14 @@ func TestRenderProgressBar(t *testing.T) {
 }
 
 func TestRenderLayerHeader(t *testing.T) {
+	t.Parallel()
 	header := renderLayerHeader(0, 2, []string{"Runtime/go"}, "4.4s", 80)
 	assert.Contains(t, header, "Layer 1/2: Runtime/go")
 	assert.Contains(t, header, "4.4s")
 }
 
 func TestRenderLayerHeader_Styled(t *testing.T) {
+	t.Parallel()
 	enableColorForTest(t)
 
 	header := renderLayerHeader(0, 2, []string{"Runtime/go"}, "4.4s", 80)
@@ -147,6 +157,7 @@ func TestRenderLayerHeader_Styled(t *testing.T) {
 }
 
 func TestRenderCompletedLine(t *testing.T) {
+	t.Parallel()
 	task := &taskState{
 		kind:        resource.KindTool,
 		name:        "bat",
@@ -163,6 +174,7 @@ func TestRenderCompletedLine(t *testing.T) {
 }
 
 func TestRenderFailedLine(t *testing.T) {
+	t.Parallel()
 	task := &taskState{
 		kind:    resource.KindTool,
 		name:    "bat",
@@ -176,6 +188,7 @@ func TestRenderFailedLine(t *testing.T) {
 }
 
 func TestRenderProgressLine(t *testing.T) {
+	t.Parallel()
 	task := &taskState{
 		kind:        resource.KindRuntime,
 		name:        "go",
@@ -193,6 +206,7 @@ func TestRenderProgressLine(t *testing.T) {
 }
 
 func TestRenderDelegationLines(t *testing.T) {
+	t.Parallel()
 	task := &taskState{
 		kind:      resource.KindTool,
 		name:      "gopls",
@@ -214,6 +228,7 @@ func TestRenderDelegationLines(t *testing.T) {
 }
 
 func TestRenderDelegationLines_Styled(t *testing.T) {
+	t.Parallel()
 	enableColorForTest(t)
 
 	task := &taskState{
@@ -233,6 +248,7 @@ func TestRenderDelegationLines_Styled(t *testing.T) {
 }
 
 func TestTaskLabel(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		task *taskState
@@ -261,12 +277,14 @@ func TestTaskLabel(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tt.want, taskLabel(tt.task))
 		})
 	}
 }
 
 func TestView_ShowsCurrentLayerAndPendingHeaders(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -285,6 +303,7 @@ func TestView_ShowsCurrentLayerAndPendingHeaders(t *testing.T) {
 }
 
 func TestView_OnlyRendersStartedTasks(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -316,6 +335,7 @@ func TestView_OnlyRendersStartedTasks(t *testing.T) {
 }
 
 func TestView_RendersFinalStateWhenDone(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -342,6 +362,7 @@ func TestView_RendersFinalStateWhenDone(t *testing.T) {
 }
 
 func TestView_EmptyBeforeFirstEvent(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -349,6 +370,7 @@ func TestView_EmptyBeforeFirstEvent(t *testing.T) {
 }
 
 func TestView_DelegationLogLinesWhileRunning(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -391,6 +413,7 @@ func TestView_DelegationLogLinesWhileRunning(t *testing.T) {
 }
 
 func TestView_DelegationLogLinesClearedAfterCompletion(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -429,6 +452,7 @@ func TestView_DelegationLogLinesClearedAfterCompletion(t *testing.T) {
 }
 
 func TestView_DelegationLogLinesClearedInFinalSnapshot(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -468,6 +492,7 @@ func TestView_DelegationLogLinesClearedInFinalSnapshot(t *testing.T) {
 }
 
 func TestView_NoLayerHeaderDuplication_TwoLayers(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -502,6 +527,7 @@ func TestView_NoLayerHeaderDuplication_TwoLayers(t *testing.T) {
 }
 
 func TestView_NoLayerHeaderDuplication_AfterDone(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -546,6 +572,7 @@ func TestView_NoLayerHeaderDuplication_AfterDone(t *testing.T) {
 }
 
 func TestView_NoLayerHeaderDuplication_ThreeLayers(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -622,6 +649,7 @@ func TestView_NoLayerHeaderDuplication_ThreeLayers(t *testing.T) {
 }
 
 func TestLayerHeaderStyle(t *testing.T) {
+	t.Parallel()
 	enableColorForTest(t)
 
 	input := "Layer 1/2: Runtime/go"
@@ -632,6 +660,7 @@ func TestLayerHeaderStyle(t *testing.T) {
 }
 
 func TestDelegationLogStyle(t *testing.T) {
+	t.Parallel()
 	enableColorForTest(t)
 
 	input := "go: downloading golang.org/x/tools v0.31.0"
@@ -642,6 +671,7 @@ func TestDelegationLogStyle(t *testing.T) {
 }
 
 func TestRenderTaskList_CompletedDelegationNoLogs(t *testing.T) {
+	t.Parallel()
 	tasks := map[string]*taskState{
 		"Tool/gopls": {
 			key:     "Tool/gopls",
@@ -672,6 +702,7 @@ func TestRenderTaskList_CompletedDelegationNoLogs(t *testing.T) {
 }
 
 func TestView_DelegationLogLinesStyledWhileRunning(t *testing.T) {
+	t.Parallel()
 	enableColorForTest(t)
 
 	results := &ApplyResults{}
@@ -707,6 +738,7 @@ func TestView_DelegationLogLinesStyledWhileRunning(t *testing.T) {
 }
 
 func TestView_DelegationLogLinesClearedAfterCompletionView(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -739,6 +771,7 @@ func TestView_DelegationLogLinesClearedAfterCompletionView(t *testing.T) {
 }
 
 func TestView_SnapshotClearsDelegationLogLines(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -784,6 +817,7 @@ func TestView_SnapshotClearsDelegationLogLines(t *testing.T) {
 }
 
 func TestView_CompletedTasksRenderedBeforeRunning(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -844,12 +878,14 @@ func TestView_CompletedTasksRenderedBeforeRunning(t *testing.T) {
 }
 
 func TestRenderLogPanel_Empty(t *testing.T) {
+	t.Parallel()
 	var b strings.Builder
 	renderLogPanel(&b, nil, 80)
 	assert.Empty(t, b.String(), "log panel should not render when there are no log lines")
 }
 
 func TestRenderLogPanel_WithLines(t *testing.T) {
+	t.Parallel()
 	lines := []slogLine{
 		{level: slog.LevelWarn, message: "backup failed"},
 		{level: slog.LevelError, message: "state write error"},
@@ -866,6 +902,7 @@ func TestRenderLogPanel_WithLines(t *testing.T) {
 }
 
 func TestRenderLogPanel_Styled(t *testing.T) {
+	t.Parallel()
 	enableColorForTest(t)
 
 	lines := []slogLine{
@@ -880,6 +917,7 @@ func TestRenderLogPanel_Styled(t *testing.T) {
 }
 
 func TestSlogLevelLabel(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		level slog.Level
 		want  string
@@ -891,6 +929,7 @@ func TestSlogLevelLabel(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.want, func(t *testing.T) {
+			t.Parallel()
 			label := slogLevelLabel(tt.level)
 			assert.Contains(t, label, tt.want)
 		})
@@ -898,6 +937,7 @@ func TestSlogLevelLabel(t *testing.T) {
 }
 
 func TestView_LogPanelShownWithSlogLines(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -919,6 +959,7 @@ func TestView_LogPanelShownWithSlogLines(t *testing.T) {
 }
 
 func TestView_LogPanelHiddenWithoutSlogLines(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -933,6 +974,7 @@ func TestView_LogPanelHiddenWithoutSlogLines(t *testing.T) {
 }
 
 func TestView_FinalViewIncludesLogPanel(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 

--- a/internal/ui/reporter_test.go
+++ b/internal/ui/reporter_test.go
@@ -33,6 +33,7 @@ func (m *mockSender) messages() []tea.Msg {
 }
 
 func TestThrottledReporter_ForwardsNonProgressEvents(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		eventType engine.EventType
@@ -46,6 +47,7 @@ func TestThrottledReporter_ForwardsNonProgressEvents(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ms := &mockSender{}
 			r := NewThrottledReporter(ms)
 
@@ -66,6 +68,7 @@ func TestThrottledReporter_ForwardsNonProgressEvents(t *testing.T) {
 }
 
 func TestThrottledReporter_ThrottlesProgressEvents(t *testing.T) {
+	t.Parallel()
 	ms := &mockSender{}
 	r := NewThrottledReporter(ms)
 
@@ -97,6 +100,7 @@ func TestThrottledReporter_ThrottlesProgressEvents(t *testing.T) {
 }
 
 func TestThrottledReporter_ThrottlesPerResource(t *testing.T) {
+	t.Parallel()
 	ms := &mockSender{}
 	r := NewThrottledReporter(ms)
 
@@ -123,6 +127,7 @@ func TestThrottledReporter_ThrottlesPerResource(t *testing.T) {
 }
 
 func TestThrottledReporter_Done(t *testing.T) {
+	t.Parallel()
 	ms := &mockSender{}
 	r := NewThrottledReporter(ms)
 
@@ -136,6 +141,7 @@ func TestThrottledReporter_Done(t *testing.T) {
 }
 
 func TestThrottledReporter_DoneWithError(t *testing.T) {
+	t.Parallel()
 	ms := &mockSender{}
 	r := NewThrottledReporter(ms)
 

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestUpdate_EventLayerStart_InitializesModel(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -40,6 +41,7 @@ func TestUpdate_EventLayerStart_InitializesModel(t *testing.T) {
 }
 
 func TestUpdate_EventLayerStart_SnapshotsOnSecondLayer(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -100,6 +102,7 @@ func TestUpdate_EventLayerStart_SnapshotsOnSecondLayer(t *testing.T) {
 }
 
 func TestUpdate_EventStart_CreatesTask(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -131,6 +134,7 @@ func TestUpdate_EventStart_CreatesTask(t *testing.T) {
 }
 
 func TestUpdate_EventProgress_SetsHasProgress(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -161,6 +165,7 @@ func TestUpdate_EventProgress_SetsHasProgress(t *testing.T) {
 }
 
 func TestUpdate_EventProgress_IgnoredWithoutStart(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -184,6 +189,7 @@ func TestUpdate_EventProgress_IgnoredWithoutStart(t *testing.T) {
 }
 
 func TestUpdate_EventOutput_AddsLogLines(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -214,6 +220,7 @@ func TestUpdate_EventOutput_AddsLogLines(t *testing.T) {
 }
 
 func TestUpdate_EventComplete_UpdatesResults(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -244,6 +251,7 @@ func TestUpdate_EventComplete_UpdatesResults(t *testing.T) {
 }
 
 func TestUpdate_EventError_UpdatesResults(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -271,6 +279,7 @@ func TestUpdate_EventError_UpdatesResults(t *testing.T) {
 }
 
 func TestUpdate_ApplyDone_QuitsProgram(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -289,6 +298,7 @@ func TestUpdate_ApplyDone_QuitsProgram(t *testing.T) {
 }
 
 func TestUpdate_ApplyDone_WithError(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -305,6 +315,7 @@ func TestUpdate_ApplyDone_WithError(t *testing.T) {
 }
 
 func TestUpdate_WindowSizeMsg(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -315,6 +326,7 @@ func TestUpdate_WindowSizeMsg(t *testing.T) {
 }
 
 func TestUpdate_SnapshotDeepCopy(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -359,6 +371,7 @@ func TestUpdate_SnapshotDeepCopy(t *testing.T) {
 }
 
 func TestUpdate_SlogMsg_AppendsToSlogLines(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 
@@ -377,6 +390,7 @@ func TestUpdate_SlogMsg_AppendsToSlogLines(t *testing.T) {
 }
 
 func TestUpdate_SlogMsg_TruncatesAtMaxSlogLines(t *testing.T) {
+	t.Parallel()
 	results := &ApplyResults{}
 	m := NewApplyModel(results)
 


### PR DESCRIPTION
Add t.Parallel() to all top-level test functions and table-driven
subtests across 57 test files (~500 test functions).

Exceptions (t.Setenv() incompatible with t.Parallel()):
- TestBuildRegistry (config/loader_test.go)
- TestTokenFromEnv, TestNewHTTPClient_EndToEnd (github/client_test.go)
- TestResolveLatestVersion (cuemod/init_test.go)
- TestStore_SetQuiet (state/store_test.go) - modifies global slog

Verified with: go test -race -count=2 ./internal/...

Signed-off-by: terashima <iscale821@gmail.com>
Co-authored-by: Claude Code <noreply@anthropic.com>
