### PR TITLE
feat: add taint reinstall and removal visibility to UI and plan

### DIFF
--- a/internal/graph/tree.go
+++ b/internal/graph/tree.go
@@ -217,9 +217,10 @@ func (p *TreePrinter) PrintSummary(resourceInfo map[NodeID]ResourceInfo) {
 		}
 	}
 
-	fmt.Fprintf(p.writer, "\nSummary: %s to install, %s to upgrade, %s to remove\n",
+	fmt.Fprintf(p.writer, "\nSummary: %s to install, %s to upgrade, %s to reinstall, %s to remove\n",
 		p.installColor.Sprintf("%d", counts[ActionInstall]),
 		p.upgradeColor.Sprintf("%d", counts[ActionUpgrade]),
+		p.reinstallColor.Sprintf("%d", counts[ActionReinstall]),
 		p.removeColor.Sprintf("%d", counts[ActionRemove]),
 	)
 }

--- a/internal/graph/tree_test.go
+++ b/internal/graph/tree_test.go
@@ -1,0 +1,87 @@
+package graph
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/fatih/color"
+	"github.com/stretchr/testify/assert"
+	"github.com/terassyi/tomei/internal/resource"
+)
+
+func init() {
+	// Disable color output for deterministic test assertions.
+	color.NoColor = true
+}
+
+func TestPrintSummary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		info     map[NodeID]ResourceInfo
+		wantLine string
+	}{
+		{
+			name:     "no actions",
+			info:     map[NodeID]ResourceInfo{},
+			wantLine: "\nSummary: 0 to install, 0 to upgrade, 0 to reinstall, 0 to remove\n",
+		},
+		{
+			name: "install only",
+			info: map[NodeID]ResourceInfo{
+				NewNodeID(resource.KindTool, "gopls"): {Kind: resource.KindTool, Name: "gopls", Action: ActionInstall},
+				NewNodeID(resource.KindTool, "dlv"):   {Kind: resource.KindTool, Name: "dlv", Action: ActionInstall},
+				NewNodeID(resource.KindRuntime, "go"): {Kind: resource.KindRuntime, Name: "go", Action: ActionNone},
+			},
+			wantLine: "\nSummary: 2 to install, 0 to upgrade, 0 to reinstall, 0 to remove\n",
+		},
+		{
+			name: "upgrade triggers reinstall",
+			info: map[NodeID]ResourceInfo{
+				NewNodeID(resource.KindRuntime, "go"): {Kind: resource.KindRuntime, Name: "go", Version: "1.25.6", Action: ActionUpgrade},
+				NewNodeID(resource.KindTool, "gopls"): {Kind: resource.KindTool, Name: "gopls", Action: ActionReinstall},
+				NewNodeID(resource.KindTool, "dlv"):   {Kind: resource.KindTool, Name: "dlv", Action: ActionReinstall},
+			},
+			wantLine: "\nSummary: 0 to install, 1 to upgrade, 2 to reinstall, 0 to remove\n",
+		},
+		{
+			name: "mixed actions",
+			info: map[NodeID]ResourceInfo{
+				NewNodeID(resource.KindRuntime, "go"): {Kind: resource.KindRuntime, Name: "go", Action: ActionUpgrade},
+				NewNodeID(resource.KindTool, "gopls"): {Kind: resource.KindTool, Name: "gopls", Action: ActionReinstall},
+				NewNodeID(resource.KindTool, "fd"):    {Kind: resource.KindTool, Name: "fd", Action: ActionInstall},
+				NewNodeID(resource.KindTool, "old"):   {Kind: resource.KindTool, Name: "old", Action: ActionRemove},
+				NewNodeID(resource.KindTool, "bat"):   {Kind: resource.KindTool, Name: "bat", Action: ActionNone},
+			},
+			wantLine: "\nSummary: 1 to install, 1 to upgrade, 1 to reinstall, 1 to remove\n",
+		},
+		{
+			name: "remove only",
+			info: map[NodeID]ResourceInfo{
+				NewNodeID(resource.KindTool, "old-tool"): {Kind: resource.KindTool, Name: "old-tool", Action: ActionRemove},
+			},
+			wantLine: "\nSummary: 0 to install, 0 to upgrade, 0 to reinstall, 1 to remove\n",
+		},
+		{
+			name: "all none is zero counts",
+			info: map[NodeID]ResourceInfo{
+				NewNodeID(resource.KindTool, "gopls"): {Kind: resource.KindTool, Name: "gopls", Action: ActionNone},
+				NewNodeID(resource.KindRuntime, "go"): {Kind: resource.KindRuntime, Name: "go", Action: ActionNone},
+			},
+			wantLine: "\nSummary: 0 to install, 0 to upgrade, 0 to reinstall, 0 to remove\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			printer := NewTreePrinter(&buf, true)
+			printer.PrintSummary(tt.info)
+
+			assert.Equal(t, tt.wantLine, buf.String())
+		})
+	}
+}

--- a/internal/ui/applystyle.go
+++ b/internal/ui/applystyle.go
@@ -6,6 +6,8 @@ var (
 	doneMarkStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))   // green
 	failMarkStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))   // red
 	layerHeaderStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("14"))  // light cyan
+	taintHeaderStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))   // cyan
+	removeHeaderStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))   // yellow
 	delegationLogStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("245")) // gray
 	warnLogStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))   // yellow
 	errorLogStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))   // red

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/terassyi/tomei/internal/installer/engine"
 	"github.com/terassyi/tomei/internal/resource"
 )
 
@@ -50,6 +51,7 @@ type taskState struct {
 
 // layerState holds the snapshot of a completed layer.
 type layerState struct {
+	phase          engine.Phase
 	elapsed        time.Duration
 	tasks          map[string]*taskState
 	taskOrder      []string
@@ -62,8 +64,9 @@ type ApplyModel struct {
 	allLayerNodes [][]string
 	totalLayers   int
 
-	// Current layer index
+	// Current layer index and phase
 	currentLayer int
+	currentPhase engine.Phase
 	layerStart   time.Time
 	layerElapsed time.Duration // cached for View()
 

--- a/internal/ui/render_test.go
+++ b/internal/ui/render_test.go
@@ -141,7 +141,7 @@ func TestRenderProgressBar(t *testing.T) {
 
 func TestRenderLayerHeader(t *testing.T) {
 	t.Parallel()
-	header := renderLayerHeader(0, 2, []string{"Runtime/go"}, "4.4s", 80)
+	header := renderLayerHeader(engine.PhaseDAG, 0, 2, []string{"Runtime/go"}, "4.4s", 80)
 	assert.Contains(t, header, "Layer 1/2: Runtime/go")
 	assert.Contains(t, header, "4.4s")
 }
@@ -150,10 +150,28 @@ func TestRenderLayerHeader_Styled(t *testing.T) {
 	t.Parallel()
 	enableColorForTest(t)
 
-	header := renderLayerHeader(0, 2, []string{"Runtime/go"}, "4.4s", 80)
+	header := renderLayerHeader(engine.PhaseDAG, 0, 2, []string{"Runtime/go"}, "4.4s", 80)
 	assert.Contains(t, header, "Layer 1/2: Runtime/go")
 	assert.Contains(t, header, "4.4s")
 	assert.True(t, containsANSI(header), "layer header should contain ANSI escape sequences for cyan styling")
+}
+
+func TestRenderLayerHeader_PhaseTaint(t *testing.T) {
+	t.Parallel()
+	header := renderLayerHeader(engine.PhaseTaint, 0, 0, []string{"Tool/gopls", "Tool/dlv"}, "5.2s", 80)
+	assert.Contains(t, header, "Reinstall:")
+	assert.Contains(t, header, "Tool/gopls")
+	assert.Contains(t, header, "5.2s")
+	assert.NotContains(t, header, "Layer")
+}
+
+func TestRenderLayerHeader_PhaseRemove(t *testing.T) {
+	t.Parallel()
+	header := renderLayerHeader(engine.PhaseRemove, 0, 0, []string{"Tool/old-tool"}, "0.1s", 80)
+	assert.Contains(t, header, "Remove:")
+	assert.Contains(t, header, "Tool/old-tool")
+	assert.Contains(t, header, "0.1s")
+	assert.NotContains(t, header, "Layer")
 }
 
 func TestRenderCompletedLine(t *testing.T) {


### PR DESCRIPTION
- Introduce Phase type (PhaseDAG, PhaseTaint, PhaseRemove) in engine events
- Emit phase-aware events during taint reinstall and removal execution
- Display Reinstalled/Removed counts in apply summary (TUI and progress)
- Predict taint reinstalls in plan output with [↻ reinstall] annotation
- Show removal predictions in plan output with [- remove] annotation
- Fix updateResults to use Phase for correct reinstall counting
- Refactor handleRemovals with generic helpers to eliminate duplication
- Add unit, integration, and E2E tests for all visibility features

Signed-off-by: terashima <iscale821@gmail.com>
