### PR TITLE
feat: add tomei state show command for raw state inspection

### DIFF
--- a/cmd/tomei/state/show.go
+++ b/cmd/tomei/state/show.go
@@ -1,0 +1,58 @@
+package state
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/terassyi/tomei/internal/config"
+	"github.com/terassyi/tomei/internal/path"
+	internalstate "github.com/terassyi/tomei/internal/state"
+)
+
+var showCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Display the current state",
+	Long: `Display the raw state.json content.
+
+Shows all installed resources, runtimes, tools, and registries
+currently tracked by tomei.`,
+	RunE: runShow,
+}
+
+func runShow(cmd *cobra.Command, _ []string) error {
+	// Load config
+	cfg, err := config.LoadConfig(config.DefaultConfigDir)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	// Create paths
+	paths, err := path.NewFromConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to create paths: %w", err)
+	}
+
+	// Create store
+	store, err := internalstate.NewStore[internalstate.UserState](paths.UserDataDir())
+	if err != nil {
+		return fmt.Errorf("failed to create state store: %w", err)
+	}
+
+	// Load current state (read-only, no lock)
+	current, err := store.LoadReadOnly()
+	if err != nil {
+		return fmt.Errorf("failed to load current state: %w", err)
+	}
+
+	// Print state file path to stderr so JSON output stays clean for piping
+	cmd.PrintErrln("State file:", store.StatePath())
+
+	data, err := json.MarshalIndent(current, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal state: %w", err)
+	}
+	cmd.Println(string(data))
+	return nil
+}

--- a/cmd/tomei/state/state.go
+++ b/cmd/tomei/state/state.go
@@ -11,4 +11,5 @@ var Cmd = &cobra.Command{
 
 func init() {
 	Cmd.AddCommand(diffCmd)
+	Cmd.AddCommand(showCmd)
 }


### PR DESCRIPTION
Add 'tomei state show' subcommand that displays the full state.json
content as formatted JSON. The state file path is printed to stderr
so JSON output stays clean for piping.

Signed-off-by: terashima <iscale821@gmail.com>
