### PR TITLE
feat: add pnpm/Node.js example and fix delegation runtime PATH

### DIFF
--- a/examples/real-world/README.md
+++ b/examples/real-world/README.md
@@ -14,7 +14,7 @@ real-world/
 ├── utility.cue             # bat, rg, fd, jq, yq, fzf
 ├── go.cue                  # gopls, staticcheck, goimports, cue (via go install)
 ├── rust.cue                # cargo-binstall + binstall installer
-├── uv.cue                  # ruff, mypy, httpie, ansible (via uv)
+├── uv.cue                  # ruff, mypy, httpie, black (via uv)
 ├── node.cue                # prettier, ts-node, typescript, npm-check-updates (via pnpm)
 └── krew.cue                # ctx, ns, neat, node-shell (via krew)
 ```
@@ -37,7 +37,7 @@ real-world/
 | `utility.cue` | aqua | bat, rg, fd, jq, yq, fzf |
 | `go.cue` | go install | gopls, staticcheck, goimports, cue |
 | `rust.cue` | rust (preset) | cargo-binstall + binstall installer |
-| `uv.cue` | uv (delegation) | ruff, mypy, httpie, ansible |
+| `uv.cue` | uv (delegation) | ruff, mypy, httpie, black |
 | `node.cue` | pnpm (delegation) | prettier, ts-node, typescript, npm-check-updates |
 | `krew.cue` | krew (delegation) | ctx, ns, neat, node-shell |
 

--- a/examples/real-world/node.cue
+++ b/examples/real-world/node.cue
@@ -1,0 +1,20 @@
+package tomei
+
+// Node.js tools installed via pnpm add -g
+pnpmTools: {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "ToolSet"
+	metadata: {
+		name:        "pnpm-tools"
+		description: "Node.js CLI tools installed via pnpm"
+	}
+	spec: {
+		runtimeRef: "pnpm"
+		tools: {
+			prettier: {package: "prettier", version: "3.5.3"}
+			"ts-node": {package: "ts-node", version: "10.9.2"}
+			typescript: {package: "typescript", version: "5.7.3"}
+			"npm-check-updates": {package: "npm-check-updates", version: "17.1.14"}
+		}
+	}
+}

--- a/examples/real-world/runtimes.cue
+++ b/examples/real-world/runtimes.cue
@@ -67,7 +67,7 @@ pnpmRuntime: {
 		type:    "delegation"
 		version: "10.29.3"
 		bootstrap: {
-			install:        "curl -fsSL https://get.pnpm.io/install.sh | SHELL=/bin/bash PNPM_VERSION={{.Version}} sh -"
+			install:        "curl -fsSL https://get.pnpm.io/install.sh | SHELL=/bin/bash PNPM_VERSION={{.Version}} sh - && export PNPM_HOME=$HOME/.local/share/pnpm && export PATH=$PNPM_HOME:$PATH && $PNPM_HOME/pnpm env use --global lts"
 			check:          "~/.local/share/pnpm/pnpm --version"
 			remove:         "rm -rf ~/.local/share/pnpm"
 			resolveVersion: "~/.local/share/pnpm/pnpm --version 2>/dev/null || echo ''"
@@ -75,6 +75,9 @@ pnpmRuntime: {
 		binaries: ["pnpm", "pnpx"]
 		binDir:      "~/.local/share/pnpm"
 		toolBinPath: "~/.local/share/pnpm"
+		env: {
+			PNPM_HOME: "~/.local/share/pnpm"
+		}
 		commands: {
 			install: "~/.local/share/pnpm/pnpm add -g {{.Package}}{{if .Version}}@{{.Version}}{{end}}"
 			remove:  "~/.local/share/pnpm/pnpm remove -g {{.Package}}"

--- a/examples/real-world/uv.cue
+++ b/examples/real-world/uv.cue
@@ -14,7 +14,7 @@ uvTools: {
 			ruff: {package: "ruff", version: "0.15.1"}
 			mypy: {package: "mypy", version: "1.19.1"}
 			httpie: {package: "httpie", version: "3.2.4"}
-			ansible: {package: "ansible", version: "13.3.0"}
+			black: {package: "black", version: "25.1.0"}
 		}
 	}
 }

--- a/internal/installer/engine/engine.go
+++ b/internal/installer/engine/engine.go
@@ -344,6 +344,7 @@ func (e *Engine) Apply(ctx context.Context, resources []resource.Resource) error
 		for name, runtimeState := range st.Runtimes {
 			e.toolInstaller.RegisterRuntime(name, &tool.RuntimeInfo{
 				InstallPath: runtimeState.InstallPath,
+				BinDir:      runtimeState.BinDir,
 				ToolBinPath: runtimeState.ToolBinPath,
 				Env:         runtimeState.Env,
 				Commands:    runtimeState.Commands,


### PR DESCRIPTION
- Add node.cue with pnpm ToolSet (prettier, ts-node, typescript,
  npm-check-updates) to examples/real-world
- Fix pnpm bootstrap to install Node.js via pnpm env use --global lts
- Add PNPM_HOME to pnpm runtime env for global bin directory detection
- Fix tool installer PATH construction for delegation runtimes: use
  BinDir instead of InstallPath/bin when InstallPath is empty
- Add BinDir field to RuntimeInfo and pass it from engine
- Replace ansible with black in uv.cue (ansible entrypoint issue)

Signed-off-by: terashima <iscale821@gmail.com>
