### PR TITLE
feat: add args field to ToolItem/ToolSpec for delegation install options

### DIFF
--- a/cuemodule/schema/schema.cue
+++ b/cuemodule/schema/schema.cue
@@ -139,6 +139,7 @@ package schema
 		enabled?:       bool
 		source?:        #DownloadSource
 		package?:       #Package
+		args?: [...string]
 	}
 }
 
@@ -155,6 +156,7 @@ package schema
 			enabled?: bool
 			source?:  #DownloadSource
 			package?: #Package
+			args?: [...string]
 		}}
 	}
 }

--- a/examples/real-world/README.md
+++ b/examples/real-world/README.md
@@ -37,7 +37,7 @@ real-world/
 | `utility.cue` | aqua | bat, rg, fd, jq, yq, fzf |
 | `go.cue` | go install | gopls, staticcheck, goimports, cue |
 | `rust.cue` | rust (preset) | cargo-binstall + binstall installer |
-| `uv.cue` | uv (delegation) | ruff, mypy, httpie, black |
+| `uv.cue` | uv (delegation) | ruff, mypy, httpie, ansible |
 | `node.cue` | pnpm (delegation) | prettier, ts-node, typescript, npm-check-updates |
 | `krew.cue` | krew (delegation) | ctx, ns, neat, node-shell |
 

--- a/examples/real-world/runtimes.cue
+++ b/examples/real-world/runtimes.cue
@@ -46,7 +46,7 @@ uvRuntime: {
 		binDir:      "~/.local/bin"
 		toolBinPath: "~/.local/bin"
 		commands: {
-			install: "~/.local/bin/uv tool install {{.Package}}{{if .Version}}=={{.Version}}{{end}}"
+			install: "~/.local/bin/uv tool install {{.Package}}{{if .Version}}=={{.Version}}{{end}}{{if .Args}} {{.Args}}{{end}}"
 			remove:  "~/.local/bin/uv tool uninstall {{.Package}}"
 		}
 	}

--- a/examples/real-world/uv.cue
+++ b/examples/real-world/uv.cue
@@ -14,7 +14,7 @@ uvTools: {
 			ruff: {package: "ruff", version: "0.15.1"}
 			mypy: {package: "mypy", version: "1.19.1"}
 			httpie: {package: "httpie", version: "3.2.4"}
-			black: {package: "black", version: "25.1.0"}
+			ansible: {package: "ansible", version: "13.3.0", args: ["--with-executables-from", "ansible-core"]}
 		}
 	}
 }

--- a/internal/installer/command/executor.go
+++ b/internal/installer/command/executor.go
@@ -23,6 +23,7 @@ type Vars struct {
 	Version string // Version string (e.g., v0.16.0)
 	Name    string // Tool name (e.g., gopls)
 	BinPath string // Binary path (e.g., ~/go/bin/gopls)
+	Args    string // Additional arguments (space-joined, e.g., "--with-executables-from ansible-core")
 }
 
 // Executor executes shell commands with variable substitution.

--- a/internal/installer/command/executor_test.go
+++ b/internal/installer/command/executor_test.go
@@ -53,6 +53,26 @@ func TestExecutor_expand(t *testing.T) {
 			expected: "echo hello",
 		},
 		{
+			name:   "expand args",
+			cmdStr: "uv tool install {{.Package}}=={{.Version}} {{.Args}}",
+			vars: Vars{
+				Package: "ansible",
+				Version: "13.3.0",
+				Args:    "--with-executables-from ansible-core",
+			},
+			expected: "uv tool install ansible==13.3.0 --with-executables-from ansible-core",
+		},
+		{
+			name:   "args with conditional template",
+			cmdStr: "go install {{.Package}}@{{.Version}}{{if .Args}} {{.Args}}{{end}}",
+			vars: Vars{
+				Package: "golang.org/x/tools/gopls",
+				Version: "v0.16.0",
+				Args:    "",
+			},
+			expected: "go install golang.org/x/tools/gopls@v0.16.0",
+		},
+		{
 			name:   "empty variable values",
 			cmdStr: "cmd {{.Package}} {{.Version}}",
 			vars: Vars{

--- a/internal/installer/tool/installer.go
+++ b/internal/installer/tool/installer.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/terassyi/tomei/internal/checksum"
@@ -433,6 +434,7 @@ func (i *Installer) installByRuntime(ctx context.Context, res *resource.Tool, na
 		Version: spec.Version,
 		Name:    name,
 		BinPath: filepath.Join(info.ToolBinPath, name),
+		Args:    strings.Join(spec.Args, " "),
 	}
 
 	// Build environment with PATH including runtime's bin directory
@@ -496,6 +498,7 @@ func (i *Installer) installByInstaller(ctx context.Context, res *resource.Tool, 
 		Version: spec.Version,
 		Name:    name,
 		BinPath: "", // installer manages the path
+		Args:    strings.Join(spec.Args, " "),
 	}
 
 	// Build environment with PATH including the installer's toolRef binary directory

--- a/internal/resource/tool.go
+++ b/internal/resource/tool.go
@@ -239,6 +239,11 @@ type ToolSpec struct {
 	// The tool will be tainted (marked for reinstallation) when the runtime is upgraded.
 	// Either InstallerRef or RuntimeRef must be specified.
 	RuntimeRef string `json:"runtimeRef,omitempty"`
+
+	// Args provides additional arguments appended to the install command.
+	// These are joined with spaces and available as {{.Args}} in command templates.
+	// Example: ["--with-executables-from", "ansible-core"] for uv tool install.
+	Args []string `json:"args,omitempty"`
 }
 
 // Validate validates the ToolSpec.
@@ -398,6 +403,7 @@ func (ts *ToolSet) Expand() ([]Resource, error) {
 				Version:       item.Version,
 				Source:        item.Source,
 				Package:       item.Package,
+				Args:          item.Args,
 			},
 		}
 		tools = append(tools, tool)
@@ -425,6 +431,10 @@ type ToolItem struct {
 	// For delegation-based: { name: "golang.org/x/tools/gopls" }
 	// Mutually exclusive with Source.
 	Package *Package `json:"package,omitempty"`
+
+	// Args provides additional arguments appended to the install command.
+	// These are joined with spaces and available as {{.Args}} in command templates.
+	Args []string `json:"args,omitempty"`
 }
 
 // IsEnabled returns whether the tool item is enabled.


### PR DESCRIPTION
Add args: [...string] to ToolItem and ToolSpec, allowing runtime-specific
arguments to be passed through to delegation install commands via {{.Args}}
template variable.

Data flow: CUE manifest args → ToolItem.Args → Expand() → ToolSpec.Args
→ Vars.Args (strings.Join) → command template {{.Args}}

Use case: uv tool install ansible --with-executables-from ansible-core

Changes:
- resource/tool.go: Args on ToolSpec, ToolItem, and Expand() copy
- command/executor.go: Args field on Vars struct
- tool/installer.go: strings.Join in installByRuntime/installByInstaller
- schema.cue: args?: [...string] on #Tool and #ToolSet
- examples/real-world: ansible with args, uv template with {{if .Args}}

Signed-off-by: terashima <iscale821@gmail.com>
