### PR TITLE
refactor: change CommandSet fields from string to []string

### DIFF
--- a/cuemodule/presets/go/go.cue
+++ b/cuemodule/presets/go/go.cue
@@ -34,8 +34,8 @@ package go
 			GOBIN:  "~/go/bin"
 		}
 		commands: {
-			install: "go install {{.Package}}@{{.Version}}"
-			remove:  "rm -f {{.BinPath}}"
+			install: ["go install {{.Package}}@{{.Version}}"]
+			remove: ["rm -f {{.BinPath}}"]
 		}
 	}
 }

--- a/cuemodule/presets/rust/rust.cue
+++ b/cuemodule/presets/rust/rust.cue
@@ -17,10 +17,10 @@ package rust
 		type:    "delegation"
 		version: string | *"stable"
 		bootstrap: {
-			install:        "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain {{.Version}}"
-			check:          "~/.cargo/bin/rustc --version"
-			remove:         "~/.cargo/bin/rustup self uninstall -y"
-			resolveVersion: "~/.cargo/bin/rustc --version 2>/dev/null | grep -oP '\\d+\\.\\d+\\.\\d+' || echo ''"
+			install: ["curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain {{.Version}}"]
+			check: ["~/.cargo/bin/rustc --version"]
+			remove: ["~/.cargo/bin/rustup self uninstall -y"]
+			resolveVersion: ["~/.cargo/bin/rustc --version 2>/dev/null | grep -oP '\\d+\\.\\d+\\.\\d+' || echo ''"]
 		}
 		binaries: ["rustc", "cargo", "rustup"]
 		binDir:      "~/.cargo/bin"
@@ -30,8 +30,8 @@ package rust
 			RUSTUP_HOME: "~/.rustup"
 		}
 		commands: {
-			install: "~/.cargo/bin/cargo install {{.Package}}{{if .Version}}@{{.Version}}{{end}}"
-			remove:  "rm -f {{.BinPath}}"
+			install: ["~/.cargo/bin/cargo install {{.Package}}{{if .Version}}@{{.Version}}{{end}}"]
+			remove: ["rm -f {{.BinPath}}"]
 		}
 	}
 }
@@ -70,8 +70,8 @@ package rust
 		type:    "delegation"
 		toolRef: "cargo-binstall"
 		commands: {
-			install: "~/.cargo/bin/cargo-binstall {{.Package}}{{if .Version}}@{{.Version}}{{end}} --no-confirm"
-			remove:  "rm -f {{.BinPath}}"
+			install: ["~/.cargo/bin/cargo-binstall {{.Package}}{{if .Version}}@{{.Version}}{{end}} --no-confirm"]
+			remove: ["rm -f {{.BinPath}}"]
 		}
 	}
 }

--- a/cuemodule/schema/schema.cue
+++ b/cuemodule/schema/schema.cue
@@ -31,17 +31,17 @@ package schema
 }
 
 #CommandSet: {
-	install: string & !=""
-	check?:  string
-	remove?: string
+	install: [...string] & [_, ...]
+	check?: [...string]
+	remove?: [...string]
 }
 
 // RuntimeBootstrap extends CommandSet with version resolution support.
 #RuntimeBootstrap: {
-	install:         string & !=""
-	check?:          string
-	remove?:         string
-	resolveVersion?: string
+	install: [...string] & [_, ...]
+	check?: [...string]
+	remove?: [...string]
+	resolveVersion?: [...string]
 }
 
 // Package accepts both string ("owner/repo" or module path) and object form.
@@ -80,8 +80,8 @@ package schema
 		}
 		if type == "delegation" {
 			bootstrap: #RuntimeBootstrap & {
-				install: string & !=""
-				check:   string & !=""
+				install: [...string] & [_, ...]
+				check: [...string] & [_, ...]
 			}
 		}
 	}

--- a/cuemodule/schema_test.go
+++ b/cuemodule/schema_test.go
@@ -123,8 +123,8 @@ func TestSchema_ValidResources(t *testing.T) {
 					binaries:    ["go", "gofmt"]
 					toolBinPath: "~/go/bin"
 					commands: {
-						install: "go install {{.Package}}@{{.Version}}"
-						remove:  "rm -f {{.BinPath}}"
+						install: ["go install {{.Package}}@{{.Version}}"]
+						remove:  ["rm -f {{.BinPath}}"]
 					}
 					env: {
 						GOROOT: "~/.local/share/tomei/runtimes/go/1.25.6"
@@ -142,10 +142,10 @@ func TestSchema_ValidResources(t *testing.T) {
 					type:    "delegation"
 					version: "stable"
 					bootstrap: {
-						install: "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
-						check:   "rustc --version"
-						remove:  "rustup self uninstall -y"
-						resolveVersion: "rustc --version | grep -oP '[0-9]+\\.[0-9]+\\.[0-9]+'"
+						install: ["curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"]
+						check:   ["rustc --version"]
+						remove:  ["rustup self uninstall -y"]
+						resolveVersion: ["rustc --version | grep -oP '[0-9]+\\.[0-9]+\\.[0-9]+'"]
 					}
 					binaries:    ["rustc", "cargo", "rustup"]
 					toolBinPath: "~/.cargo/bin"
@@ -173,9 +173,9 @@ func TestSchema_ValidResources(t *testing.T) {
 					type:       "delegation"
 					runtimeRef: "go"
 					commands: {
-						install: "go install {{.Package}}@{{.Version}}"
-						check:   "go version -m {{.BinPath}}"
-						remove:  "rm {{.BinPath}}"
+						install: ["go install {{.Package}}@{{.Version}}"]
+						check:   ["go version -m {{.BinPath}}"]
+						remove:  ["rm {{.BinPath}}"]
 					}
 				}
 			}`,
@@ -191,9 +191,9 @@ func TestSchema_ValidResources(t *testing.T) {
 					source: {
 						type: "delegation"
 						commands: {
-							install: "helm repo add bitnami https://charts.bitnami.com/bitnami"
-							check:   "helm repo list | grep bitnami"
-							remove:  "helm repo remove bitnami"
+							install: ["helm repo add bitnami https://charts.bitnami.com/bitnami"]
+							check:   ["helm repo list | grep bitnami"]
+							remove:  ["helm repo remove bitnami"]
 						}
 					}
 				}

--- a/e2e/config/delegation-test/rust-runtime.cue
+++ b/e2e/config/delegation-test/rust-runtime.cue
@@ -13,10 +13,10 @@ rustRuntime: {
 		type:    "delegation"
 		version: _rustVersion
 		bootstrap: {
-			install:        "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain {{.Version}}"
-			check:          "~/.cargo/bin/rustc --version"
-			remove:         "~/.cargo/bin/rustup self uninstall -y"
-			resolveVersion: "~/.cargo/bin/rustc --version 2>/dev/null | grep -oP '\\d+\\.\\d+\\.\\d+' || echo ''"
+			install: ["curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain {{.Version}}"]
+			check: ["~/.cargo/bin/rustc --version"]
+			remove: ["~/.cargo/bin/rustup self uninstall -y"]
+			resolveVersion: ["~/.cargo/bin/rustc --version 2>/dev/null | grep -oP '\\d+\\.\\d+\\.\\d+' || echo ''"]
 		}
 		binaries: ["rustc", "cargo", "rustup"]
 		binDir:      "~/.cargo/bin"
@@ -26,8 +26,8 @@ rustRuntime: {
 			RUSTUP_HOME: "~/.rustup"
 		}
 		commands: {
-			install: "~/.cargo/bin/cargo install {{.Package}}@{{.Version}}"
-			remove:  "rm -f {{.BinPath}}"
+			install: ["~/.cargo/bin/cargo install {{.Package}}@{{.Version}}"]
+			remove: ["rm -f {{.BinPath}}"]
 		}
 	}
 }

--- a/e2e/config/dependency-test/circular.cue
+++ b/e2e/config/dependency-test/circular.cue
@@ -9,7 +9,7 @@ installerA: {
 		type:    "delegation"
 		toolRef: "tool-b"
 		commands: {
-			install: "installer-a install {{.Package}}"
+			install: ["installer-a install {{.Package}}"]
 		}
 	}
 }

--- a/e2e/config/dependency-test/circular3.cue
+++ b/e2e/config/dependency-test/circular3.cue
@@ -18,7 +18,7 @@ installerB: {
 	spec: {
 		type:    "delegation"
 		toolRef: "tool-a"
-		commands: {install: "echo install"}
+		commands: {install: ["echo install"]}
 	}
 }
 
@@ -39,6 +39,6 @@ installerC: {
 	spec: {
 		type:    "delegation"
 		toolRef: "tool-c"
-		commands: {install: "echo install"}
+		commands: {install: ["echo install"]}
 	}
 }

--- a/e2e/config/dependency-test/invalid-installer.cue
+++ b/e2e/config/dependency-test/invalid-installer.cue
@@ -9,6 +9,6 @@ invalidInstaller: {
 		type:       "delegation"
 		runtimeRef: "go"
 		toolRef:    "some-tool"
-		commands: {install: "echo install"}
+		commands: {install: ["echo install"]}
 	}
 }

--- a/e2e/config/dependency-test/parallel-failure.cue
+++ b/e2e/config/dependency-test/parallel-failure.cue
@@ -51,8 +51,8 @@ failInstaller: {
 	spec: {
 		type: "delegation"
 		commands: {
-			install: "echo 'simulated failure' && exit 1"
-			remove:  "echo removing"
+			install: ["echo 'simulated failure'", "exit 1"]
+			remove: ["echo removing"]
 		}
 	}
 }

--- a/e2e/config/dependency-test/runtime-chain.cue
+++ b/e2e/config/dependency-test/runtime-chain.cue
@@ -29,8 +29,8 @@ goRuntime: {
 			GOBIN:  "~/go/bin"
 		}
 		commands: {
-			install: "go install {{.Package}}@{{.Version}}"
-			remove:  "rm -f {{.BinPath}}"
+			install: ["go install {{.Package}}@{{.Version}}"]
+			remove: ["rm -f {{.BinPath}}"]
 		}
 	}
 }
@@ -44,7 +44,7 @@ goInstaller: {
 		type:       "delegation"
 		runtimeRef: "go"
 		commands: {
-			install: "go install {{.Package}}{{if .Version}}@{{.Version}}{{end}}"
+			install: ["go install {{.Package}}{{if .Version}}@{{.Version}}{{end}}"]
 		}
 	}
 }

--- a/e2e/config/dependency-test/toolref.cue
+++ b/e2e/config/dependency-test/toolref.cue
@@ -61,7 +61,7 @@ jqInstaller: {
 		type:    "delegation"
 		toolRef: "jq"
 		commands: {
-			install: "jq --version && echo 'Installing {{.Package}} via jq-installer'"
+			install: ["jq --version", "echo 'Installing {{.Package}} via jq-installer'"]
 		}
 	}
 }

--- a/e2e/config/installer-repo-test/helm-repo.cue
+++ b/e2e/config/installer-repo-test/helm-repo.cue
@@ -24,7 +24,7 @@ helmInstaller: {
 		type:    "delegation"
 		toolRef: "helm"
 		commands: {
-			install: "helm repo add {{.Name}} {{.URL}}"
+			install: ["helm repo add {{.Name}} {{.URL}}"]
 		}
 	}
 }
@@ -40,9 +40,9 @@ bitnamiRepo: {
 			type: "delegation"
 			url:  "https://charts.bitnami.com/bitnami"
 			commands: {
-				install: "helm repo add bitnami https://charts.bitnami.com/bitnami"
-				check:   "helm repo list 2>/dev/null | grep -q ^bitnami"
-				remove:  "helm repo remove bitnami"
+				install: ["helm repo add bitnami https://charts.bitnami.com/bitnami"]
+				check: ["helm repo list 2>/dev/null | grep -q ^bitnami"]
+				remove: ["helm repo remove bitnami"]
 			}
 		}
 	}

--- a/e2e/config/installer-repo-test/repo-with-tool.cue
+++ b/e2e/config/installer-repo-test/repo-with-tool.cue
@@ -28,7 +28,7 @@ helmInstaller: {
 		type:    "delegation"
 		toolRef: "helm"
 		commands: {
-			install: "mkdir -p /tmp/tomei-e2e-charts && helm pull bitnami/{{.Package}} --destination /tmp/tomei-e2e-charts"
+			install: ["mkdir -p /tmp/tomei-e2e-charts", "helm pull bitnami/{{.Package}} --destination /tmp/tomei-e2e-charts"]
 		}
 	}
 }
@@ -44,9 +44,9 @@ bitnamiRepo: {
 			type: "delegation"
 			url:  "https://charts.bitnami.com/bitnami"
 			commands: {
-				install: "helm repo add bitnami https://charts.bitnami.com/bitnami"
-				check:   "helm repo list 2>/dev/null | grep -q ^bitnami"
-				remove:  "helm repo remove bitnami"
+				install: ["helm repo add bitnami https://charts.bitnami.com/bitnami"]
+				check: ["helm repo list 2>/dev/null | grep -q ^bitnami"]
+				remove: ["helm repo remove bitnami"]
 			}
 		}
 	}

--- a/e2e/config/logs-test/failing-tool.cue
+++ b/e2e/config/logs-test/failing-tool.cue
@@ -7,8 +7,13 @@ failInstaller: {
 	spec: {
 		type: "delegation"
 		commands: {
-			install: "echo 'step 1: preparing...' && echo 'step 2: downloading...' && echo 'step 3: ERROR: build failed' && exit 1"
-			remove:  "echo removing"
+			install: [
+				"echo 'step 1: preparing...'",
+				"echo 'step 2: downloading...'",
+				"echo 'step 3: ERROR: build failed'",
+				"exit 1",
+			]
+			remove: ["echo removing"]
 		}
 	}
 }

--- a/e2e/config/manifests/runtime.cue
+++ b/e2e/config/manifests/runtime.cue
@@ -31,8 +31,8 @@ goRuntime: {
 		}
 		// Commands for tool installation via go install
 		commands: {
-			install: "go install {{.Package}}@{{.Version}}"
-			remove:  "rm -f {{.BinPath}}"
+			install: ["go install {{.Package}}@{{.Version}}"]
+			remove: ["rm -f {{.BinPath}}"]
 		}
 	}
 }

--- a/e2e/config/manifests/runtime.cue.upgrade
+++ b/e2e/config/manifests/runtime.cue.upgrade
@@ -29,8 +29,8 @@ goRuntime: {
 			GOBIN:  "~/go/bin"
 		}
 		commands: {
-			install: "go install {{.Package}}@{{.Version}}"
-			remove:  "rm -f {{.BinPath}}"
+			install: ["go install {{.Package}}@{{.Version}}"]
+			remove: ["rm -f {{.BinPath}}"]
 		}
 	}
 }

--- a/examples/minimal/runtime.cue
+++ b/examples/minimal/runtime.cue
@@ -21,8 +21,8 @@ goRuntime: {
 			GOBIN:  "~/go/bin"
 		}
 		commands: {
-			install: "go install {{.Package}}@{{.Version}}"
-			remove:  "rm -f {{.BinPath}}"
+			install: ["go install {{.Package}}@{{.Version}}"]
+			remove: ["rm -f {{.BinPath}}"]
 		}
 	}
 }

--- a/examples/minimal/rust.cue
+++ b/examples/minimal/rust.cue
@@ -22,10 +22,10 @@ rustRuntime: {
 		type:    "delegation"
 		version: _rustVersion
 		bootstrap: {
-			install:        "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain {{.Version}}"
-			check:          "~/.cargo/bin/rustc --version"
-			remove:         "~/.cargo/bin/rustup self uninstall -y"
-			resolveVersion: "~/.cargo/bin/rustc --version 2>/dev/null | grep -oP '\\d+\\.\\d+\\.\\d+' || echo ''"
+			install: ["curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain {{.Version}}"]
+			check: ["~/.cargo/bin/rustc --version"]
+			remove: ["~/.cargo/bin/rustup self uninstall -y"]
+			resolveVersion: ["~/.cargo/bin/rustc --version 2>/dev/null | grep -oP '\\d+\\.\\d+\\.\\d+' || echo ''"]
 		}
 		binaries: ["rustc", "cargo", "rustup"]
 		binDir:      "~/.cargo/bin"
@@ -35,8 +35,8 @@ rustRuntime: {
 			RUSTUP_HOME: "~/.rustup"
 		}
 		commands: {
-			install: "~/.cargo/bin/cargo install {{.Package}}{{if .Version}}@{{.Version}}{{end}}"
-			remove:  "rm -f {{.BinPath}}"
+			install: ["~/.cargo/bin/cargo install {{.Package}}{{if .Version}}@{{.Version}}{{end}}"]
+			remove: ["rm -f {{.BinPath}}"]
 		}
 	}
 }
@@ -67,8 +67,8 @@ binstallInstaller: {
 		type:    "delegation"
 		toolRef: "cargo-binstall"
 		commands: {
-			install: "~/.cargo/bin/cargo-binstall {{.Package}}{{if .Version}}@{{.Version}}{{end}} --no-confirm"
-			remove:  "rm -f {{.BinPath}}"
+			install: ["~/.cargo/bin/cargo-binstall {{.Package}}{{if .Version}}@{{.Version}}{{end}} --no-confirm"]
+			remove: ["rm -f {{.BinPath}}"]
 		}
 	}
 }

--- a/examples/real-world/runtimes.cue
+++ b/examples/real-world/runtimes.cue
@@ -37,17 +37,17 @@ uvRuntime: {
 		type:    "delegation"
 		version: "0.10.2"
 		bootstrap: {
-			install:        "curl -LsSf https://astral.sh/uv/{{.Version}}/install.sh | sh"
-			check:          "~/.local/bin/uv --version"
-			remove:         "~/.local/bin/uv self uninstall"
-			resolveVersion: "~/.local/bin/uv --version 2>/dev/null | grep -oP '\\d+\\.\\d+\\.\\d+' || echo ''"
+			install: ["curl -LsSf https://astral.sh/uv/{{.Version}}/install.sh | sh"]
+			check: ["~/.local/bin/uv --version"]
+			remove: ["~/.local/bin/uv self uninstall"]
+			resolveVersion: ["~/.local/bin/uv --version 2>/dev/null | grep -oP '\\d+\\.\\d+\\.\\d+' || echo ''"]
 		}
 		binaries: ["uv", "uvx"]
 		binDir:      "~/.local/bin"
 		toolBinPath: "~/.local/bin"
 		commands: {
-			install: "~/.local/bin/uv tool install {{.Package}}{{if .Version}}=={{.Version}}{{end}}{{if .Args}} {{.Args}}{{end}}"
-			remove:  "~/.local/bin/uv tool uninstall {{.Package}}"
+			install: ["~/.local/bin/uv tool install {{.Package}}{{if .Version}}=={{.Version}}{{end}}{{if .Args}} {{.Args}}{{end}}"]
+			remove: ["~/.local/bin/uv tool uninstall {{.Package}}"]
 		}
 	}
 }
@@ -67,10 +67,15 @@ pnpmRuntime: {
 		type:    "delegation"
 		version: "10.29.3"
 		bootstrap: {
-			install:        "curl -fsSL https://get.pnpm.io/install.sh | SHELL=/bin/bash PNPM_VERSION={{.Version}} sh - && export PNPM_HOME=$HOME/.local/share/pnpm && export PATH=$PNPM_HOME:$PATH && $PNPM_HOME/pnpm env use --global lts"
-			check:          "~/.local/share/pnpm/pnpm --version"
-			remove:         "rm -rf ~/.local/share/pnpm"
-			resolveVersion: "~/.local/share/pnpm/pnpm --version 2>/dev/null || echo ''"
+			install: [
+				"curl -fsSL https://get.pnpm.io/install.sh | SHELL=/bin/bash PNPM_VERSION={{.Version}} sh -",
+				"export PNPM_HOME=$HOME/.local/share/pnpm",
+				"export PATH=$PNPM_HOME:$PATH",
+				"$PNPM_HOME/pnpm env use --global lts",
+			]
+			check: ["~/.local/share/pnpm/pnpm --version"]
+			remove: ["rm -rf ~/.local/share/pnpm"]
+			resolveVersion: ["~/.local/share/pnpm/pnpm --version 2>/dev/null || echo ''"]
 		}
 		binaries: ["pnpm", "pnpx"]
 		binDir:      "~/.local/share/pnpm"
@@ -79,8 +84,8 @@ pnpmRuntime: {
 			PNPM_HOME: "~/.local/share/pnpm"
 		}
 		commands: {
-			install: "~/.local/share/pnpm/pnpm add -g {{.Package}}{{if .Version}}@{{.Version}}{{end}}"
-			remove:  "~/.local/share/pnpm/pnpm remove -g {{.Package}}"
+			install: ["~/.local/share/pnpm/pnpm add -g {{.Package}}{{if .Version}}@{{.Version}}{{end}}"]
+			remove: ["~/.local/share/pnpm/pnpm remove -g {{.Package}}"]
 		}
 	}
 }

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/terassyi/tomei/internal/resource"
@@ -572,9 +573,9 @@ spec: {
     source: {
         type: "delegation"
         commands: {
-            install: "helm repo add bitnami https://charts.bitnami.com/bitnami"
-            check:   "helm repo list | grep bitnami"
-            remove:  "helm repo remove bitnami"
+            install: ["helm repo add bitnami https://charts.bitnami.com/bitnami"]
+            check:   ["helm repo list | grep bitnami"]
+            remove:  ["helm repo remove bitnami"]
         }
     }
 }
@@ -611,9 +612,8 @@ spec: {
 	if repo.InstallerRepositorySpec.Source.Type != resource.InstallerRepositorySourceDelegation {
 		t.Errorf("expected source type delegation, got %s", repo.InstallerRepositorySpec.Source.Type)
 	}
-	if repo.InstallerRepositorySpec.Source.Commands.Install != "helm repo add bitnami https://charts.bitnami.com/bitnami" {
-		t.Errorf("unexpected install command: %s", repo.InstallerRepositorySpec.Source.Commands.Install)
-	}
+	wantInstall := []string{"helm repo add bitnami https://charts.bitnami.com/bitnami"}
+	assert.Equal(t, wantInstall, repo.InstallerRepositorySpec.Source.Commands.Install)
 }
 
 func TestLoader_LoadFile_InstallerRepository_Git(t *testing.T) {

--- a/internal/graph/property_test.go
+++ b/internal/graph/property_test.go
@@ -617,8 +617,8 @@ func createRuntimeWithPattern(name string, pattern resource.InstallType) *resour
 	if pattern == resource.InstallTypeDelegation {
 		spec.Bootstrap = &resource.RuntimeBootstrapSpec{
 			CommandSet: resource.CommandSet{
-				Install: "install-" + name,
-				Check:   "check-" + name,
+				Install: []string{"install-" + name},
+				Check:   []string{"check-" + name},
 			},
 		}
 	}

--- a/internal/graph/resolver_test.go
+++ b/internal/graph/resolver_test.go
@@ -66,7 +66,7 @@ func TestResolver_AddResource_InstallerWithToolRef(t *testing.T) {
 			Type:    resource.InstallTypeDelegation,
 			ToolRef: "pnpm",
 			Commands: &resource.CommandsSpec{
-				Install: "pnpm add -g {{.Package}}@{{.Version}}",
+				Install: []string{"pnpm add -g {{.Package}}@{{.Version}}"},
 			},
 		},
 	}
@@ -141,7 +141,7 @@ func TestResolver_Resolve_ToolChain(t *testing.T) {
 			Type:    resource.InstallTypeDelegation,
 			ToolRef: "cargo-binstall", // Installer depends on Tool
 			Commands: &resource.CommandsSpec{
-				Install: "cargo binstall -y {{.Package}}{{if .Version}}@{{.Version}}{{end}}",
+				Install: []string{"cargo binstall -y {{.Package}}{{if .Version}}@{{.Version}}{{end}}"},
 			},
 		},
 	}
@@ -210,7 +210,7 @@ func TestResolver_Validate_CircularDependency(t *testing.T) {
 			Type:    resource.InstallTypeDelegation,
 			ToolRef: "tool-a",
 			Commands: &resource.CommandsSpec{
-				Install: "some-command",
+				Install: []string{"some-command"},
 			},
 		},
 	}

--- a/internal/graph/scenario_test.go
+++ b/internal/graph/scenario_test.go
@@ -179,7 +179,7 @@ func TestResolver_ComplexManifest_DiamondDependency(t *testing.T) {
 			Type:    resource.InstallTypeDelegation,
 			ToolRef: "tool-a", // Can only have one ToolRef, but we simulate diamond via multiple tools
 			Commands: &resource.CommandsSpec{
-				Install: "combined-install",
+				Install: []string{"combined-install"},
 			},
 		},
 	}
@@ -257,7 +257,7 @@ func TestResolver_CycleDetection_TwoNodeCycle(t *testing.T) {
 			Type:    resource.InstallTypeDelegation,
 			ToolRef: "tool-a",
 			Commands: &resource.CommandsSpec{
-				Install: "install-b",
+				Install: []string{"install-b"},
 			},
 		},
 	}
@@ -301,7 +301,7 @@ func TestResolver_CycleDetection_ThreeNodeCycle(t *testing.T) {
 			Type:    resource.InstallTypeDelegation,
 			ToolRef: "tool-c",
 			Commands: &resource.CommandsSpec{
-				Install: "install-b",
+				Install: []string{"install-b"},
 			},
 		},
 	}
@@ -328,7 +328,7 @@ func TestResolver_CycleDetection_ThreeNodeCycle(t *testing.T) {
 			Type:    resource.InstallTypeDelegation,
 			ToolRef: "tool-a",
 			Commands: &resource.CommandsSpec{
-				Install: "install-a",
+				Install: []string{"install-a"},
 			},
 		},
 	}
@@ -677,7 +677,7 @@ func createInstallerWithRuntime(name, runtimeRef string) *resource.Installer {
 			Type:       resource.InstallTypeDelegation,
 			RuntimeRef: runtimeRef,
 			Commands: &resource.CommandsSpec{
-				Install: fmt.Sprintf("%s install", name),
+				Install: []string{fmt.Sprintf("%s install", name)},
 			},
 		},
 	}
@@ -694,7 +694,7 @@ func createInstallerWithTool(name, toolRef string) *resource.Installer {
 			Type:    resource.InstallTypeDelegation,
 			ToolRef: toolRef,
 			Commands: &resource.CommandsSpec{
-				Install: fmt.Sprintf("%s install", name),
+				Install: []string{fmt.Sprintf("%s install", name)},
 			},
 		},
 	}

--- a/internal/installer/engine/engine_test.go
+++ b/internal/installer/engine/engine_test.go
@@ -400,7 +400,7 @@ runtime: {
 		binaries: ["go", "gofmt"]
 		toolBinPath: "~/go/bin"
 		commands: {
-			install: "go install {{.Package}}@{{.Version}}"
+			install: ["go install {{.Package}}@{{.Version}}"]
 		}
 	}
 }
@@ -524,7 +524,7 @@ runtime: {
 		binaries: ["go", "gofmt"]
 		toolBinPath: "~/go/bin"
 		commands: {
-			install: "go install {{.Package}}@{{.Version}}"
+			install: ["go install {{.Package}}@{{.Version}}"]
 		}
 	}
 }
@@ -761,7 +761,7 @@ goRuntime: {
 			GOBIN: "~/go/bin"
 		}
 		commands: {
-			install: "go install {{.Package}}@{{.Version}}"
+			install: ["go install {{.Package}}@{{.Version}}"]
 		}
 	}
 }
@@ -785,7 +785,7 @@ pnpmInstaller: {
 		type: "delegation"
 		toolRef: "pnpm"
 		commands: {
-			install: "pnpm add -g {{.Package}}@{{.Version}}"
+			install: ["pnpm add -g {{.Package}}@{{.Version}}"]
 		}
 	}
 }
@@ -896,7 +896,7 @@ installerA: {
 		type: "delegation"
 		toolRef: "tool-b"
 		commands: {
-			install: "install-a {{.Package}}"
+			install: ["install-a {{.Package}}"]
 		}
 	}
 }
@@ -2970,9 +2970,9 @@ repo: {
 			type: "delegation"
 			url:  "https://charts.bitnami.com/bitnami"
 			commands: {
-				install: "helm repo add bitnami https://charts.bitnami.com/bitnami"
-				check:   "helm repo list | grep bitnami"
-				remove:  "helm repo remove bitnami"
+				install: ["helm repo add bitnami https://charts.bitnami.com/bitnami"]
+				check:   ["helm repo list | grep bitnami"]
+				remove:  ["helm repo remove bitnami"]
 			}
 		}
 	}
@@ -3028,9 +3028,9 @@ repo: {
 			type: "delegation"
 			url:  "https://charts.bitnami.com/bitnami"
 			commands: {
-				install: "helm repo add bitnami https://charts.bitnami.com/bitnami"
-				check:   "helm repo list | grep bitnami"
-				remove:  "helm repo remove bitnami"
+				install: ["helm repo add bitnami https://charts.bitnami.com/bitnami"]
+				check:   ["helm repo list | grep bitnami"]
+				remove:  ["helm repo remove bitnami"]
 			}
 		}
 	}
@@ -3152,9 +3152,9 @@ repo: {
 			type: "delegation"
 			url:  "https://charts.bitnami.com/bitnami"
 			commands: {
-				install: "helm repo add bitnami https://charts.bitnami.com/bitnami"
-				check:   "helm repo list | grep bitnami"
-				remove:  "helm repo remove bitnami"
+				install: ["helm repo add bitnami https://charts.bitnami.com/bitnami"]
+				check:   ["helm repo list | grep bitnami"]
+				remove:  ["helm repo remove bitnami"]
 			}
 		}
 	}

--- a/internal/installer/executor/store_test.go
+++ b/internal/installer/executor/store_test.go
@@ -469,7 +469,7 @@ func TestInstallerRepositoryStore_SaveAndLoad(t *testing.T) {
 	repoState := &resource.InstallerRepositoryState{
 		InstallerRef:  "helm",
 		SourceType:    resource.InstallerRepositorySourceDelegation,
-		RemoveCommand: "helm repo remove bitnami",
+		RemoveCommand: []string{"helm repo remove bitnami"},
 	}
 
 	require.NoError(t, irs.Save("bitnami", repoState))

--- a/internal/installer/reconciler/installer_repository_test.go
+++ b/internal/installer/reconciler/installer_repository_test.go
@@ -23,7 +23,7 @@ func TestInstallerRepositoryReconciler_Install(t *testing.T) {
 				Source: resource.InstallerRepositorySourceSpec{
 					Type: resource.InstallerRepositorySourceDelegation,
 					Commands: &resource.CommandSet{
-						Install: "helm repo add bitnami https://charts.bitnami.com/bitnami",
+						Install: []string{"helm repo add bitnami https://charts.bitnami.com/bitnami"},
 					},
 				},
 			},
@@ -153,7 +153,7 @@ func TestInstallerRepositoryReconciler_Remove(t *testing.T) {
 		"bitnami": {
 			InstallerRef:  "helm",
 			SourceType:    resource.InstallerRepositorySourceDelegation,
-			RemoveCommand: "helm repo remove bitnami",
+			RemoveCommand: []string{"helm repo remove bitnami"},
 			UpdatedAt:     time.Now(),
 		},
 	}

--- a/internal/installer/repository/installer.go
+++ b/internal/installer/repository/installer.go
@@ -16,9 +16,9 @@ import (
 // commandRunner is the interface for executing shell commands.
 // This enables testing with mocks instead of real command execution.
 type commandRunner interface {
-	Execute(ctx context.Context, cmdStr string, vars command.Vars) error
-	ExecuteWithEnv(ctx context.Context, cmdStr string, vars command.Vars, env map[string]string) error
-	Check(ctx context.Context, cmdStr string, vars command.Vars, env map[string]string) bool
+	Execute(ctx context.Context, cmds []string, vars command.Vars) error
+	ExecuteWithEnv(ctx context.Context, cmds []string, vars command.Vars, env map[string]string) error
+	Check(ctx context.Context, cmds []string, vars command.Vars, env map[string]string) bool
 }
 
 // gitRunner is the interface for git operations.
@@ -126,7 +126,7 @@ func (i *Installer) installDelegation(ctx context.Context, spec *resource.Instal
 	env := i.buildEnvWithToolPath(spec.InstallerRef)
 
 	// Check if already installed
-	if commands.Check != "" {
+	if len(commands.Check) > 0 {
 		vars := command.Vars{Name: name}
 		if i.cmdRunner.Check(ctx, commands.Check, vars, env) {
 			slog.Debug("installer repository already configured", "name", name)
@@ -169,7 +169,7 @@ func (i *Installer) installGit(ctx context.Context, spec *resource.InstallerRepo
 }
 
 func (i *Installer) removeDelegation(ctx context.Context, st *resource.InstallerRepositoryState, name string) error {
-	if st.RemoveCommand == "" {
+	if len(st.RemoveCommand) == 0 {
 		slog.Warn("no remove command for repository, skipping", "name", name)
 		return nil
 	}
@@ -196,7 +196,7 @@ func (i *Installer) removeGit(st *resource.InstallerRepositoryState, name string
 }
 
 func (i *Installer) buildDelegationState(spec *resource.InstallerRepositorySpec) *resource.InstallerRepositoryState {
-	var removeCmd string
+	var removeCmd []string
 	if spec.Source.Commands != nil {
 		removeCmd = spec.Source.Commands.Remove
 	}

--- a/internal/installer/tool/installer.go
+++ b/internal/installer/tool/installer.go
@@ -417,7 +417,7 @@ func (i *Installer) installByRuntime(ctx context.Context, res *resource.Tool, na
 	}
 
 	// Check if runtime has commands defined
-	if info.Commands == nil || info.Commands.Install == "" {
+	if info.Commands == nil || len(info.Commands.Install) == 0 {
 		return nil, fmt.Errorf("runtime %q does not have install command defined", spec.RuntimeRef)
 	}
 
@@ -483,7 +483,7 @@ func (i *Installer) installByInstaller(ctx context.Context, res *resource.Tool, 
 	spec := res.ToolSpec
 
 	// Check if installer has commands defined
-	if info.Commands == nil || info.Commands.Install == "" {
+	if info.Commands == nil || len(info.Commands.Install) == 0 {
 		return nil, fmt.Errorf("installer %q does not have install command defined", spec.InstallerRef)
 	}
 

--- a/internal/installer/tool/installer_test.go
+++ b/internal/installer/tool/installer_test.go
@@ -432,7 +432,7 @@ func TestToolInstaller_Install_Args(t *testing.T) {
 					BinDir:      "/usr/local/bin",
 					ToolBinPath: filepath.Dir(captureFile),
 					Commands: &resource.CommandsSpec{
-						Install: "echo {{.Package}}=={{.Version}} {{.Args}} > " + captureFile,
+						Install: []string{"echo {{.Package}}=={{.Version}} {{.Args}} > " + captureFile},
 					},
 				})
 			},
@@ -457,7 +457,7 @@ func TestToolInstaller_Install_Args(t *testing.T) {
 				inst.RegisterInstaller("uv", &InstallerInfo{
 					Type: resource.InstallTypeDelegation,
 					Commands: &resource.CommandsSpec{
-						Install: "echo {{.Package}}=={{.Version}} {{.Args}} > " + captureFile,
+						Install: []string{"echo {{.Package}}=={{.Version}} {{.Args}} > " + captureFile},
 					},
 				})
 			},

--- a/internal/resource/installer_repository.go
+++ b/internal/resource/installer_repository.go
@@ -54,7 +54,7 @@ func (s *InstallerRepositorySpec) Validate() error {
 	}
 	switch s.Source.Type {
 	case InstallerRepositorySourceDelegation:
-		if s.Source.Commands == nil || s.Source.Commands.Install == "" {
+		if s.Source.Commands == nil || len(s.Source.Commands.Install) == 0 {
 			return fmt.Errorf("source.commands.install is required for delegation type")
 		}
 	case InstallerRepositorySourceGit:
@@ -101,9 +101,9 @@ type InstallerRepositoryState struct {
 	// Empty for delegation type.
 	LocalPath string `json:"localPath,omitempty"`
 
-	// RemoveCommand stores the remove command for delegation type.
+	// RemoveCommand stores the remove command(s) for delegation type.
 	// Stored in state because Remove() only receives state (no spec).
-	RemoveCommand string `json:"removeCommand,omitempty"`
+	RemoveCommand []string `json:"removeCommand,omitempty"`
 
 	// UpdatedAt is the timestamp when this repository was last configured.
 	UpdatedAt time.Time `json:"updatedAt"`

--- a/internal/resource/installer_repository_test.go
+++ b/internal/resource/installer_repository_test.go
@@ -21,9 +21,9 @@ func TestInstallerRepositorySpec_Validate(t *testing.T) {
 				Source: InstallerRepositorySourceSpec{
 					Type: InstallerRepositorySourceDelegation,
 					Commands: &CommandSet{
-						Install: "helm repo add bitnami https://charts.bitnami.com/bitnami",
-						Check:   "helm repo list | grep bitnami",
-						Remove:  "helm repo remove bitnami",
+						Install: []string{"helm repo add bitnami https://charts.bitnami.com/bitnami"},
+						Check:   []string{"helm repo list | grep bitnami"},
+						Remove:  []string{"helm repo remove bitnami"},
 					},
 				},
 			},
@@ -44,7 +44,7 @@ func TestInstallerRepositorySpec_Validate(t *testing.T) {
 				Source: InstallerRepositorySourceSpec{
 					Type: InstallerRepositorySourceDelegation,
 					Commands: &CommandSet{
-						Install: "helm repo add bitnami https://charts.bitnami.com/bitnami",
+						Install: []string{"helm repo add bitnami https://charts.bitnami.com/bitnami"},
 					},
 				},
 			},
@@ -106,7 +106,7 @@ func TestInstallerRepositorySpec_Validate(t *testing.T) {
 				Source: InstallerRepositorySourceSpec{
 					Type: InstallerRepositorySourceDelegation,
 					Commands: &CommandSet{
-						Install: "kubectl krew index add my-index https://github.com/my-org/krew-index.git",
+						Install: []string{"kubectl krew index add my-index https://github.com/my-org/krew-index.git"},
 					},
 				},
 			},
@@ -172,7 +172,7 @@ func TestInstallerRepository_Spec(t *testing.T) {
 		Source: InstallerRepositorySourceSpec{
 			Type: InstallerRepositorySourceDelegation,
 			Commands: &CommandSet{
-				Install: "helm repo add bitnami https://charts.bitnami.com/bitnami",
+				Install: []string{"helm repo add bitnami https://charts.bitnami.com/bitnami"},
 			},
 		},
 	}

--- a/internal/resource/installer_test.go
+++ b/internal/resource/installer_test.go
@@ -42,7 +42,7 @@ func TestInstallerSpec_Validate(t *testing.T) {
 			spec: InstallerSpec{
 				Type: InstallTypeDelegation,
 				Commands: &CommandsSpec{
-					Install: "go install {{.Package}}@{{.Version}}",
+					Install: []string{"go install {{.Package}}@{{.Version}}"},
 				},
 			},
 			wantErr: "",
@@ -54,7 +54,7 @@ func TestInstallerSpec_Validate(t *testing.T) {
 				RuntimeRef: "go",
 				ToolRef:    "pnpm",
 				Commands: &CommandsSpec{
-					Install: "some command",
+					Install: []string{"some command"},
 				},
 			},
 			wantErr: "cannot specify both runtimeRef and toolRef",
@@ -65,7 +65,7 @@ func TestInstallerSpec_Validate(t *testing.T) {
 				Type:       InstallTypeDelegation,
 				RuntimeRef: "go",
 				Commands: &CommandsSpec{
-					Install: "go install {{.Package}}@{{.Version}}",
+					Install: []string{"go install {{.Package}}@{{.Version}}"},
 				},
 			},
 			wantErr: "",
@@ -76,7 +76,7 @@ func TestInstallerSpec_Validate(t *testing.T) {
 				Type:    InstallTypeDelegation,
 				ToolRef: "pnpm",
 				Commands: &CommandsSpec{
-					Install: "pnpm add -g {{.Package}}@{{.Version}}",
+					Install: []string{"pnpm add -g {{.Package}}@{{.Version}}"},
 				},
 			},
 			wantErr: "",

--- a/internal/resource/runtime.go
+++ b/internal/resource/runtime.go
@@ -75,8 +75,8 @@ type RuntimeBootstrapSpec struct {
 
 	// ResolveVersion is an optional command to resolve version aliases like "stable" or "latest".
 	// Should output the actual version number to stdout.
-	// Example: "rustup check 2>/dev/null | grep -oP 'stable-.*?: \\K[0-9.]+' || echo ''"
-	ResolveVersion string `json:"resolveVersion,omitempty"`
+	// Example: ["rustup check 2>/dev/null | grep -oP 'stable-.*?: \\K[0-9.]+' || echo ''"]
+	ResolveVersion []string `json:"resolveVersion,omitempty"`
 }
 
 // Validate validates the RuntimeSpec.
@@ -98,10 +98,10 @@ func (s *RuntimeSpec) Validate() error {
 		if s.Bootstrap == nil {
 			return fmt.Errorf("bootstrap is required for delegation type")
 		}
-		if s.Bootstrap.Install == "" {
+		if len(s.Bootstrap.Install) == 0 {
 			return fmt.Errorf("bootstrap.install is required for delegation type")
 		}
-		if s.Bootstrap.Check == "" {
+		if len(s.Bootstrap.Check) == 0 {
 			return fmt.Errorf("bootstrap.check is required for delegation type")
 		}
 	}
@@ -176,9 +176,9 @@ type RuntimeState struct {
 	// Used when executing tools that depend on this runtime.
 	Env map[string]string `json:"env,omitempty"`
 
-	// RemoveCommand is the shell command to uninstall a delegation-pattern runtime.
+	// RemoveCommand is the shell command(s) to uninstall a delegation-pattern runtime.
 	// Stored in state because Remove() only receives state (no spec).
-	RemoveCommand string `json:"removeCommand,omitempty"`
+	RemoveCommand []string `json:"removeCommand,omitempty"`
 
 	// UpdatedAt is the timestamp when this runtime was last installed or updated.
 	UpdatedAt time.Time `json:"updatedAt"`

--- a/internal/resource/types.go
+++ b/internal/resource/types.go
@@ -207,17 +207,18 @@ func ClassifyVersion(specVersion string) VersionKind {
 
 // CommandSet defines a set of shell commands for install/check/remove operations.
 // This is the common type used by BootstrapSpec, CommandsSpec, and RuntimeBootstrapSpec.
+// Each command is a string slice; multiple entries are joined with " && " at execution time.
 // Commands may support Go template variables depending on the context.
 type CommandSet struct {
-	// Install is the shell command to install/setup.
-	Install string `json:"install"`
+	// Install is the shell command(s) to install/setup.
+	Install []string `json:"install"`
 
-	// Check is the shell command to verify installation.
+	// Check is the shell command(s) to verify installation.
 	// Should exit 0 if installed, non-zero otherwise.
-	Check string `json:"check,omitempty"`
+	Check []string `json:"check,omitempty"`
 
-	// Remove is the shell command to uninstall/cleanup.
-	Remove string `json:"remove,omitempty"`
+	// Remove is the shell command(s) to uninstall/cleanup.
+	Remove []string `json:"remove,omitempty"`
 }
 
 // BaseResource provides common fields for all resources.

--- a/tests/engine_test.go
+++ b/tests/engine_test.go
@@ -774,8 +774,8 @@ goRuntime: {
 			GOBIN: "~/go/bin"
 		}
 		commands: {
-			install: "go install {{.Package}}@{{.Version}}"
-			remove: "rm -f {{.BinPath}}"
+			install: ["go install {{.Package}}@{{.Version}}"]
+			remove: ["rm -f {{.BinPath}}"]
 		}
 	}
 }
@@ -836,7 +836,7 @@ gopls: {
 
 	// Verify runtime has commands
 	assert.NotNil(t, st.Runtimes["go"].Commands)
-	assert.Equal(t, "go install {{.Package}}@{{.Version}}", st.Runtimes["go"].Commands.Install)
+	assert.Equal(t, []string{"go install {{.Package}}@{{.Version}}"}, st.Runtimes["go"].Commands.Install)
 }
 
 // TestEngine_Apply_InstallerDelegation tests installing a tool via installer delegation (e.g., brew install).
@@ -856,8 +856,8 @@ brewInstaller: {
 	spec: {
 		type: "delegation"
 		commands: {
-			install: "brew install {{.Package}}"
-			remove: "brew uninstall {{.Package}}"
+			install: ["brew install {{.Package}}"]
+			remove: ["brew uninstall {{.Package}}"]
 		}
 	}
 }
@@ -938,7 +938,7 @@ goRuntime: {
 		binaries: ["go", "gofmt"]
 		toolBinPath: "~/go/bin"
 		commands: {
-			install: "go install {{.Package}}@{{.Version}}"
+			install: ["go install {{.Package}}@{{.Version}}"]
 		}
 	}
 }
@@ -1107,7 +1107,7 @@ runtime: {
 		}
 		binaries: ["go", "gofmt"]
 		toolBinPath: "~/go/bin"
-		commands: { install: "go install {{.Package}}@{{.Version}}" }
+		commands: { install: ["go install {{.Package}}@{{.Version}}"] }
 	}
 }
 
@@ -1315,7 +1315,7 @@ runtime: {
 		}
 		binaries: ["go", "gofmt"]
 		toolBinPath: "~/go/bin"
-		commands: { install: "go install {{.Package}}@{{.Version}}" }
+		commands: { install: ["go install {{.Package}}@{{.Version}}"] }
 	}
 }
 
@@ -2060,8 +2060,8 @@ goRuntime: {
 			GOBIN: "~/go/bin"
 		}
 		commands: {
-			install: "go install {{.Package}}@{{.Version}}"
-			remove: "rm -f {{.BinPath}}"
+			install: ["go install {{.Package}}@{{.Version}}"]
+			remove: ["rm -f {{.BinPath}}"]
 		}
 	}
 }
@@ -2074,7 +2074,7 @@ goInstaller: {
 		type: "delegation"
 		runtimeRef: "go"
 		commands: {
-			install: "go install {{.Package}}@{{.Version}}"
+			install: ["go install {{.Package}}@{{.Version}}"]
 		}
 	}
 }

--- a/tests/installer_repository_test.go
+++ b/tests/installer_repository_test.go
@@ -34,9 +34,9 @@ func TestInstallerRepository_Delegation(t *testing.T) {
 					Type: resource.InstallerRepositorySourceDelegation,
 					URL:  "https://example.com/charts",
 					Commands: &resource.CommandSet{
-						Install: "touch " + markerFile,
-						Check:   "test -f " + markerFile,
-						Remove:  "rm " + markerFile,
+						Install: []string{"touch " + markerFile},
+						Check:   []string{"test -f " + markerFile},
+						Remove:  []string{"rm " + markerFile},
 					},
 				},
 			},
@@ -49,7 +49,7 @@ func TestInstallerRepository_Delegation(t *testing.T) {
 		assert.Equal(t, "helm", state.InstallerRef)
 		assert.Equal(t, resource.InstallerRepositorySourceDelegation, state.SourceType)
 		assert.Equal(t, "https://example.com/charts", state.URL)
-		assert.Equal(t, "rm "+markerFile, state.RemoveCommand)
+		assert.Equal(t, []string{"rm " + markerFile}, state.RemoveCommand)
 		assert.False(t, state.UpdatedAt.IsZero())
 		assert.FileExists(t, markerFile)
 	})
@@ -74,8 +74,8 @@ func TestInstallerRepository_Delegation(t *testing.T) {
 					Type: resource.InstallerRepositorySourceDelegation,
 					Commands: &resource.CommandSet{
 						// Install appends to counter file - if called, file will exist
-						Install: "echo x >> " + counterFile,
-						Check:   "test -f " + markerFile,
+						Install: []string{"echo x >> " + counterFile},
+						Check:   []string{"test -f " + markerFile},
 					},
 				},
 			},
@@ -105,9 +105,9 @@ func TestInstallerRepository_Delegation(t *testing.T) {
 				Source: resource.InstallerRepositorySourceSpec{
 					Type: resource.InstallerRepositorySourceDelegation,
 					Commands: &resource.CommandSet{
-						Install: "touch " + markerFile,
-						Check:   "test -f " + markerFile,
-						Remove:  "rm " + markerFile,
+						Install: []string{"touch " + markerFile},
+						Check:   []string{"test -f " + markerFile},
+						Remove:  []string{"rm " + markerFile},
 					},
 				},
 			},
@@ -141,7 +141,7 @@ func TestInstallerRepository_Delegation(t *testing.T) {
 				Source: resource.InstallerRepositorySourceSpec{
 					Type: resource.InstallerRepositorySourceDelegation,
 					Commands: &resource.CommandSet{
-						Install: "exit 1",
+						Install: []string{"exit 1"},
 					},
 				},
 			},

--- a/tests/resource_test.go
+++ b/tests/resource_test.go
@@ -222,8 +222,8 @@ spec: {
 	type: "delegation"
 	runtimeRef: "go"
 	commands: {
-		install: "go install {{.Package}}@{{.Version}}"
-		check: "go version -m {{.BinPath}}"
+		install: ["go install {{.Package}}@{{.Version}}"]
+		check: ["go version -m {{.BinPath}}"]
 	}
 }
 `
@@ -532,7 +532,7 @@ spec: {
 		GOROOT: "/opt/go/1.25.5"
 	}
 	commands: {
-		install: "go install {{.Package}}@{{.Version}}"
+		install: ["go install {{.Package}}@{{.Version}}"]
 	}
 }
 `,
@@ -550,8 +550,8 @@ spec: {
 	version: "stable"
 	toolBinPath: "~/.cargo/bin"
 	bootstrap: {
-		install: "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
-		check: "rustup --version"
+		install: ["curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"]
+		check: ["rustup --version"]
 	}
 	binaries: ["rustc", "cargo"]
 }
@@ -581,8 +581,8 @@ metadata: name: "brew"
 spec: {
 	type: "delegation"
 	commands: {
-		install: "brew install {{.Package}}"
-		remove: "brew uninstall {{.Package}}"
+		install: ["brew install {{.Package}}"]
+		remove: ["brew uninstall {{.Package}}"]
 	}
 }
 `,

--- a/tests/runtime_delegation_test.go
+++ b/tests/runtime_delegation_test.go
@@ -37,14 +37,14 @@ func TestRuntimeDelegation_Install(t *testing.T) {
 				ToolBinPath: binDir,
 				Bootstrap: &resource.RuntimeBootstrapSpec{
 					CommandSet: resource.CommandSet{
-						Install: "echo installing version {{.Version}}",
-						Check:   "true",
-						Remove:  "echo removing",
+						Install: []string{"echo installing version {{.Version}}"},
+						Check:   []string{"true"},
+						Remove:  []string{"echo removing"},
 					},
 				},
 				Commands: &resource.CommandsSpec{
-					Install: "echo installing tool {{.Package}}@{{.Version}}",
-					Remove:  "echo removing tool {{.Name}}",
+					Install: []string{"echo installing tool {{.Package}}@{{.Version}}"},
+					Remove:  []string{"echo removing tool {{.Name}}"},
 				},
 				Env: map[string]string{
 					"MOCK_HOME": filepath.Join(tmpDir, "mock-home"),
@@ -63,9 +63,9 @@ func TestRuntimeDelegation_Install(t *testing.T) {
 		assert.Equal(t, "1.0.0", state.SpecVersion)
 		assert.Equal(t, binDir, state.ToolBinPath)
 		assert.Equal(t, binDir, state.BinDir) // defaults to ToolBinPath
-		assert.Equal(t, "echo removing", state.RemoveCommand)
+		assert.Equal(t, []string{"echo removing"}, state.RemoveCommand)
 		assert.NotNil(t, state.Commands)
-		assert.Equal(t, "echo installing tool {{.Package}}@{{.Version}}", state.Commands.Install)
+		assert.Equal(t, []string{"echo installing tool {{.Package}}@{{.Version}}"}, state.Commands.Install)
 		assert.Equal(t, filepath.Join(tmpDir, "mock-home"), state.Env["MOCK_HOME"])
 		assert.Empty(t, state.InstallPath) // delegation doesn't set installPath
 		assert.Empty(t, state.Digest)      // no download digest
@@ -85,10 +85,10 @@ func TestRuntimeDelegation_Install(t *testing.T) {
 				ToolBinPath: binDir,
 				Bootstrap: &resource.RuntimeBootstrapSpec{
 					CommandSet: resource.CommandSet{
-						Install: "echo installing version {{.Version}}",
-						Check:   "true",
+						Install: []string{"echo installing version {{.Version}}"},
+						Check:   []string{"true"},
 					},
-					ResolveVersion: "echo 1.83.0",
+					ResolveVersion: []string{"echo 1.83.0"},
 				},
 			},
 		}
@@ -114,8 +114,8 @@ func TestRuntimeDelegation_Install(t *testing.T) {
 				ToolBinPath: filepath.Join(tmpDir, "bin"),
 				Bootstrap: &resource.RuntimeBootstrapSpec{
 					CommandSet: resource.CommandSet{
-						Install: "echo installing",
-						Check:   "false", // always fails
+						Install: []string{"echo installing"},
+						Check:   []string{"false"}, // always fails
 					},
 				},
 			},
@@ -138,8 +138,8 @@ func TestRuntimeDelegation_Install(t *testing.T) {
 				ToolBinPath: filepath.Join(tmpDir, "bin"),
 				Bootstrap: &resource.RuntimeBootstrapSpec{
 					CommandSet: resource.CommandSet{
-						Install: "exit 1",
-						Check:   "true",
+						Install: []string{"exit 1"},
+						Check:   []string{"true"},
 					},
 				},
 			},
@@ -162,7 +162,7 @@ func TestRuntimeDelegation_Remove(t *testing.T) {
 		st := &resource.RuntimeState{
 			Type:          resource.InstallTypeDelegation,
 			Version:       "1.0.0",
-			RemoveCommand: "touch " + markerFile,
+			RemoveCommand: []string{"touch " + markerFile},
 		}
 
 		err := installer.Remove(context.Background(), st, "mock")
@@ -194,7 +194,7 @@ func TestRuntimeDelegation_Remove(t *testing.T) {
 		st := &resource.RuntimeState{
 			Type:          resource.InstallTypeDelegation,
 			Version:       "1.0.0",
-			RemoveCommand: "exit 1",
+			RemoveCommand: []string{"exit 1"},
 		}
 
 		err := installer.Remove(context.Background(), st, "mock")
@@ -218,9 +218,9 @@ func TestRuntimeDelegation_InstallThenRemove(t *testing.T) {
 			ToolBinPath: binDir,
 			Bootstrap: &resource.RuntimeBootstrapSpec{
 				CommandSet: resource.CommandSet{
-					Install: "mkdir -p " + mockHome,
-					Check:   "test -d " + mockHome,
-					Remove:  "rm -rf " + mockHome,
+					Install: []string{"mkdir -p " + mockHome},
+					Check:   []string{"test -d " + mockHome},
+					Remove:  []string{"rm -rf " + mockHome},
 				},
 			},
 		},


### PR DESCRIPTION
Change Install, Check, Remove, and ResolveVersion fields from string
to []string across CommandSet, RuntimeBootstrapSpec, and state types.

Commands are joined with " && " at execution time via expandCommands.
Extract buildCommand helper to eliminate boilerplate in Executor methods.

Update all CUE schemas, presets, examples, and tests accordingly.

Signed-off-by: terashima <iscale821@gmail.com>
