### PR TITLE
docs: update docs to reflect CUE-native schema import and @tag() migration

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,7 +20,7 @@ CUE's `@tag()` injection does not propagate to imported packages resolved via a 
 
 ### Schema validation
 
-Schema validation uses CUE's `Unify()` to check conformance and `Validate(cue.Concrete(true))` for final validation. The schema ([`cuemodule/schema/schema.cue`](../cuemodule/schema/schema.cue)) is embedded in the binary via [`cuemodule/embed.go`](../cuemodule/embed.go).
+Schema constraints are enforced via CUE-native imports. Presets import `tomei.terassyi.net/schema`, so type constraints (HTTPS-only URLs, name patterns, required fields) are applied automatically when using presets. User manifests can also import the schema directly for explicit validation. The loader uses `cue.Value.Decode()` to convert validated CUE values into Go structs.
 
 ## Resource System
 

--- a/docs/cue-schema.md
+++ b/docs/cue-schema.md
@@ -437,7 +437,7 @@ myTool: schema.#Tool & {
 
 Available definitions: `schema.#Tool`, `schema.#ToolSet`, `schema.#Runtime`, `schema.#Installer`, `schema.#InstallerRepository`, `schema.#Resource`, etc.
 
-Schema import is optional — `tomei` validates all resources against the embedded schema internally regardless of whether the manifest uses `import "tomei.terassyi.net/schema"`.
+Schema import is optional. When using presets (`tomei.terassyi.net/presets/*`), schema constraints are applied automatically because presets import the schema module. For manifests without presets, adding `schema.#Tool &` or `schema.#Runtime &` to resource definitions enables explicit validation.
 
 ## OCI Registry (Module Resolution)
 
@@ -492,14 +492,14 @@ Presets that need platform information (e.g., Go) accept explicit `platform` par
 
 ## Validation
 
-`tomei` validates manifests against the embedded CUE schema at load time. Run `tomei validate <path>` to check manifests without applying.
+`tomei validate <path>` checks manifests without applying. When manifests use presets or explicitly import the schema, CUE-native type constraints are enforced at load time.
 
 Validation checks:
 
-- CUE syntax errors
-- Schema conformance (field types, required fields, enum values)
-- `metadata.name` regex pattern
-- HTTPS-only URLs
+- CUE syntax and evaluation errors
+- Schema conformance via imports (field types, required fields, enum values)
+- `metadata.name` regex pattern (enforced by schema)
+- HTTPS-only URLs (enforced by schema)
 - Circular dependency detection in the resource graph
 
 ### Common errors

--- a/docs/module-publishing.md
+++ b/docs/module-publishing.md
@@ -63,8 +63,8 @@ cuemodule/
 │   ├── aqua/aqua.cue           # Aqua toolset preset
 │   ├── go/go.cue               # Go runtime preset
 │   └── rust/rust.cue           # Rust runtime preset
-├── embed.go                    # go:embed for SchemaCUE (production)
-├── embed_presets.go            # go:embed for PresetsFS (integration tests only)
+├── embed.go                    # go:embed for SchemaCUE (schema unit tests)
+├── embed_presets.go            # go:embed for PresetsFS (integration test mock registry)
 └── schema_test.go              # Schema compilation tests
 ```
 


### PR DESCRIPTION
- Remove references to embedded schema, validateResource, Unify()
- Update _env overlay descriptions to @tag() attributes
- Fix embed.go usage comments (production → schema unit tests)
- Remove deleted Schema Validation (1a) section from e2e/scenario.md
- Update Schema Management (1c) to match current E2E tests

Signed-off-by: terashima <iscale821@gmail.com>
