### PR TITLE
feat: add node, python, deno, bun presets and DRY-ify existing presets

### DIFF
--- a/.github/workflows/weekly-scenario.yaml
+++ b/.github/workflows/weekly-scenario.yaml
@@ -58,6 +58,8 @@ jobs:
           cargo --version
           uv --version
           pnpm --version
+          deno --version
+          bun --version
           # Go tools
           gopls version
           staticcheck --version
@@ -86,6 +88,10 @@ jobs:
           mypy --version
           http --version
           ansible --version
+          # deno tools
+          deployctl --version
+          # bun tools
+          biome --version
 
       - name: Upload logs on failure
         if: failure()

--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,18 @@ vendor-cue: ## Vendor CUE schema and presets into examples/*/cue.mod/pkg/
 		mkdir -p $$dir/cue.mod/pkg/tomei.terassyi.net/presets/go; \
 		mkdir -p $$dir/cue.mod/pkg/tomei.terassyi.net/presets/rust; \
 		mkdir -p $$dir/cue.mod/pkg/tomei.terassyi.net/presets/aqua; \
+		mkdir -p $$dir/cue.mod/pkg/tomei.terassyi.net/presets/node; \
+		mkdir -p $$dir/cue.mod/pkg/tomei.terassyi.net/presets/python; \
+		mkdir -p $$dir/cue.mod/pkg/tomei.terassyi.net/presets/deno; \
+		mkdir -p $$dir/cue.mod/pkg/tomei.terassyi.net/presets/bun; \
 		cp cuemodule/schema/schema.cue $$dir/cue.mod/pkg/tomei.terassyi.net/schema/; \
 		cp cuemodule/presets/go/go.cue $$dir/cue.mod/pkg/tomei.terassyi.net/presets/go/; \
 		cp cuemodule/presets/rust/rust.cue $$dir/cue.mod/pkg/tomei.terassyi.net/presets/rust/; \
 		cp cuemodule/presets/aqua/aqua.cue $$dir/cue.mod/pkg/tomei.terassyi.net/presets/aqua/; \
+		cp cuemodule/presets/node/node.cue $$dir/cue.mod/pkg/tomei.terassyi.net/presets/node/; \
+		cp cuemodule/presets/python/python.cue $$dir/cue.mod/pkg/tomei.terassyi.net/presets/python/; \
+		cp cuemodule/presets/deno/deno.cue $$dir/cue.mod/pkg/tomei.terassyi.net/presets/deno/; \
+		cp cuemodule/presets/bun/bun.cue $$dir/cue.mod/pkg/tomei.terassyi.net/presets/bun/; \
 		sed -i.bak '/^deps:/,/^}/d' $$dir/cue.mod/module.cue && rm -f $$dir/cue.mod/module.cue.bak; \
 	done
 

--- a/cuemodule/embed_presets.go
+++ b/cuemodule/embed_presets.go
@@ -4,5 +4,5 @@ package cuemodule
 
 import "embed"
 
-//go:embed presets/go/go.cue presets/rust/rust.cue presets/aqua/aqua.cue
+//go:embed presets/go/go.cue presets/rust/rust.cue presets/aqua/aqua.cue presets/node/node.cue presets/python/python.cue presets/deno/deno.cue presets/bun/bun.cue
 var PresetsFS embed.FS

--- a/cuemodule/presets/bun/bun.cue
+++ b/cuemodule/presets/bun/bun.cue
@@ -1,0 +1,98 @@
+package bun
+
+import "tomei.terassyi.net/schema"
+
+// #BunRuntime declares a Bun runtime installed from GitHub releases.
+// User provides spec.version and platform.
+//
+// Usage:
+//   bunRuntime: #BunRuntime & {
+//       platform: { os: _os, arch: _arch }
+//       spec: version: "1.2.21"
+//   }
+#BunRuntime: schema.#Runtime & {
+	let _binDir = "~/.bun/bin"
+	let _bun = _binDir + "/bun"
+
+	platform: {
+		os:   string
+		arch: string
+	}
+
+	let _archMap = {
+		amd64: "x64"
+		arm64: "aarch64"
+	}
+	let _target = "bun-" + platform.os + "-" + _archMap[platform.arch]
+
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "Runtime"
+	metadata: {
+		name:        "bun"
+		description: string | *"Bun JavaScript/TypeScript runtime"
+	}
+	spec: {
+		type:    "download"
+		version: string & !=""
+		source: {
+			url:         "https://github.com/oven-sh/bun/releases/download/bun-v\(spec.version)/\(_target).zip"
+			archiveType: "zip"
+		}
+		binaries: ["bun"]
+		binDir:      _binDir
+		toolBinPath: _binDir
+		commands: {
+			install: ["\(_bun) install -g {{.Package}}{{if .Version}}@{{.Version}}{{end}}"]
+			remove: ["rm -f {{.BinPath}}"]
+		}
+	}
+}
+
+// #BunTool declares a single tool installed via bun install -g.
+//
+// Usage:
+//   myTool: #BunTool & {
+//       metadata: name: "my-tool"
+//       spec: {
+//           package: "my-tool"
+//           version: "1.0.0"
+//       }
+//   }
+#BunTool: schema.#Tool & {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "Tool"
+	metadata: {
+		name:         string
+		description?: string
+	}
+	spec: {
+		runtimeRef: "bun"
+		package:    string & !=""
+		version:    string & !=""
+	}
+}
+
+// #BunToolSet declares a set of tools installed via bun install -g.
+//
+// Usage:
+//   bunTools: #BunToolSet & {
+//       metadata: name: "bun-tools"
+//       spec: tools: {
+//           prettier: {package: "prettier", version: "3.5.0"}
+//       }
+//   }
+#BunToolSet: schema.#ToolSet & {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "ToolSet"
+	metadata: {
+		name:        string
+		description: string | *"Tools installed via bun install"
+	}
+	spec: {
+		runtimeRef: "bun"
+		tools: {[string]: {
+			package: string & !=""
+			version: string & !=""
+		}}
+	}
+}

--- a/cuemodule/presets/deno/deno.cue
+++ b/cuemodule/presets/deno/deno.cue
@@ -1,0 +1,102 @@
+package deno
+
+import "tomei.terassyi.net/schema"
+
+// #DenoRuntime declares a Deno runtime installed from dl.deno.land.
+// User provides spec.version and platform.
+//
+// Usage:
+//   denoRuntime: #DenoRuntime & {
+//       platform: { os: _os, arch: _arch }
+//       spec: version: "2.6.10"
+//   }
+#DenoRuntime: schema.#Runtime & {
+	let _binDir = "~/.deno/bin"
+	let _deno = _binDir + "/deno"
+
+	platform: {
+		os:   string
+		arch: string
+	}
+
+	let _archMap = {
+		amd64: "x86_64"
+		arm64: "aarch64"
+	}
+	let _osMap = {
+		linux:  "unknown-linux-gnu"
+		darwin: "apple-darwin"
+	}
+	let _target = _archMap[platform.arch] + "-" + _osMap[platform.os]
+
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "Runtime"
+	metadata: {
+		name:        "deno"
+		description: string | *"Deno JavaScript/TypeScript runtime"
+	}
+	spec: {
+		type:    "download"
+		version: string & !=""
+		source: {
+			url:         "https://dl.deno.land/release/v\(spec.version)/deno-\(_target).zip"
+			archiveType: "zip"
+		}
+		binaries: ["deno"]
+		binDir:      _binDir
+		toolBinPath: _binDir
+		commands: {
+			install: ["\(_deno) install -g {{.Package}}{{if .Version}}@{{.Version}}{{end}}"]
+			remove: ["rm -f {{.BinPath}}"]
+		}
+	}
+}
+
+// #DenoTool declares a single tool installed via deno install -g.
+//
+// Usage:
+//   myTool: #DenoTool & {
+//       metadata: name: "my-tool"
+//       spec: {
+//           package: "npm:my-tool"
+//           version: "1.0.0"
+//       }
+//   }
+#DenoTool: schema.#Tool & {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "Tool"
+	metadata: {
+		name:         string
+		description?: string
+	}
+	spec: {
+		runtimeRef: "deno"
+		package:    string & !=""
+		version:    string & !=""
+	}
+}
+
+// #DenoToolSet declares a set of tools installed via deno install -g.
+//
+// Usage:
+//   denoTools: #DenoToolSet & {
+//       metadata: name: "deno-tools"
+//       spec: tools: {
+//           deployctl: {package: "jsr:@deno/deployctl", version: "1.12.0"}
+//       }
+//   }
+#DenoToolSet: schema.#ToolSet & {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "ToolSet"
+	metadata: {
+		name:        string
+		description: string | *"Tools installed via deno install"
+	}
+	spec: {
+		runtimeRef: "deno"
+		tools: {[string]: {
+			package: string & !=""
+			version: string & !=""
+		}}
+	}
+}

--- a/cuemodule/presets/go/go.cue
+++ b/cuemodule/presets/go/go.cue
@@ -11,6 +11,8 @@ import "tomei.terassyi.net/schema"
 //       spec: version: "1.25.6"
 //   }
 #GoRuntime: schema.#Runtime & {
+	let _goBin = "~/go/bin"
+
 	platform: {
 		os:   string
 		arch: string
@@ -29,11 +31,11 @@ import "tomei.terassyi.net/schema"
 			checksum: url: "https://go.dev/dl/?mode=json&include=all"
 		}
 		binaries: ["go", "gofmt"]
-		binDir:      "~/go/bin"
-		toolBinPath: "~/go/bin"
+		binDir:      _goBin
+		toolBinPath: _goBin
 		env: {
 			GOROOT: "~/.local/share/tomei/runtimes/go/\(spec.version)"
-			GOBIN:  "~/go/bin"
+			GOBIN:  _goBin
 		}
 		commands: {
 			install: ["go install {{.Package}}@{{.Version}}"]

--- a/cuemodule/presets/node/node.cue
+++ b/cuemodule/presets/node/node.cue
@@ -1,0 +1,96 @@
+package node
+
+import "tomei.terassyi.net/schema"
+
+// #PnpmRuntime declares a Node.js runtime managed via pnpm standalone installer.
+// pnpm bootstraps itself and provisions a global Node.js LTS via `pnpm env use`.
+//
+// Usage:
+//   pnpmRuntime: #PnpmRuntime
+//   pnpmRuntime: #PnpmRuntime & {spec: version: "10.29.3"}
+#PnpmRuntime: schema.#Runtime & {
+	let _pnpmHome = "~/.local/share/pnpm"
+	let _pnpm = _pnpmHome + "/pnpm"
+
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "Runtime"
+	metadata: {
+		name:        "pnpm"
+		description: string | *"Node.js package manager (standalone, manages Node.js via pnpm env)"
+	}
+	spec: {
+		type:    "delegation"
+		version: string | *"latest"
+		bootstrap: {
+			install: [
+				"curl -fsSL https://get.pnpm.io/install.sh | SHELL=/bin/bash PNPM_VERSION={{.Version}} sh -",
+				"export PNPM_HOME=$HOME/.local/share/pnpm",
+				"export PATH=$PNPM_HOME:$PATH",
+				"$PNPM_HOME/pnpm env use --global lts",
+			]
+			check: ["\(_pnpm) --version"]
+			remove: ["rm -rf \(_pnpmHome)"]
+			resolveVersion: ["\(_pnpm) --version 2>/dev/null || echo ''"]
+		}
+		binaries: ["pnpm", "pnpx"]
+		binDir:      _pnpmHome
+		toolBinPath: _pnpmHome
+		env: {
+			PNPM_HOME: _pnpmHome
+		}
+		commands: {
+			install: ["\(_pnpm) add -g {{.Package}}{{if .Version}}@{{.Version}}{{end}}"]
+			remove: ["\(_pnpm) remove -g {{.Package}}"]
+		}
+	}
+}
+
+// #PnpmTool declares a single tool installed via pnpm add -g.
+//
+// Usage:
+//   prettier: #PnpmTool & {
+//       metadata: name: "prettier"
+//       spec: {
+//           package: "prettier"
+//           version: "3.5.3"
+//       }
+//   }
+#PnpmTool: schema.#Tool & {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "Tool"
+	metadata: {
+		name:         string
+		description?: string
+	}
+	spec: {
+		runtimeRef: "pnpm"
+		package:    string & !=""
+		version:    string & !=""
+	}
+}
+
+// #PnpmToolSet declares a set of tools installed via pnpm add -g.
+//
+// Usage:
+//   nodeTools: #PnpmToolSet & {
+//       metadata: name: "node-tools"
+//       spec: tools: {
+//           prettier:   {package: "prettier", version: "3.5.3"}
+//           typescript: {package: "typescript", version: "5.7.3"}
+//       }
+//   }
+#PnpmToolSet: schema.#ToolSet & {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "ToolSet"
+	metadata: {
+		name:        string
+		description: string | *"Node.js tools installed via pnpm"
+	}
+	spec: {
+		runtimeRef: "pnpm"
+		tools: {[string]: {
+			package: string & !=""
+			version: string & !=""
+		}}
+	}
+}

--- a/cuemodule/presets/python/python.cue
+++ b/cuemodule/presets/python/python.cue
@@ -1,0 +1,90 @@
+package python
+
+import "tomei.terassyi.net/schema"
+
+// #UvRuntime declares a Python tool/runtime manager installed via the uv standalone installer.
+//
+// Usage:
+//   uvRuntime: #UvRuntime
+//   uvRuntime: #UvRuntime & {spec: version: "0.10.2"}
+#UvRuntime: schema.#Runtime & {
+	let _binDir = "~/.local/bin"
+	let _uv = _binDir + "/uv"
+
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "Runtime"
+	metadata: {
+		name:        "uv"
+		description: string | *"Python package manager and project tool"
+	}
+	spec: {
+		type:    "delegation"
+		version: string | *"latest"
+		bootstrap: {
+			install: ["curl -LsSf https://astral.sh/uv/{{.Version}}/install.sh | sh"]
+			check: ["\(_uv) --version"]
+			remove: ["\(_uv) self uninstall"]
+			resolveVersion: ["\(_uv) --version 2>/dev/null | grep -oP '\\d+\\.\\d+\\.\\d+' || echo ''"]
+		}
+		binaries: ["uv", "uvx"]
+		binDir:      _binDir
+		toolBinPath: _binDir
+		commands: {
+			install: ["\(_uv) tool install {{.Package}}{{if .Version}}=={{.Version}}{{end}}{{if .Args}} {{.Args}}{{end}}"]
+			remove: ["\(_uv) tool uninstall {{.Package}}"]
+		}
+	}
+}
+
+// #UvTool declares a single Python tool installed via uv tool install.
+//
+// Usage:
+//   ruff: #UvTool & {
+//       metadata: name: "ruff"
+//       spec: {
+//           package: "ruff"
+//           version: "0.15.1"
+//       }
+//   }
+#UvTool: schema.#Tool & {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "Tool"
+	metadata: {
+		name:         string
+		description?: string
+	}
+	spec: {
+		runtimeRef: "uv"
+		package:    string & !=""
+		version?:   string
+	}
+}
+
+// #UvToolSet declares a set of Python tools installed via uv tool install.
+// Supports the args field for tools that require extra flags (e.g. ansible
+// with --with-executables-from).
+//
+// Usage:
+//   pythonTools: #UvToolSet & {
+//       metadata: name: "python-tools"
+//       spec: tools: {
+//           ruff:    {package: "ruff", version: "0.15.1"}
+//           ansible: {package: "ansible", version: "13.3.0", args: ["--with-executables-from", "ansible-core"]}
+//       }
+//   }
+#UvToolSet: schema.#ToolSet & {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "ToolSet"
+	metadata: {
+		name:        string
+		description: string | *"Python tools installed via uv"
+	}
+	spec: {
+		runtimeRef: "uv"
+		tools: {[string]: {
+			package:  string & !=""
+			version?: string
+			args?: [...string]
+		}}
+	}
+}

--- a/cuemodule/presets/rust/rust.cue
+++ b/cuemodule/presets/rust/rust.cue
@@ -9,6 +9,9 @@ import "tomei.terassyi.net/schema"
 //   rustRuntime: #RustRuntime
 //   rustRuntime: #RustRuntime & {spec: version: "nightly"}
 #RustRuntime: schema.#Runtime & {
+	let _cargoHome = "~/.cargo"
+	let _cargoBin = _cargoHome + "/bin"
+
 	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Runtime"
 	metadata: {
@@ -20,19 +23,19 @@ import "tomei.terassyi.net/schema"
 		version: string | *"stable"
 		bootstrap: {
 			install: ["curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain {{.Version}}"]
-			check: ["~/.cargo/bin/rustc --version"]
-			remove: ["~/.cargo/bin/rustup self uninstall -y"]
-			resolveVersion: ["~/.cargo/bin/rustc --version 2>/dev/null | grep -oP '\\d+\\.\\d+\\.\\d+' || echo ''"]
+			check: ["\(_cargoBin)/rustc --version"]
+			remove: ["\(_cargoBin)/rustup self uninstall -y"]
+			resolveVersion: ["\(_cargoBin)/rustc --version 2>/dev/null | grep -oP '\\d+\\.\\d+\\.\\d+' || echo ''"]
 		}
 		binaries: ["rustc", "cargo", "rustup"]
-		binDir:      "~/.cargo/bin"
-		toolBinPath: "~/.cargo/bin"
+		binDir:      _cargoBin
+		toolBinPath: _cargoBin
 		env: {
-			CARGO_HOME:  "~/.cargo"
+			CARGO_HOME:  _cargoHome
 			RUSTUP_HOME: "~/.rustup"
 		}
 		commands: {
-			install: ["~/.cargo/bin/cargo install {{.Package}}{{if .Version}}@{{.Version}}{{end}}"]
+			install: ["\(_cargoBin)/cargo install {{.Package}}{{if .Version}}@{{.Version}}{{end}}"]
 			remove: ["rm -f {{.BinPath}}"]
 		}
 		taintOnUpgrade: true
@@ -63,6 +66,8 @@ import "tomei.terassyi.net/schema"
 // Usage:
 //   binstallInstaller: #BinstallInstaller
 #BinstallInstaller: schema.#Installer & {
+	let _cargoBin = "~/.cargo/bin"
+
 	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "Installer"
 	metadata: {
@@ -73,7 +78,7 @@ import "tomei.terassyi.net/schema"
 		type:    "delegation"
 		toolRef: "cargo-binstall"
 		commands: {
-			install: ["~/.cargo/bin/cargo-binstall {{.Package}}{{if .Version}}@{{.Version}}{{end}} --no-confirm"]
+			install: ["\(_cargoBin)/cargo-binstall {{.Package}}{{if .Version}}@{{.Version}}{{end}} --no-confirm"]
 			remove: ["rm -f {{.BinPath}}"]
 		}
 	}

--- a/examples/minimal/cue.mod/module.cue
+++ b/examples/minimal/cue.mod/module.cue
@@ -1,5 +1,2 @@
 module: "manifests.local@v0"
 language: version: "v0.9.0"
-deps: {
-	"tomei.terassyi.net@v0": v: "v0.0.1"
-}

--- a/examples/real-world/bun.cue
+++ b/examples/real-world/bun.cue
@@ -1,0 +1,11 @@
+package tomei
+
+import "tomei.terassyi.net/presets/bun"
+
+// Bun tools installed via bun install -g
+bunTools: bun.#BunToolSet & {
+	metadata: name: "bun-tools"
+	spec: tools: {
+		biome: {package: "@biomejs/biome", version: "1.9.4"}
+	}
+}

--- a/examples/real-world/cue.mod/module.cue
+++ b/examples/real-world/cue.mod/module.cue
@@ -1,5 +1,2 @@
 module: "manifests.local@v0"
 language: version: "v0.9.0"
-deps: {
-	"tomei.terassyi.net@v0": v: "v0.0.1"
-}

--- a/examples/real-world/deno.cue
+++ b/examples/real-world/deno.cue
@@ -1,0 +1,11 @@
+package tomei
+
+import "tomei.terassyi.net/presets/deno"
+
+// Deno tools installed via deno install -g
+denoTools: deno.#DenoToolSet & {
+	metadata: name: "deno-tools"
+	spec: tools: {
+		deployctl: {package: "jsr:@deno/deployctl", version: "1.12.0"}
+	}
+}

--- a/examples/real-world/node.cue
+++ b/examples/real-world/node.cue
@@ -1,20 +1,14 @@
 package tomei
 
+import "tomei.terassyi.net/presets/node"
+
 // Node.js tools installed via pnpm add -g
-pnpmTools: {
-	apiVersion: "tomei.terassyi.net/v1beta1"
-	kind:       "ToolSet"
-	metadata: {
-		name:        "pnpm-tools"
-		description: "Node.js CLI tools installed via pnpm"
-	}
-	spec: {
-		runtimeRef: "pnpm"
-		tools: {
-			prettier: {package: "prettier", version: "3.5.3"}
-			"ts-node": {package: "ts-node", version: "10.9.2"}
-			typescript: {package: "typescript", version: "5.7.3"}
-			"npm-check-updates": {package: "npm-check-updates", version: "17.1.14"}
-		}
+pnpmTools: node.#PnpmToolSet & {
+	metadata: name: "pnpm-tools"
+	spec: tools: {
+		prettier: {package: "prettier", version: "3.5.3"}
+		"ts-node": {package: "ts-node", version: "10.9.2"}
+		typescript: {package: "typescript", version: "5.7.3"}
+		"npm-check-updates": {package: "npm-check-updates", version: "17.1.14"}
 	}
 }

--- a/examples/real-world/runtimes.cue
+++ b/examples/real-world/runtimes.cue
@@ -3,89 +3,41 @@ package tomei
 import (
 	gopreset "tomei.terassyi.net/presets/go"
 	"tomei.terassyi.net/presets/rust"
+	"tomei.terassyi.net/presets/python"
+	"tomei.terassyi.net/presets/node"
+	"tomei.terassyi.net/presets/deno"
+	"tomei.terassyi.net/presets/bun"
 )
 
-// ---------------------------------------------------------------------------
 // Go runtime (download from go.dev)
-// ---------------------------------------------------------------------------
-
 goRuntime: gopreset.#GoRuntime & {
 	platform: {os: _os, arch: _arch}
 	spec: version: "1.26.0"
 }
 
-// ---------------------------------------------------------------------------
 // Rust runtime (delegation via rustup)
-// ---------------------------------------------------------------------------
-
 rustRuntime: rust.#RustRuntime & {
 	spec: version: "stable"
 }
 
-// ---------------------------------------------------------------------------
 // uv runtime (delegation — standalone installer)
-// ---------------------------------------------------------------------------
-
-uvRuntime: {
-	apiVersion: "tomei.terassyi.net/v1beta1"
-	kind:       "Runtime"
-	metadata: {
-		name:        "uv"
-		description: "Python package manager and project tool"
-	}
-	spec: {
-		type:    "delegation"
-		version: "0.10.2"
-		bootstrap: {
-			install: ["curl -LsSf https://astral.sh/uv/{{.Version}}/install.sh | sh"]
-			check: ["~/.local/bin/uv --version"]
-			remove: ["~/.local/bin/uv self uninstall"]
-			resolveVersion: ["~/.local/bin/uv --version 2>/dev/null | grep -oP '\\d+\\.\\d+\\.\\d+' || echo ''"]
-		}
-		binaries: ["uv", "uvx"]
-		binDir:      "~/.local/bin"
-		toolBinPath: "~/.local/bin"
-		commands: {
-			install: ["~/.local/bin/uv tool install {{.Package}}{{if .Version}}=={{.Version}}{{end}}{{if .Args}} {{.Args}}{{end}}"]
-			remove: ["~/.local/bin/uv tool uninstall {{.Package}}"]
-		}
-	}
+uvRuntime: python.#UvRuntime & {
+	spec: version: "0.10.2"
 }
 
-// ---------------------------------------------------------------------------
 // Node.js runtime (delegation via pnpm standalone installer)
-// ---------------------------------------------------------------------------
+pnpmRuntime: node.#PnpmRuntime & {
+	spec: version: "10.29.3"
+}
 
-pnpmRuntime: {
-	apiVersion: "tomei.terassyi.net/v1beta1"
-	kind:       "Runtime"
-	metadata: {
-		name:        "pnpm"
-		description: "Node.js package manager (standalone, manages Node.js via pnpm env)"
-	}
-	spec: {
-		type:    "delegation"
-		version: "10.29.3"
-		bootstrap: {
-			install: [
-				"curl -fsSL https://get.pnpm.io/install.sh | SHELL=/bin/bash PNPM_VERSION={{.Version}} sh -",
-				"export PNPM_HOME=$HOME/.local/share/pnpm",
-				"export PATH=$PNPM_HOME:$PATH",
-				"$PNPM_HOME/pnpm env use --global lts",
-			]
-			check: ["~/.local/share/pnpm/pnpm --version"]
-			remove: ["rm -rf ~/.local/share/pnpm"]
-			resolveVersion: ["~/.local/share/pnpm/pnpm --version 2>/dev/null || echo ''"]
-		}
-		binaries: ["pnpm", "pnpx"]
-		binDir:      "~/.local/share/pnpm"
-		toolBinPath: "~/.local/share/pnpm"
-		env: {
-			PNPM_HOME: "~/.local/share/pnpm"
-		}
-		commands: {
-			install: ["~/.local/share/pnpm/pnpm add -g {{.Package}}{{if .Version}}@{{.Version}}{{end}}"]
-			remove: ["~/.local/share/pnpm/pnpm remove -g {{.Package}}"]
-		}
-	}
+// Deno runtime (download from dl.deno.land)
+denoRuntime: deno.#DenoRuntime & {
+	platform: {os: _os, arch: _arch}
+	spec: version: "2.1.4"
+}
+
+// Bun runtime (download from GitHub releases)
+bunRuntime: bun.#BunRuntime & {
+	platform: {os: _os, arch: _arch}
+	spec: version: "1.1.42"
 }

--- a/examples/real-world/uv.cue
+++ b/examples/real-world/uv.cue
@@ -1,20 +1,14 @@
 package tomei
 
+import "tomei.terassyi.net/presets/python"
+
 // Python tools installed via uv tool install
-uvTools: {
-	apiVersion: "tomei.terassyi.net/v1beta1"
-	kind:       "ToolSet"
-	metadata: {
-		name:        "uv-tools"
-		description: "Python CLI tools installed via uv"
-	}
-	spec: {
-		runtimeRef: "uv"
-		tools: {
-			ruff: {package: "ruff", version: "0.15.1"}
-			mypy: {package: "mypy", version: "1.19.1"}
-			httpie: {package: "httpie", version: "3.2.4"}
-			ansible: {package: "ansible", version: "13.3.0", args: ["--with-executables-from", "ansible-core"]}
-		}
+uvTools: python.#UvToolSet & {
+	metadata: name: "uv-tools"
+	spec: tools: {
+		ruff: {package: "ruff", version: "0.15.1"}
+		mypy: {package: "mypy", version: "1.19.1"}
+		httpie: {package: "httpie", version: "3.2.4"}
+		ansible: {package: "ansible", version: "13.3.0", args: ["--with-executables-from", "ansible-core"]}
 	}
 }


### PR DESCRIPTION
Add four new CUE presets:
- node: #PnpmRuntime, #PnpmTool, #PnpmToolSet (delegation via pnpm)
- python: #UvRuntime, #UvTool, #UvToolSet (delegation via uv)
- deno: #DenoRuntime, #DenoTool, #DenoToolSet (download with platform mapping)
- bun: #BunRuntime, #BunTool, #BunToolSet (download from GitHub releases)

DRY-ify existing presets with CUE let variables:
- go: let _goBin for repeated ~/go/bin references
- rust: let _cargoHome, _cargoBin for repeated ~/.cargo references

Update examples/real-world/ to use all seven presets with deno and bun
examples. Update weekly-scenario CI to verify deno and bun runtimes and
tools. Add nine integration tests covering all new presets including
platform variations and an all-presets import conflict test.

Signed-off-by: terashima <iscale821@gmail.com>
