### PR TITLE
fix: skip taint reinstall on first-time runtime install

### DIFF
--- a/e2e/basic_test.go
+++ b/e2e/basic_test.go
@@ -91,10 +91,13 @@ func basicTests() {
 	})
 
 	Context("Runtime and Tool Installation", func() {
-		It("downloads and installs Runtime and Tools", func() {
+		It("downloads and installs Runtime and Tools without taint reinstall", func() {
 			By("Running tomei apply command")
-			_, err := ExecApply(testExec, "~/manifests/")
+			output, err := ExecApply(testExec, "~/manifests/")
 			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying no taint reinstall on first install")
+			Expect(output).NotTo(ContainSubstring("Reinstalled:"))
 		})
 	})
 

--- a/internal/installer/engine/engine.go
+++ b/internal/installer/engine/engine.go
@@ -663,8 +663,9 @@ func (e *Engine) executeRuntimeNode(
 
 	*totalActions++
 
-	// Track if runtime was updated
-	if action.Type == resource.ActionInstall || action.Type == resource.ActionUpgrade || action.Type == resource.ActionReinstall {
+	// Track if runtime was upgraded (not first install).
+	// Only upgrades should trigger taint on dependent tools.
+	if action.Type == resource.ActionUpgrade {
 		updatedRuntimes[action.Name] = true
 	}
 


### PR DESCRIPTION
Only track runtime upgrades (ActionUpgrade) in updatedRuntimes map.
Previously ActionInstall was also included, causing unnecessary taint
reinstall of dependent tools on first-time apply when the runtime has
taintOnUpgrade enabled.

Add integration test TestEngine_TaintNotTriggeredOnFirstInstall and
e2e assertion that first apply has no Reinstalled summary.

Signed-off-by: terashima <iscale821@gmail.com>
