### PR TITLE
refactor: introduce TaintReason named type with constants

### DIFF
--- a/internal/installer/engine/engine_test.go
+++ b/internal/installer/engine/engine_test.go
@@ -2892,7 +2892,7 @@ func TestApplyUpdateTaints_SyncMode(t *testing.T) {
 
 			for _, name := range tt.wantTainted {
 				assert.True(t, st.Tools[name].IsTainted(), "tool %s should be tainted", name)
-				assert.Equal(t, "sync_update", st.Tools[name].TaintReason)
+				assert.Equal(t, resource.TaintReasonSyncUpdate, st.Tools[name].TaintReason)
 			}
 			for _, name := range tt.wantNotTainted {
 				assert.False(t, st.Tools[name].IsTainted(), "tool %s should not be tainted", name)
@@ -2986,7 +2986,7 @@ func TestApplyUpdateTaints_UpdateTools(t *testing.T) {
 
 			for _, name := range tt.wantTainted {
 				assert.True(t, st.Tools[name].IsTainted(), "tool %s should be tainted", name)
-				assert.Equal(t, "update_requested", st.Tools[name].TaintReason)
+				assert.Equal(t, resource.TaintReasonUpdateRequested, st.Tools[name].TaintReason)
 			}
 			for _, name := range tt.wantNotTainted {
 				assert.False(t, st.Tools[name].IsTainted(), "tool %s should not be tainted", name)
@@ -3074,7 +3074,7 @@ func TestApplyUpdateTaints_UpdateRuntimes(t *testing.T) {
 
 			for _, name := range tt.wantTainted {
 				assert.True(t, st.Runtimes[name].IsTainted(), "runtime %s should be tainted", name)
-				assert.Equal(t, "update_requested", st.Runtimes[name].TaintReason)
+				assert.Equal(t, resource.TaintReasonUpdateRequested, st.Runtimes[name].TaintReason)
 			}
 			for _, name := range tt.wantNotTainted {
 				assert.False(t, st.Runtimes[name].IsTainted(), "runtime %s should not be tainted", name)

--- a/internal/installer/executor/store_test.go
+++ b/internal/installer/executor/store_test.go
@@ -145,7 +145,7 @@ func TestCachedStore_markDirtyViaSave(t *testing.T) {
 
 	sc := NewStateCache(store)
 	st := state.NewUserState()
-	st.Tools["exa"] = &resource.ToolState{Version: "0.10.0", TaintReason: "runtime_upgrade"}
+	st.Tools["exa"] = &resource.ToolState{Version: "0.10.0", TaintReason: resource.TaintReasonRuntimeUpgraded}
 	sc.Init(st)
 
 	ts := NewToolStore(sc)

--- a/internal/installer/reconciler/reconciler_test.go
+++ b/internal/installer/reconciler/reconciler_test.go
@@ -233,7 +233,7 @@ func TestReconciler_Reconcile_Tainted(t *testing.T) {
 			SpecVersion:  "14.1.1",
 			InstallPath:  "/path/to/rg",
 			BinPath:      "/bin/rg",
-			TaintReason:  "runtime_upgraded",
+			TaintReason:  resource.TaintReasonRuntimeUpgraded,
 			UpdatedAt:    time.Now(),
 		},
 	}
@@ -464,7 +464,7 @@ func TestToolComparator_VersionKind(t *testing.T) {
 				SpecVersion: tt.specVer,
 			}
 			if tt.tainted {
-				state.TaintReason = "sync_update"
+				state.TaintReason = resource.TaintReasonSyncUpdate
 			}
 
 			needsUpdate, reason := comparator(res, state)
@@ -575,7 +575,7 @@ func TestRuntimeComparator_VersionKind(t *testing.T) {
 				SpecVersion: tt.specVer,
 			}
 			if tt.tainted {
-				state.Taint("update_requested")
+				state.Taint(resource.TaintReasonUpdateRequested)
 			}
 
 			needsUpdate, reason := comparator(res, state)

--- a/internal/installer/reconciler/runtime.go
+++ b/internal/installer/reconciler/runtime.go
@@ -11,7 +11,7 @@ func RuntimeComparator() Comparator[*resource.Runtime, *resource.RuntimeState] {
 			return true, "version changed: " + state.Version + " -> " + res.RuntimeSpec.Version
 		}
 		if state.IsTainted() {
-			return true, "tainted: " + state.TaintReason
+			return true, "tainted: " + string(state.TaintReason)
 		}
 		return false, ""
 	}

--- a/internal/installer/reconciler/tool.go
+++ b/internal/installer/reconciler/tool.go
@@ -30,7 +30,7 @@ func ToolComparator() Comparator[*resource.Tool, *resource.ToolState] {
 			return true, "version changed: " + state.Version + " -> " + res.ToolSpec.Version
 		}
 		if state.IsTainted() {
-			return true, "tainted: " + state.TaintReason
+			return true, "tainted: " + string(state.TaintReason)
 		}
 		return false, ""
 	}

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -113,7 +113,7 @@ func (toolFormatter) FormatRow(name string, t *resource.ToolState, wide bool) []
 	if t.RuntimeRef != "" {
 		ref = t.RuntimeRef
 	}
-	row := []string{name, t.Version, formatVersionKind(t.VersionKind, t.SpecVersion), ref, t.TaintReason}
+	row := []string{name, t.Version, formatVersionKind(t.VersionKind, t.SpecVersion), ref, string(t.TaintReason)}
 	if wide {
 		pkg := ""
 		if t.Package != nil {

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -189,10 +189,10 @@ func TestToolFormatter_FormatRow(t *testing.T) {
 			Version:     "v0.17.0",
 			RuntimeRef:  "go",
 			VersionKind: resource.VersionLatest,
-			TaintReason: "runtime_upgraded",
+			TaintReason: resource.TaintReasonRuntimeUpgraded,
 		}
 		row := f.FormatRow("gopls", ts, false)
-		assert.Equal(t, "runtime_upgraded", row[4])
+		assert.Equal(t, string(resource.TaintReasonRuntimeUpgraded), row[4])
 		assert.Len(t, row, 5)
 	})
 
@@ -335,7 +335,7 @@ func TestPrintTable_Tools(t *testing.T) {
 			Version:     "v0.17.0",
 			RuntimeRef:  "go",
 			VersionKind: resource.VersionLatest,
-			TaintReason: "runtime_upgraded",
+			TaintReason: resource.TaintReasonRuntimeUpgraded,
 		},
 	}
 
@@ -349,7 +349,7 @@ func TestPrintTable_Tools(t *testing.T) {
 	assert.Contains(t, output, "TAINTED")
 
 	// Taint reason visible for gopls
-	assert.Contains(t, output, "runtime_upgraded")
+	assert.Contains(t, output, string(resource.TaintReasonRuntimeUpgraded))
 
 	// Rows sorted alphabetically (gopls before ripgrep)
 	assert.Contains(t, output, "gopls")

--- a/internal/resource/runtime.go
+++ b/internal/resource/runtime.go
@@ -246,9 +246,8 @@ type RuntimeState struct {
 	TaintOnUpgrade bool `json:"taintOnUpgrade,omitempty"`
 
 	// TaintReason indicates why this runtime needs reinstallation.
-	// Common reasons: "update_requested" (--update-runtimes flag).
 	// Empty string means the runtime is not tainted.
-	TaintReason string `json:"taintReason,omitempty"`
+	TaintReason TaintReason `json:"taintReason,omitempty"`
 
 	// UpdatedAt is the timestamp when this runtime was last installed or updated.
 	UpdatedAt time.Time `json:"updatedAt"`
@@ -262,7 +261,7 @@ func (s *RuntimeState) IsTainted() bool {
 }
 
 // Taint marks the runtime for reinstallation.
-func (s *RuntimeState) Taint(reason string) {
+func (s *RuntimeState) Taint(reason TaintReason) {
 	s.TaintReason = reason
 }
 

--- a/internal/resource/runtime_test.go
+++ b/internal/resource/runtime_test.go
@@ -112,32 +112,32 @@ func TestRuntimeState_Taint(t *testing.T) {
 	tests := []struct {
 		name         string
 		initial      *RuntimeState
-		taintReason  string
+		taintReason  TaintReason
 		wantTainted  bool
-		wantReason   string
+		wantReason   TaintReason
 		clearTaint   bool
 		wantAfterClr bool
 	}{
 		{
 			name:        "taint empty state",
 			initial:     &RuntimeState{},
-			taintReason: "update_requested",
+			taintReason: TaintReasonUpdateRequested,
 			wantTainted: true,
-			wantReason:  "update_requested",
+			wantReason:  TaintReasonUpdateRequested,
 		},
 		{
 			name:        "taint with runtime_upgraded reason",
 			initial:     &RuntimeState{Version: "1.83.0"},
-			taintReason: "runtime_upgraded",
+			taintReason: TaintReasonRuntimeUpgraded,
 			wantTainted: true,
-			wantReason:  "runtime_upgraded",
+			wantReason:  TaintReasonRuntimeUpgraded,
 		},
 		{
 			name:         "taint then clear",
 			initial:      &RuntimeState{},
-			taintReason:  "update_requested",
+			taintReason:  TaintReasonUpdateRequested,
 			wantTainted:  true,
-			wantReason:   "update_requested",
+			wantReason:   TaintReasonUpdateRequested,
 			clearTaint:   true,
 			wantAfterClr: false,
 		},

--- a/internal/resource/tool.go
+++ b/internal/resource/tool.go
@@ -530,9 +530,8 @@ type ToolState struct {
 	SpecVersion string `json:"specVersion,omitempty"`
 
 	// TaintReason indicates why this tool needs reinstallation.
-	// Common reasons: "runtime_upgraded" (runtime was updated).
 	// Empty string means the tool is not tainted.
-	TaintReason string `json:"taintReason,omitempty"`
+	TaintReason TaintReason `json:"taintReason,omitempty"`
 
 	// UpdatedAt is the timestamp when this tool was last installed or updated.
 	UpdatedAt time.Time `json:"updatedAt"`
@@ -546,7 +545,7 @@ func (t *ToolState) IsTainted() bool {
 }
 
 // Taint marks the tool for reinstallation.
-func (t *ToolState) Taint(reason string) {
+func (t *ToolState) Taint(reason TaintReason) {
 	t.TaintReason = reason
 }
 

--- a/internal/resource/types.go
+++ b/internal/resource/types.go
@@ -217,6 +217,20 @@ func IsExactVersion(version string) bool {
 	return len(v) > 0 && v[0] >= '0' && v[0] <= '9'
 }
 
+// TaintReason represents the reason a resource needs reinstallation.
+type TaintReason string
+
+const (
+	// TaintReasonRuntimeUpgraded indicates the tool's runtime was upgraded.
+	TaintReasonRuntimeUpgraded TaintReason = "runtime_upgraded"
+
+	// TaintReasonSyncUpdate indicates the tool was tainted by --sync for latest-version update.
+	TaintReasonSyncUpdate TaintReason = "sync_update"
+
+	// TaintReasonUpdateRequested indicates the user requested an update via --update-tools/--update-runtimes.
+	TaintReasonUpdateRequested TaintReason = "update_requested"
+)
+
 // CommandSet defines a set of shell commands for install/check/remove operations.
 // This is the common type used by BootstrapSpec, CommandsSpec, and RuntimeBootstrapSpec.
 // Each command is a string slice; multiple entries are joined with " && " at execution time.

--- a/internal/resource/types_test.go
+++ b/internal/resource/types_test.go
@@ -67,12 +67,12 @@ func TestToolState_Taint(t *testing.T) {
 		t.Error("new state should not be tainted")
 	}
 
-	state.Taint("runtime_upgraded")
+	state.Taint(TaintReasonRuntimeUpgraded)
 	if !state.IsTainted() {
 		t.Error("state should be tainted after Taint()")
 	}
-	if state.TaintReason != "runtime_upgraded" {
-		t.Errorf("expected taint reason 'runtime_upgraded', got %q", state.TaintReason)
+	if state.TaintReason != TaintReasonRuntimeUpgraded {
+		t.Errorf("expected taint reason %q, got %q", TaintReasonRuntimeUpgraded, state.TaintReason)
 	}
 
 	state.ClearTaint()

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -200,7 +200,7 @@ func TestState_Taint(t *testing.T) {
 	require.NoError(t, store.Save(st))
 
 	// Simulate runtime upgrade - taint dependent tools
-	st.Tools["gopls"].Taint("runtime_upgraded")
+	st.Tools["gopls"].Taint(resource.TaintReasonRuntimeUpgraded)
 	require.NoError(t, store.Save(st))
 	require.NoError(t, store.Unlock())
 
@@ -211,7 +211,7 @@ func TestState_Taint(t *testing.T) {
 	require.NoError(t, store.Unlock())
 
 	assert.True(t, st.Tools["gopls"].IsTainted())
-	assert.Equal(t, "runtime_upgraded", st.Tools["gopls"].TaintReason)
+	assert.Equal(t, resource.TaintReasonRuntimeUpgraded, st.Tools["gopls"].TaintReason)
 
 	// Clear taint
 	require.NoError(t, store.Lock())


### PR DESCRIPTION
Replace bare string taint reasons with TaintReason type and
constants (TaintReasonRuntimeUpgraded, TaintReasonSyncUpdate,
TaintReasonUpdateRequested). JSON serialization unchanged.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: terashima <iscale821@gmail.com>
