### PR TITLE
refactor: unify graph.Action into resource.ActionType

### DIFF
--- a/cmd/tomei/plan.go
+++ b/cmd/tomei/plan.go
@@ -146,7 +146,7 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 		resInfo := graph.ResourceInfo{
 			Kind:   res.Kind(),
 			Name:   res.Name(),
-			Action: graph.ActionInstall, // default to install
+			Action: resource.ActionInstall, // default to install
 		}
 
 		// Get version from spec
@@ -167,26 +167,26 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 			case resource.KindRuntime:
 				if rt, ok := userState.Runtimes[res.Name()]; ok {
 					if rt.IsTainted() {
-						resInfo.Action = graph.ActionReinstall
+						resInfo.Action = resource.ActionReinstall
 					} else if rt.Version == resInfo.Version {
-						resInfo.Action = graph.ActionNone
+						resInfo.Action = resource.ActionNone
 					} else {
-						resInfo.Action = graph.ActionUpgrade
+						resInfo.Action = resource.ActionUpgrade
 					}
 				}
 			case resource.KindTool:
 				if tool, ok := userState.Tools[res.Name()]; ok {
 					if tool.IsTainted() {
-						resInfo.Action = graph.ActionReinstall
+						resInfo.Action = resource.ActionReinstall
 					} else if tool.Version == resInfo.Version {
-						resInfo.Action = graph.ActionNone
+						resInfo.Action = resource.ActionNone
 					} else {
-						resInfo.Action = graph.ActionUpgrade
+						resInfo.Action = resource.ActionUpgrade
 					}
 				}
 			case resource.KindInstaller:
 				// Installers don't have versions in state typically
-				resInfo.Action = graph.ActionNone
+				resInfo.Action = resource.ActionNone
 			}
 		}
 
@@ -202,7 +202,7 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 					Kind:    resource.KindRuntime,
 					Name:    name,
 					Version: rt.Version,
-					Action:  graph.ActionRemove,
+					Action:  resource.ActionRemove,
 				}
 			}
 		}
@@ -213,7 +213,7 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 					Kind:    resource.KindTool,
 					Name:    name,
 					Version: tool.Version,
-					Action:  graph.ActionRemove,
+					Action:  resource.ActionRemove,
 				}
 			}
 		}
@@ -229,7 +229,7 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 					runtimeSpecs[res.Name()] = rt.RuntimeSpec
 				}
 				nodeID := graph.NewNodeID(res.Kind(), res.Name())
-				if ri, ok := info[nodeID]; ok && (ri.Action == graph.ActionUpgrade || ri.Action == graph.ActionReinstall) {
+				if ri, ok := info[nodeID]; ok && (ri.Action == resource.ActionUpgrade || ri.Action == resource.ActionReinstall) {
 					upgradedRuntimes[res.Name()] = true
 				}
 			}
@@ -245,8 +245,8 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 					continue
 				}
 				nodeID := graph.NewNodeID(resource.KindTool, name)
-				if ri, ok := info[nodeID]; ok && ri.Action == graph.ActionNone {
-					ri.Action = graph.ActionReinstall
+				if ri, ok := info[nodeID]; ok && ri.Action == resource.ActionNone {
+					ri.Action = resource.ActionReinstall
 					info[nodeID] = ri
 				}
 			}
@@ -338,7 +338,7 @@ func planForResources(w io.Writer, resources []resource.Resource, disableColor b
 
 	hasChanges := false
 	for _, info := range result.resourceInfo {
-		if info.Action != graph.ActionNone {
+		if info.Action != resource.ActionNone {
 			hasChanges = true
 			break
 		}

--- a/internal/graph/export.go
+++ b/internal/graph/export.go
@@ -18,12 +18,12 @@ type PlanOutput struct {
 
 // PlanResource represents a resource in the plan output.
 type PlanResource struct {
-	Kind         resource.Kind `json:"kind" yaml:"kind"`
-	Name         string        `json:"name" yaml:"name"`
-	Version      string        `json:"version,omitempty" yaml:"version,omitempty"`
-	Action       Action        `json:"action" yaml:"action"`
-	Layer        int           `json:"layer" yaml:"layer"`
-	Dependencies []string      `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
+	Kind         resource.Kind       `json:"kind" yaml:"kind"`
+	Name         string              `json:"name" yaml:"name"`
+	Version      string              `json:"version,omitempty" yaml:"version,omitempty"`
+	Action       resource.ActionType `json:"action" yaml:"action"`
+	Layer        int                 `json:"layer" yaml:"layer"`
+	Dependencies []string            `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
 }
 
 // PlanLayer represents an execution layer in the plan output.
@@ -105,15 +105,15 @@ func (e *Exporter) BuildOutput() PlanOutput {
 	}
 	for _, res := range output.Resources {
 		switch res.Action {
-		case ActionInstall:
+		case resource.ActionInstall:
 			summary.Install++
-		case ActionUpgrade:
+		case resource.ActionUpgrade:
 			summary.Upgrade++
-		case ActionReinstall:
+		case resource.ActionReinstall:
 			summary.Reinstall++
-		case ActionRemove:
+		case resource.ActionRemove:
 			summary.Remove++
-		case ActionNone:
+		case resource.ActionNone:
 			summary.NoChange++
 		}
 	}

--- a/internal/graph/tree.go
+++ b/internal/graph/tree.go
@@ -11,23 +11,12 @@ import (
 	"github.com/terassyi/tomei/internal/resource"
 )
 
-// Action represents the action to be taken on a resource.
-type Action string
-
-const (
-	ActionInstall   Action = "install"
-	ActionUpgrade   Action = "upgrade"
-	ActionReinstall Action = "reinstall"
-	ActionRemove    Action = "remove"
-	ActionNone      Action = "none"
-)
-
 // ResourceInfo holds information about a resource for display.
 type ResourceInfo struct {
 	Kind    resource.Kind
 	Name    string
 	Version string
-	Action  Action
+	Action  resource.ActionType
 }
 
 // TreePrinter prints dependency graphs as ASCII trees with colors.
@@ -167,23 +156,23 @@ func (p *TreePrinter) formatNode(nodeID NodeID, info ResourceInfo, hasInfo bool)
 		actionStr := ""
 		var actionColor *color.Color
 		switch info.Action {
-		case ActionInstall:
+		case resource.ActionInstall:
 			actionStr = " [+ install]"
 			actionColor = p.installColor
-		case ActionUpgrade:
+		case resource.ActionUpgrade:
 			actionStr = " [~ upgrade]"
 			actionColor = p.upgradeColor
-		case ActionReinstall:
+		case resource.ActionReinstall:
 			actionStr = " [↻ reinstall]"
 			actionColor = p.reinstallColor
-		case ActionRemove:
+		case resource.ActionRemove:
 			actionStr = " [- remove]"
 			actionColor = p.removeColor
-		case ActionNone:
+		case resource.ActionNone:
 			actionColor = p.noChangeColor
 		}
 
-		if actionColor != nil && info.Action != ActionNone {
+		if actionColor != nil && info.Action != resource.ActionNone {
 			sb.WriteString(actionColor.Sprint(nodeName + versionStr + actionStr))
 		} else {
 			sb.WriteString(nodeName + versionStr)
@@ -209,23 +198,23 @@ func (p *TreePrinter) PrintLayers(layers []Layer, resourceInfo map[NodeID]Resour
 
 // PrintSummary prints the action summary.
 func (p *TreePrinter) PrintSummary(resourceInfo map[NodeID]ResourceInfo) {
-	counts := map[Action]int{
-		ActionInstall:   0,
-		ActionUpgrade:   0,
-		ActionReinstall: 0,
-		ActionRemove:    0,
+	counts := map[resource.ActionType]int{
+		resource.ActionInstall:   0,
+		resource.ActionUpgrade:   0,
+		resource.ActionReinstall: 0,
+		resource.ActionRemove:    0,
 	}
 
 	for _, info := range resourceInfo {
-		if info.Action != ActionNone {
+		if info.Action != resource.ActionNone {
 			counts[info.Action]++
 		}
 	}
 
 	fmt.Fprintf(p.writer, "\nSummary: %s to install, %s to upgrade, %s to reinstall, %s to remove\n",
-		p.installColor.Sprintf("%d", counts[ActionInstall]),
-		p.upgradeColor.Sprintf("%d", counts[ActionUpgrade]),
-		p.reinstallColor.Sprintf("%d", counts[ActionReinstall]),
-		p.removeColor.Sprintf("%d", counts[ActionRemove]),
+		p.installColor.Sprintf("%d", counts[resource.ActionInstall]),
+		p.upgradeColor.Sprintf("%d", counts[resource.ActionUpgrade]),
+		p.reinstallColor.Sprintf("%d", counts[resource.ActionReinstall]),
+		p.removeColor.Sprintf("%d", counts[resource.ActionRemove]),
 	)
 }

--- a/internal/graph/tree_test.go
+++ b/internal/graph/tree_test.go
@@ -24,44 +24,44 @@ func TestPrintSummary(t *testing.T) {
 		{
 			name: "install only",
 			info: map[NodeID]ResourceInfo{
-				NewNodeID(resource.KindTool, "gopls"): {Kind: resource.KindTool, Name: "gopls", Action: ActionInstall},
-				NewNodeID(resource.KindTool, "dlv"):   {Kind: resource.KindTool, Name: "dlv", Action: ActionInstall},
-				NewNodeID(resource.KindRuntime, "go"): {Kind: resource.KindRuntime, Name: "go", Action: ActionNone},
+				NewNodeID(resource.KindTool, "gopls"): {Kind: resource.KindTool, Name: "gopls", Action: resource.ActionInstall},
+				NewNodeID(resource.KindTool, "dlv"):   {Kind: resource.KindTool, Name: "dlv", Action: resource.ActionInstall},
+				NewNodeID(resource.KindRuntime, "go"): {Kind: resource.KindRuntime, Name: "go", Action: resource.ActionNone},
 			},
 			wantLine: "\nSummary: 2 to install, 0 to upgrade, 0 to reinstall, 0 to remove\n",
 		},
 		{
 			name: "upgrade triggers reinstall",
 			info: map[NodeID]ResourceInfo{
-				NewNodeID(resource.KindRuntime, "go"): {Kind: resource.KindRuntime, Name: "go", Version: "1.25.6", Action: ActionUpgrade},
-				NewNodeID(resource.KindTool, "gopls"): {Kind: resource.KindTool, Name: "gopls", Action: ActionReinstall},
-				NewNodeID(resource.KindTool, "dlv"):   {Kind: resource.KindTool, Name: "dlv", Action: ActionReinstall},
+				NewNodeID(resource.KindRuntime, "go"): {Kind: resource.KindRuntime, Name: "go", Version: "1.25.6", Action: resource.ActionUpgrade},
+				NewNodeID(resource.KindTool, "gopls"): {Kind: resource.KindTool, Name: "gopls", Action: resource.ActionReinstall},
+				NewNodeID(resource.KindTool, "dlv"):   {Kind: resource.KindTool, Name: "dlv", Action: resource.ActionReinstall},
 			},
 			wantLine: "\nSummary: 0 to install, 1 to upgrade, 2 to reinstall, 0 to remove\n",
 		},
 		{
 			name: "mixed actions",
 			info: map[NodeID]ResourceInfo{
-				NewNodeID(resource.KindRuntime, "go"): {Kind: resource.KindRuntime, Name: "go", Action: ActionUpgrade},
-				NewNodeID(resource.KindTool, "gopls"): {Kind: resource.KindTool, Name: "gopls", Action: ActionReinstall},
-				NewNodeID(resource.KindTool, "fd"):    {Kind: resource.KindTool, Name: "fd", Action: ActionInstall},
-				NewNodeID(resource.KindTool, "old"):   {Kind: resource.KindTool, Name: "old", Action: ActionRemove},
-				NewNodeID(resource.KindTool, "bat"):   {Kind: resource.KindTool, Name: "bat", Action: ActionNone},
+				NewNodeID(resource.KindRuntime, "go"): {Kind: resource.KindRuntime, Name: "go", Action: resource.ActionUpgrade},
+				NewNodeID(resource.KindTool, "gopls"): {Kind: resource.KindTool, Name: "gopls", Action: resource.ActionReinstall},
+				NewNodeID(resource.KindTool, "fd"):    {Kind: resource.KindTool, Name: "fd", Action: resource.ActionInstall},
+				NewNodeID(resource.KindTool, "old"):   {Kind: resource.KindTool, Name: "old", Action: resource.ActionRemove},
+				NewNodeID(resource.KindTool, "bat"):   {Kind: resource.KindTool, Name: "bat", Action: resource.ActionNone},
 			},
 			wantLine: "\nSummary: 1 to install, 1 to upgrade, 1 to reinstall, 1 to remove\n",
 		},
 		{
 			name: "remove only",
 			info: map[NodeID]ResourceInfo{
-				NewNodeID(resource.KindTool, "old-tool"): {Kind: resource.KindTool, Name: "old-tool", Action: ActionRemove},
+				NewNodeID(resource.KindTool, "old-tool"): {Kind: resource.KindTool, Name: "old-tool", Action: resource.ActionRemove},
 			},
 			wantLine: "\nSummary: 0 to install, 0 to upgrade, 0 to reinstall, 1 to remove\n",
 		},
 		{
 			name: "all none is zero counts",
 			info: map[NodeID]ResourceInfo{
-				NewNodeID(resource.KindTool, "gopls"): {Kind: resource.KindTool, Name: "gopls", Action: ActionNone},
-				NewNodeID(resource.KindRuntime, "go"): {Kind: resource.KindRuntime, Name: "go", Action: ActionNone},
+				NewNodeID(resource.KindTool, "gopls"): {Kind: resource.KindTool, Name: "gopls", Action: resource.ActionNone},
+				NewNodeID(resource.KindRuntime, "go"): {Kind: resource.KindRuntime, Name: "go", Action: resource.ActionNone},
 			},
 			wantLine: "\nSummary: 0 to install, 0 to upgrade, 0 to reinstall, 0 to remove\n",
 		},


### PR DESCRIPTION
Remove duplicate Action type from graph package and use the
existing resource.ActionType throughout. Eliminates redundant
constants and improves consistency.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: terashima <iscale821@gmail.com>
