### PR TITLE
refactor: introduce checksum.Digest named type

### DIFF
--- a/internal/checksum/file_test.go
+++ b/internal/checksum/file_test.go
@@ -89,7 +89,7 @@ func TestParseFile_GNU(t *testing.T) {
 		content    []byte
 		filename   string
 		wantAlgo   Algorithm
-		wantHash   string
+		wantHash   Digest
 		wantErr    bool
 		errContain string
 	}{
@@ -98,7 +98,7 @@ func TestParseFile_GNU(t *testing.T) {
 			content:  []byte(sha256Hash + "  test.tar.gz\n"),
 			filename: "test.tar.gz",
 			wantAlgo: AlgorithmSHA256,
-			wantHash: sha256Hash,
+			wantHash: Digest(sha256Hash),
 			wantErr:  false,
 		},
 		{
@@ -106,7 +106,7 @@ func TestParseFile_GNU(t *testing.T) {
 			content:  []byte(sha256Hash + " *test.tar.gz\n"),
 			filename: "test.tar.gz",
 			wantAlgo: AlgorithmSHA256,
-			wantHash: sha256Hash,
+			wantHash: Digest(sha256Hash),
 			wantErr:  false,
 		},
 		{
@@ -118,7 +118,7 @@ func TestParseFile_GNU(t *testing.T) {
 			),
 			filename: "test.tar.gz",
 			wantAlgo: AlgorithmSHA256,
-			wantHash: sha256Hash,
+			wantHash: Digest(sha256Hash),
 			wantErr:  false,
 		},
 		{
@@ -126,7 +126,7 @@ func TestParseFile_GNU(t *testing.T) {
 			content:  []byte(sha256Hash + "  path/to/test.tar.gz\n"),
 			filename: "test.tar.gz",
 			wantAlgo: AlgorithmSHA256,
-			wantHash: sha256Hash,
+			wantHash: Digest(sha256Hash),
 			wantErr:  false,
 		},
 		{
@@ -170,7 +170,7 @@ func TestParseFile_BSD(t *testing.T) {
 		content    []byte
 		filename   string
 		wantAlgo   Algorithm
-		wantHash   string
+		wantHash   Digest
 		wantErr    bool
 		errContain string
 	}{
@@ -179,7 +179,7 @@ func TestParseFile_BSD(t *testing.T) {
 			content:  []byte("SHA256 (test.tar.gz) = " + sha256Hash + "\n"),
 			filename: "test.tar.gz",
 			wantAlgo: AlgorithmSHA256,
-			wantHash: sha256Hash,
+			wantHash: Digest(sha256Hash),
 			wantErr:  false,
 		},
 		{
@@ -187,7 +187,7 @@ func TestParseFile_BSD(t *testing.T) {
 			content:  []byte("SHA512 (test.tar.gz) = " + sha512Hash + "\n"),
 			filename: "test.tar.gz",
 			wantAlgo: AlgorithmSHA512,
-			wantHash: sha512Hash,
+			wantHash: Digest(sha512Hash),
 			wantErr:  false,
 		},
 		{
@@ -199,7 +199,7 @@ func TestParseFile_BSD(t *testing.T) {
 			),
 			filename: "test.tar.gz",
 			wantAlgo: AlgorithmSHA256,
-			wantHash: sha256Hash,
+			wantHash: Digest(sha256Hash),
 			wantErr:  false,
 		},
 		{
@@ -207,7 +207,7 @@ func TestParseFile_BSD(t *testing.T) {
 			content:  []byte("SHA256 (path/to/test.tar.gz) = " + sha256Hash + "\n"),
 			filename: "test.tar.gz",
 			wantAlgo: AlgorithmSHA256,
-			wantHash: sha256Hash,
+			wantHash: Digest(sha256Hash),
 			wantErr:  false,
 		},
 		{
@@ -250,7 +250,7 @@ func TestParseFile_GoJSON(t *testing.T) {
 		content    []byte
 		filename   string
 		wantAlgo   Algorithm
-		wantHash   string
+		wantHash   Digest
 		wantErr    bool
 		errContain string
 	}{
@@ -274,7 +274,7 @@ func TestParseFile_GoJSON(t *testing.T) {
 			]`),
 			filename: "go1.23.5.linux-amd64.tar.gz",
 			wantAlgo: AlgorithmSHA256,
-			wantHash: sha256Hash,
+			wantHash: Digest(sha256Hash),
 			wantErr:  false,
 		},
 		{
@@ -298,7 +298,7 @@ func TestParseFile_GoJSON(t *testing.T) {
 			]`),
 			filename: "go1.23.5.linux-amd64.tar.gz",
 			wantAlgo: AlgorithmSHA256,
-			wantHash: sha256Hash,
+			wantHash: Digest(sha256Hash),
 			wantErr:  false,
 		},
 		{

--- a/internal/installer/download/downloader.go
+++ b/internal/installer/download/downloader.go
@@ -154,7 +154,7 @@ func (d *httpDownloader) Verify(ctx context.Context, filePath string, cs *resour
 
 	slog.Debug("verifying checksum", "file", filePath)
 
-	var expectedHash string
+	var expectedHash checksum.Digest
 	var algorithm checksum.Algorithm
 
 	if cs.Value != "" {
@@ -196,7 +196,7 @@ func (d *httpDownloader) Verify(ctx context.Context, filePath string, cs *resour
 // Supports two formats:
 //   - Standard text format: "<hash>  <filename>" or "<hash> *<filename>"
 //   - Go JSON format: [{"version":"go1.x","files":[{"filename":"...","sha256":"..."}]}]
-func (d *httpDownloader) fetchChecksumFromURL(ctx context.Context, url, filename string) (checksum.Algorithm, string, error) {
+func (d *httpDownloader) fetchChecksumFromURL(ctx context.Context, url, filename string) (checksum.Algorithm, checksum.Digest, error) {
 	slog.Debug("fetching checksum file", "url", url, "filename", filename)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)

--- a/internal/installer/runtime/installer.go
+++ b/internal/installer/runtime/installer.go
@@ -275,9 +275,9 @@ func (i *Installer) removeDelegation(ctx context.Context, st *resource.RuntimeSt
 
 // buildStateResolved creates a RuntimeState with explicit resolved version and version kind.
 func (i *Installer) buildStateResolved(spec *resource.RuntimeSpec, installPath, binDir, resolvedVersion string, versionKind resource.VersionKind) *resource.RuntimeState {
-	digest := ""
+	var digest checksum.Digest
 	if spec.Source != nil && spec.Source.Checksum != nil {
-		digest = checksum.ExtractHash(spec.Source.Checksum)
+		digest = checksum.ExtractHash(spec.Source.Checksum.Value)
 	}
 
 	// Expand ~ in toolBinPath

--- a/internal/installer/runtime/installer_test.go
+++ b/internal/installer/runtime/installer_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/terassyi/tomei/internal/checksum"
 	"github.com/terassyi/tomei/internal/installer/command"
 	"github.com/terassyi/tomei/internal/installer/download"
 	"github.com/terassyi/tomei/internal/installer/executor"
@@ -80,7 +81,7 @@ func TestInstaller_Install(t *testing.T) {
 		// Verify state
 		assert.Equal(t, resource.InstallTypeDownload, state.Type)
 		assert.Equal(t, "1.0.0", state.Version)
-		assert.Equal(t, archiveHash, state.Digest)
+		assert.Equal(t, checksum.Digest(archiveHash), state.Digest)
 		assert.Contains(t, state.InstallPath, "myruntime/1.0.0")
 		assert.Equal(t, []string{"mybin", "mybin2"}, state.Binaries)
 		assert.Equal(t, binDir, state.BinDir)

--- a/internal/installer/tool/installer.go
+++ b/internal/installer/tool/installer.go
@@ -157,7 +157,10 @@ func (i *Installer) installByDownload(ctx context.Context, res *resource.Tool, n
 	}
 
 	// Get expected hash for validation
-	expectedHash := checksum.ExtractHash(spec.Source.Checksum)
+	var expectedHash checksum.Digest
+	if spec.Source.Checksum != nil {
+		expectedHash = checksum.ExtractHash(spec.Source.Checksum.Value)
+	}
 
 	// Create place target
 	target := place.Target{
@@ -167,7 +170,7 @@ func (i *Installer) installByDownload(ctx context.Context, res *resource.Tool, n
 	}
 
 	// Validate existing installation
-	action, err := i.placer.Validate(target, expectedHash)
+	action, err := i.placer.Validate(target, string(expectedHash))
 	if err != nil {
 		return nil, fmt.Errorf("failed to validate: %w", err)
 	}
@@ -363,7 +366,7 @@ func (i *Installer) installFromRegistry(ctx context.Context, res *resource.Tool,
 }
 
 // buildState creates a ToolState from the installation result.
-func (i *Installer) buildState(spec *resource.ToolSpec, target place.Target, digest string) *resource.ToolState {
+func (i *Installer) buildState(spec *resource.ToolSpec, target place.Target, digest checksum.Digest) *resource.ToolState {
 	return &resource.ToolState{
 		InstallerRef: spec.InstallerRef,
 		Version:      spec.Version,

--- a/internal/resource/runtime.go
+++ b/internal/resource/runtime.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	"github.com/terassyi/tomei/internal/checksum"
 )
 
 // RuntimeSpec defines a language runtime (e.g., Go, Rust, Node.js).
@@ -210,7 +212,7 @@ type RuntimeState struct {
 
 	// Digest is the SHA256 hash of the downloaded archive (download pattern only).
 	// Used to verify integrity and detect corruption.
-	Digest string `json:"digest,omitempty"`
+	Digest checksum.Digest `json:"digest,omitempty"`
 
 	// InstallPath is the absolute path where the runtime is installed.
 	// For download pattern: ~/.local/share/tomei/runtimes/go/1.25.1

--- a/internal/resource/tool.go
+++ b/internal/resource/tool.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/terassyi/tomei/internal/checksum"
 	"github.com/terassyi/tomei/internal/installer/extract"
 )
 
@@ -494,7 +495,7 @@ type ToolState struct {
 
 	// Digest is the SHA256 hash of the installed binary (for download pattern).
 	// Used to verify integrity and detect if the binary was modified.
-	Digest string `json:"digest,omitempty"`
+	Digest checksum.Digest `json:"digest,omitempty"`
 
 	// InstallPath is the absolute path to the installed binary.
 	// For download pattern: ~/.local/share/tomei/tools/{name}/{version}/{binary}

--- a/tests/runtime_installer_test.go
+++ b/tests/runtime_installer_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/terassyi/tomei/internal/checksum"
 	"github.com/terassyi/tomei/internal/installer/download"
 	"github.com/terassyi/tomei/internal/installer/runtime"
 	"github.com/terassyi/tomei/internal/resource"
@@ -78,7 +79,7 @@ func TestRuntimeInstaller_Install_HTTP(t *testing.T) {
 
 		assert.Equal(t, resource.InstallTypeDownload, state.Type)
 		assert.Equal(t, "1.0.0", state.Version)
-		assert.Equal(t, archiveHash, state.Digest)
+		assert.Equal(t, checksum.Digest(archiveHash), state.Digest)
 		assert.DirExists(t, state.InstallPath)
 		assert.FileExists(t, filepath.Join(state.InstallPath, "bin", "mybin"))
 


### PR DESCRIPTION
Add Digest type to checksum package for type-safe hash values.
Update ToolState.Digest and RuntimeState.Digest fields, and all
related functions. Break import cycle by changing ExtractHash to
accept string value instead of *resource.Checksum.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: terashima <iscale821@gmail.com>
