### PR TITLE
refactor: use typed fields in aqua ResolvedSource

### DIFF
--- a/internal/installer/tool/installer.go
+++ b/internal/installer/tool/installer.go
@@ -326,7 +326,7 @@ func (i *Installer) installFromRegistry(ctx context.Context, res *resource.Tool,
 	// Build DownloadSource from resolved info
 	source := &resource.DownloadSource{
 		URL:         resolved.URL,
-		ArchiveType: extract.ArchiveType(resolved.Format),
+		ArchiveType: resolved.Format,
 	}
 
 	// Add checksum if available

--- a/internal/registry/aqua/resolver_test.go
+++ b/internal/registry/aqua/resolver_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/terassyi/tomei/internal/checksum"
+	"github.com/terassyi/tomei/internal/installer/extract"
 )
 
 func TestResolver_Resolve_GitHubRelease(t *testing.T) {
@@ -46,8 +48,8 @@ func TestResolver_Resolve_GitHubRelease(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "https://github.com/cli/cli/releases/download/v2.86.0/gh_2.86.0_macOS_arm64.tar.gz", result.URL)
 	assert.Equal(t, "https://github.com/cli/cli/releases/download/v2.86.0/gh_2.86.0_checksums.txt", result.ChecksumURL)
-	assert.Equal(t, "sha256", result.Algorithm)
-	assert.Equal(t, "tar.gz", result.Format)
+	assert.Equal(t, checksum.AlgorithmSHA256, result.ChecksumAlgorithm)
+	assert.Equal(t, extract.ArchiveTypeTarGz, result.Format)
 	assert.Empty(t, result.Errors)
 }
 
@@ -104,7 +106,7 @@ func TestResolver_Resolve_WithVersionOverrides(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "https://github.com/cli/cli/releases/download/v1.5.0/gh_old_1.5.0_linux_amd64.zip", result.URL)
-	assert.Equal(t, "zip", result.Format)
+	assert.Equal(t, extract.ArchiveTypeZip, result.Format)
 	assert.Contains(t, result.Warnings, "version v1.5.0 uses legacy asset format")
 }
 
@@ -135,7 +137,7 @@ func TestResolver_Resolve_WithOSOverrides(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "https://github.com/example/tool/releases/download/v1.0.0/tool_windows_amd64.zip", result.URL)
-	assert.Equal(t, "zip", result.Format)
+	assert.Equal(t, extract.ArchiveTypeZip, result.Format)
 }
 
 func TestResolver_Resolve_WithReplacements(t *testing.T) {
@@ -317,7 +319,7 @@ func TestResolver_Resolve_NoChecksum(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, result.URL)
 	assert.Empty(t, result.ChecksumURL)
-	assert.Empty(t, result.Algorithm)
+	assert.Empty(t, result.ChecksumAlgorithm)
 }
 
 func TestResolver_Resolve_UnsupportedType(t *testing.T) {
@@ -434,7 +436,7 @@ func TestResolver_Resolve_VersionPrefixWithTrimV(t *testing.T) {
 	require.NoError(t, err)
 	// version_prefix "jq-" + version "1.8.1" = tag "jq-1.8.1"
 	assert.Equal(t, "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-linux-amd64", result.URL)
-	assert.Equal(t, "raw", result.Format, "should auto-detect raw format")
+	assert.Equal(t, extract.ArchiveTypeRaw, result.Format, "should auto-detect raw format")
 }
 
 func TestResolver_Resolve_NoVersionPrefix_SemVerEqualsVersion(t *testing.T) {
@@ -493,7 +495,7 @@ func TestResolver_Resolve_HTTPWithURLInVersionOverride(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "https://dl.k8s.io/v1.35.1/bin/linux/amd64/kubectl", result.URL)
-	assert.Equal(t, "raw", result.Format)
+	assert.Equal(t, extract.ArchiveTypeRaw, result.Format)
 }
 
 func TestResolver_Resolve_RawFormatAutoDetect(t *testing.T) {
@@ -518,7 +520,7 @@ func TestResolver_Resolve_RawFormatAutoDetect(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "https://github.com/mikefarah/yq/releases/download/v4.52.2/yq_linux_amd64", result.URL)
-	assert.Equal(t, "raw", result.Format, "should auto-detect raw format when asset has no archive extension")
+	assert.Equal(t, extract.ArchiveTypeRaw, result.Format, "should auto-detect raw format when asset has no archive extension")
 }
 
 func TestHasArchiveExtension(t *testing.T) {

--- a/tests/aqua_integration_test.go
+++ b/tests/aqua_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/terassyi/tomei/internal/installer/extract"
 	"github.com/terassyi/tomei/internal/registry/aqua"
 )
 
@@ -97,7 +98,7 @@ func TestAquaResolverIntegration(t *testing.T) {
 
 		assert.Equal(t, "https://github.com/cli/cli/releases/download/v2.86.0/gh_2.86.0_linux_arm64.tar.gz", resolved.URL)
 		assert.Equal(t, "https://github.com/cli/cli/releases/download/v2.86.0/gh_2.86.0_checksums.txt", resolved.ChecksumURL)
-		assert.Equal(t, "tar.gz", resolved.Format)
+		assert.Equal(t, extract.ArchiveTypeTarGz, resolved.Format)
 	})
 
 	t.Run("resolve gh for darwin/arm64", func(t *testing.T) {
@@ -180,7 +181,7 @@ func TestAquaComplexOverrides(t *testing.T) {
 		// version_overrides replacements completely replace base replacements (no merge)
 		// darwin→Darwin, linux→Linux are applied, but arm64 has no replacement so stays as arm64
 		assert.Equal(t, "https://github.com/complex/tool/releases/download/2.5.0/tool-v2_2.5.0_Linux_arm64.tar.gz", resolved.URL)
-		assert.Equal(t, "tar.gz", resolved.Format)
+		assert.Equal(t, extract.ArchiveTypeTarGz, resolved.Format)
 	})
 
 	t.Run("version < 2.0.0 uses legacy asset with zip format", func(t *testing.T) {
@@ -188,7 +189,7 @@ func TestAquaComplexOverrides(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "https://github.com/complex/tool/releases/download/1.5.0/tool-legacy_1.5.0_linux_x86_64.zip", resolved.URL)
-		assert.Equal(t, "zip", resolved.Format)
+		assert.Equal(t, extract.ArchiveTypeZip, resolved.Format)
 	})
 
 	t.Run("darwin/arm64 uses OS override asset", func(t *testing.T) {


### PR DESCRIPTION
Change ResolvedSource.Format from string to extract.ArchiveType
and ChecksumAlgorithm from string to checksum.Algorithm. Remove
redundant type casts at call sites.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: terashima <iscale821@gmail.com>
