### PR TITLE
refactor: add compile-time interface compliance checks

### DIFF
--- a/internal/env/shell.go
+++ b/internal/env/shell.go
@@ -55,6 +55,11 @@ func NewFormatter(st ShellType) Formatter {
 	}
 }
 
+var (
+	_ Formatter = (*posixFormatter)(nil)
+	_ Formatter = (*fishFormatter)(nil)
+)
+
 type posixFormatter struct{}
 
 func (posixFormatter) ExportVar(key, value string) string {

--- a/internal/graph/resolver.go
+++ b/internal/graph/resolver.go
@@ -37,6 +37,8 @@ type Resolver interface {
 	GetNodes() []*Node
 }
 
+var _ Resolver = (*resolver)(nil)
+
 // resolver is the concrete implementation of Resolver interface.
 type resolver struct {
 	dag *dag

--- a/internal/installer/download/downloader.go
+++ b/internal/installer/download/downloader.go
@@ -31,6 +31,8 @@ type Downloader interface {
 	Verify(ctx context.Context, filePath string, checksum *resource.Checksum) error
 }
 
+var _ Downloader = (*httpDownloader)(nil)
+
 // httpDownloader implements Downloader using HTTP.
 type httpDownloader struct {
 	client *http.Client

--- a/internal/installer/extract/extractor.go
+++ b/internal/installer/extract/extractor.go
@@ -81,6 +81,13 @@ func NewExtractor(archiveType ArchiveType) (Extractor, error) {
 	}
 }
 
+var (
+	_ Extractor = (*tarGzExtractor)(nil)
+	_ Extractor = (*tarXzExtractor)(nil)
+	_ Extractor = (*zipExtractor)(nil)
+	_ Extractor = (*rawExtractor)(nil)
+)
+
 // tarGzExtractor implements Extractor for tar.gz archives.
 type tarGzExtractor struct{}
 

--- a/internal/installer/place/placer.go
+++ b/internal/installer/place/placer.go
@@ -71,6 +71,8 @@ type Placer interface {
 	Cleanup(path string) error
 }
 
+var _ Placer = (*filePlacer)(nil)
+
 // filePlacer implements Placer.
 type filePlacer struct {
 	toolsDir string // e.g., ~/.local/share/tomei/tools

--- a/internal/verify/noop.go
+++ b/internal/verify/noop.go
@@ -6,6 +6,8 @@ import (
 	"cuelang.org/go/mod/module"
 )
 
+var _ Verifier = (*noopVerifier)(nil)
+
 // noopVerifier is a Verifier that skips all verification.
 // Used when verification is disabled (e.g. --ignore-cosign, vendor mode).
 type noopVerifier struct {

--- a/internal/verify/sigstore.go
+++ b/internal/verify/sigstore.go
@@ -23,6 +23,8 @@ const (
 	expectedSANRegex = `^https://github\.com/terassyi/tomei/`
 )
 
+var _ Verifier = (*SigstoreVerifier)(nil)
+
 // SigstoreVerifier verifies cosign signatures on OCI artifacts using sigstore-go.
 // In production, it performs keyless verification via Fulcio + Rekor.
 type SigstoreVerifier struct {


### PR DESCRIPTION
Add var _ Interface = (*Impl)(nil) assertions for all interface
implementations: Verifier, Downloader, Extractor, Placer,
Formatter, and Resolver. Catches implementation drift at compile
time instead of test time.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: terashima <iscale821@gmail.com>
