### PR TITLE
fix(engine): serialize delegation tool installations per runtime

### DIFF
--- a/e2e/config/manifests/delegation.cue
+++ b/e2e/config/manifests/delegation.cue
@@ -14,3 +14,19 @@ gopls: {
 		version:    _goplsVersion
 	}
 }
+
+// goimports - Go import organizer installed via go install (Runtime Delegation)
+// Tests that multiple delegation tools for the same runtime are installed correctly.
+
+_goimportsVersion: "v0.33.0"
+
+goimports: {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "Tool"
+	metadata: name: "goimports"
+	spec: {
+		runtimeRef: "go"
+		package:    "golang.org/x/tools/cmd/goimports"
+		version:    _goimportsVersion
+	}
+}

--- a/e2e/versions_test.go
+++ b/e2e/versions_test.go
@@ -21,6 +21,7 @@ type e2eVersions struct {
 	GoVersionUpgrade string // runtime.cue.upgrade → Runtime/go
 	GhVersion        string // tools.cue → Tool/gh
 	GoplsVersion     string // delegation.cue → Tool/gopls
+	GoimportsVersion string // delegation.cue → Tool/goimports
 	RustVersion      string // rust-runtime.cue → Runtime/rust
 	SdVersion        string // rust-delegation.cue → Tool/sd
 
@@ -83,6 +84,12 @@ func loadVersions() (*e2eVersions, error) {
 		return nil, fmt.Errorf("delegation.cue: %w", err)
 	} else {
 		v.GoplsVersion = ver
+	}
+
+	if ver, err := loadVersion(loader, filepath.Join(manifestsDir, "delegation.cue"), resource.KindTool, "goimports"); err != nil {
+		return nil, fmt.Errorf("delegation.cue goimports: %w", err)
+	} else {
+		v.GoimportsVersion = ver
 	}
 
 	if ver, err := loadVersion(loader, filepath.Join(delegationTestDir, "rust-runtime.cue"), resource.KindRuntime, "rust"); err != nil {


### PR DESCRIPTION
Tools installed via runtime delegation (e.g., go install, pnpm add -g)
share global state within the package manager. Concurrent invocations
corrupt this state, causing failures like "ncu: command not found" in
weekly CI. Partition tool nodes by delegation key so that same-key tools
run sequentially while download-pattern tools and different delegation
groups remain fully parallel.

- Add delegationKeyForTool() and partitionToolsByDelegation() helpers
- Add executeToolNodesWithDelegationSerialization() with per-group
  sequential execution under the shared semaphore
- Deterministic group ordering via sorted delegation keys
- Add goimports to E2E delegation manifest for multi-tool coverage
- 8 new engine tests including property-based (rapid) verification
- Document delegation serialization in architecture.md

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: terashima <iscale821@gmail.com>
