### PR TITLE
docs: add commands pattern and update manifest examples

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -77,10 +77,9 @@ Each resource has `apiVersion`, `kind`, `metadata`, and `spec`. A Tool specifies
 
 - runtimeRef: Tool → Runtime (tool installed via runtime's commands)
 - installerRef: Tool → Installer (tool installed via installer)
+- commands: Tool (self-managed, no dependencies — first execution layer)
 - toolRef: Installer → Tool (installer depends on a tool binary)
 - repositoryRef: Tool → InstallerRepository
-
-A Tool specifies either `runtimeRef` or `installerRef`, not both.
 
 ### Tool chain example
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -215,9 +215,22 @@ tomei apply --update-all .
 tomei apply --parallel 4 .
 ```
 
+### Self-Managed Tools (Commands Pattern)
+
+Tools with `spec.commands` manage their own installation via shell commands, without needing a runtime or installer dependency.
+
+On `tomei apply`, the engine runs `commands.install` followed by `commands.check` to verify success. `resolveVersion` captures the installed version for `tomei get`.
+
+On `--update-tools`, the engine uses `commands.update` if defined, falling back to `commands.install`.
+On removal (manifest deleted), the engine runs `commands.remove`.
+
+Commands-pattern tools run in the first execution layer alongside download-pattern tools.
+
+See [CUE Schema Reference — ToolCommandSet](cue-schema.md#toolcommandset) for field details.
+
 ### Version Resolvers
 
-Runtime presets can declare a `resolveVersion` field that automatically resolves the actual version at install time. Two built-in resolver syntaxes are available, plus a shell command fallback.
+Runtime presets and commands-pattern tools can declare a `resolveVersion` field that automatically resolves the actual version at install time. Two built-in resolver syntaxes are available, plus a shell command fallback.
 
 #### `github-release:owner/repo[:tagPrefix]`
 

--- a/internal/cuemod/templates/scaffold_tool.cue.tmpl
+++ b/internal/cuemod/templates/scaffold_tool.cue.tmpl
@@ -20,6 +20,9 @@ myTool: {
 		// source: {
 		//     url: "https://example.com/tool.tar.gz"
 		// }
+		// commands: {
+		//     install: ["curl -fsSL https://example.com/install.sh | sh"]
+		// }
 		// args: ["--flag"]
 	}
 }


### PR DESCRIPTION
Update documentation to reflect the commands pattern (PR #89) and
modernize README manifest examples from raw CUE to preset/schema
import style matching examples/real-world/.

- README: replace raw CUE manifests with preset imports, update
  plan/apply output, add commands comment to scaffold example
- docs/design.md: add commands to dependency relationships, remove
  contradictory runtimeRef/installerRef constraint
- docs/usage.md: add Self-Managed Tools subsection
- e2e/README.md: list all 16 test suites, add commands-test and
  update-flags-test manifests, update directory structure
- scaffold template: add commands comment block

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: terashima <iscale821@gmail.com>
