### PR TITLE
fix(install): remove -L flag from version resolution curl

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,7 @@ detect_arch() {
 # --- Resolve latest version tag from GitHub ---
 resolve_latest_version() {
     url="${GITHUB_BASE}/releases/latest"
-    redirect=$(curl -fsSL -o /dev/null -w '%{redirect_url}' "$url")
+    redirect=$(curl -fsS -o /dev/null -w '%{redirect_url}' "$url")
     if [ -z "$redirect" ]; then
         echo "Error: failed to resolve latest version (no stable release found)" >&2
         echo "Hint: use TOMEI_VERSION=v0.1.0-rc to install a pre-release" >&2


### PR DESCRIPTION
The -L flag causes curl to follow the redirect from /releases/latest,
resulting in an empty redirect_url and a "no stable release found" error.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: terashima <iscale821@gmail.com>
