### PR TITLE
fix(resource): treat "latest" string as latest version, not exact

### DIFF
--- a/internal/installer/reconciler/tool.go
+++ b/internal/installer/reconciler/tool.go
@@ -15,7 +15,7 @@ import (
 func specVersionChanged(specVersion string, stateVersionKind resource.VersionKind, stateVersion, stateSpecVersion string) bool {
 	switch stateVersionKind {
 	case resource.VersionLatest:
-		return specVersion != ""
+		return !resource.IsLatestVersion(specVersion)
 	case resource.VersionAlias:
 		return specVersion != stateSpecVersion
 	default: // VersionExact

--- a/internal/installer/tool/installer.go
+++ b/internal/installer/tool/installer.go
@@ -343,7 +343,7 @@ func (i *Installer) installFromRegistry(ctx context.Context, res *resource.Tool,
 	// Determine version: use spec.Version or fetch latest
 	pkgName := spec.Package.String()
 	version := spec.Version
-	if version == "" {
+	if resource.IsLatestVersion(version) {
 		slog.Debug("fetching latest version from registry", "package", pkgName)
 		// Fetch package info to get repo owner/name for version lookup
 		info, err := i.resolver.FetchPackageInfo(ctx, i.registryRef, pkgName)
@@ -473,7 +473,7 @@ func (i *Installer) installByCommands(ctx context.Context, res *resource.Tool, n
 			slog.Warn("resolveVersion failed, using spec version", "name", name, "error", err)
 		} else if resolved != "" {
 			resolvedVersion = resolved
-			if spec.Version == "" {
+			if resource.IsLatestVersion(spec.Version) {
 				versionKind = resource.VersionLatest
 			} else {
 				versionKind = resource.VersionAlias

--- a/internal/installer/tool/installer_test.go
+++ b/internal/installer/tool/installer_test.go
@@ -714,6 +714,34 @@ func TestInstallByCommands(t *testing.T) {
 			wantCommands:    true,
 		},
 		{
+			name: "latest string resolves to VersionLatest",
+			cmds: &resource.ToolCommandSet{
+				CommandSet:     resource.CommandSet{Install: []string{"install-cmd"}},
+				ResolveVersion: []string{"tool --version"},
+			},
+			version:         "latest",
+			checkResult:     true,
+			resolver:        &mockCaptureRunner{result: "4.0.0"},
+			wantVersion:     "4.0.0",
+			wantVersionKind: resource.VersionLatest,
+			wantSpecVersion: "latest",
+			wantCommands:    true,
+		},
+		{
+			name: "latest string without resolver",
+			cmds: &resource.ToolCommandSet{
+				CommandSet: resource.CommandSet{
+					Install: []string{"install-cmd"},
+				},
+			},
+			version:         "latest",
+			checkResult:     true,
+			wantVersion:     "latest",
+			wantVersionKind: resource.VersionLatest,
+			wantSpecVersion: "latest",
+			wantCommands:    true,
+		},
+		{
 			name: "alias version resolves to VersionAlias",
 			cmds: &resource.ToolCommandSet{
 				CommandSet:     resource.CommandSet{Install: []string{"install-cmd"}},

--- a/internal/resource/types.go
+++ b/internal/resource/types.go
@@ -196,11 +196,17 @@ const (
 	VersionAlias VersionKind = "alias"
 )
 
+// IsLatestVersion returns true if the version string means "use latest".
+// Both empty string and "latest" are treated as latest.
+func IsLatestVersion(version string) bool {
+	return version == "" || version == "latest"
+}
+
 // ClassifyVersion determines the VersionKind for a given spec version string.
-// Empty string → VersionLatest, otherwise VersionExact.
+// Empty string or "latest" → VersionLatest, otherwise VersionExact.
 // VersionAlias is only assigned by runtime installers that use ResolveVersion.
 func ClassifyVersion(specVersion string) VersionKind {
-	if specVersion == "" {
+	if IsLatestVersion(specVersion) {
 		return VersionLatest
 	}
 	return VersionExact

--- a/internal/resource/types_test.go
+++ b/internal/resource/types_test.go
@@ -372,6 +372,54 @@ func Test_unmarshalStringOrSlice(t *testing.T) {
 	}
 }
 
+func TestIsLatestVersion(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		{"empty string", "", true},
+		{"latest", "latest", true},
+		{"stable", "stable", false},
+		{"exact version", "1.0.0", false},
+		{"lts", "lts", false},
+		{"LATEST uppercase", "LATEST", false},
+		{"Latest mixed case", "Latest", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := IsLatestVersion(tt.version)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestClassifyVersion(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		version string
+		want    VersionKind
+	}{
+		{"empty string", "", VersionLatest},
+		{"latest string", "latest", VersionLatest},
+		{"exact version", "1.0.0", VersionExact},
+		{"stable alias", "stable", VersionExact},
+		{"v-prefixed version", "v2.1.0", VersionExact},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ClassifyVersion(tt.version)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestIsExactVersion(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
CUE presets default version to "latest" but Go code only recognized
empty string as "use latest". Add IsLatestVersion() helper and update
ClassifyVersion, installFromRegistry, installByCommands, and
specVersionChanged to handle both "" and "latest" consistently.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: terashima <iscale821@gmail.com>
