### PR TITLE
feat(extract): add NormalizeArchiveType for tgz/txz alias support

### DIFF
--- a/internal/installer/extract/extractor.go
+++ b/internal/installer/extract/extractor.go
@@ -32,6 +32,24 @@ const (
 	ArchiveTypeRaw ArchiveType = "raw"
 )
 
+// NormalizeArchiveType normalizes an archive type string to a canonical ArchiveType constant.
+// It handles common aliases (e.g., "tgz" → ArchiveTypeTarGz, "txz" → ArchiveTypeTarXz).
+// Unrecognized values are passed through as-is (NewExtractor will reject them).
+func NormalizeArchiveType(raw string) ArchiveType {
+	switch strings.ToLower(raw) {
+	case "tar.gz", "tgz":
+		return ArchiveTypeTarGz
+	case "tar.xz", "txz":
+		return ArchiveTypeTarXz
+	case "zip":
+		return ArchiveTypeZip
+	case "raw":
+		return ArchiveTypeRaw
+	default:
+		return ArchiveType(raw)
+	}
+}
+
 // DetectArchiveType detects the archive type from a URL or filename.
 // Returns empty string if the type cannot be detected.
 func DetectArchiveType(urlOrFilename string) ArchiveType {

--- a/internal/installer/extract/extractor_test.go
+++ b/internal/installer/extract/extractor_test.go
@@ -16,6 +16,32 @@ import (
 	"github.com/ulikunitz/xz"
 )
 
+func TestNormalizeArchiveType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  ArchiveType
+	}{
+		{name: "tar.gz", input: "tar.gz", want: ArchiveTypeTarGz},
+		{name: "tgz", input: "tgz", want: ArchiveTypeTarGz},
+		{name: "TGZ uppercase", input: "TGZ", want: ArchiveTypeTarGz},
+		{name: "tar.xz", input: "tar.xz", want: ArchiveTypeTarXz},
+		{name: "txz", input: "txz", want: ArchiveTypeTarXz},
+		{name: "zip", input: "zip", want: ArchiveTypeZip},
+		{name: "raw", input: "raw", want: ArchiveTypeRaw},
+		{name: "unknown", input: "unknown", want: ArchiveType("unknown")},
+		{name: "empty", input: "", want: ArchiveType("")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, NormalizeArchiveType(tt.input))
+		})
+	}
+}
+
 func TestDetectArchiveType(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/registry/aqua/resolver.go
+++ b/internal/registry/aqua/resolver.go
@@ -230,7 +230,7 @@ func (r *Resolver) ResolveWithOS(ctx context.Context, ref RegistryRef, pkg, vers
 	}
 
 	// 10. Set format and files
-	result.Format = extract.ArchiveType(info.Format)
+	result.Format = extract.NormalizeArchiveType(info.Format)
 	if result.Format == "" && info.Asset != "" {
 		// Auto-detect raw binary format when asset has no archive extension
 		if !hasArchiveExtension(info.Asset) {


### PR DESCRIPTION
Aqua registry packages (e.g., skim-rs/skim, docker/cli) define their
archive format as "tgz", which is equivalent to "tar.gz" but was not
recognized by the extractor. Add NormalizeArchiveType() to canonicalize
archive type aliases at the input boundary (aqua resolver) instead of
scattering aliases across NewExtractor().

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: terashima <iscale821@gmail.com>
