### PR TITLE
feat(cue): add `tomei cue update` command for dependency version updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ tomei init
 # Set up CUE module
 tomei cue init
 
+# Update module deps to latest (after schema/preset releases)
+tomei cue update
+
 # Write manifests, then apply
 tomei plan .
 tomei apply .

--- a/cmd/tomei/cue/cue.go
+++ b/cmd/tomei/cue/cue.go
@@ -10,6 +10,7 @@ var Cmd = &cobra.Command{
 
 Subcommands:
   init       Initialize a CUE module for tomei manifests
+  update     Update tomei module dependencies to the latest version
   scaffold   Generate a CUE manifest scaffold for a resource kind
   eval       Evaluate CUE manifests with tomei configuration
   export     Export CUE manifests as JSON with tomei configuration`,
@@ -17,6 +18,7 @@ Subcommands:
 
 func init() {
 	Cmd.AddCommand(initCmd)
+	Cmd.AddCommand(updateCmd)
 	Cmd.AddCommand(scaffoldCmd)
 	Cmd.AddCommand(evalCmd)
 	Cmd.AddCommand(exportCmd)

--- a/cmd/tomei/cue/update.go
+++ b/cmd/tomei/cue/update.go
@@ -1,0 +1,108 @@
+package cue
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/terassyi/tomei/internal/cuemod"
+)
+
+var updateDryRun bool
+
+var updateCmd = &cobra.Command{
+	Use:   "update [dir]",
+	Short: "Update tomei module dependencies to the latest version",
+	Long: `Update tomei module dependencies in cue.mod/module.cue to the latest
+published version from the OCI registry.
+
+Scans the deps block for first-party tomei.terassyi.net dependencies and
+updates their version to the latest available.
+
+Usage:
+  tomei cue update              Update in current directory
+  tomei cue update ./manifests  Update in specified directory
+  tomei cue update --dry-run    Show what would be updated without writing`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runUpdate,
+}
+
+func init() {
+	updateCmd.Flags().BoolVar(&updateDryRun, "dry-run", false, "Show updates without writing changes")
+}
+
+func runUpdate(cmd *cobra.Command, args []string) error {
+	dir := "."
+	if len(args) > 0 {
+		dir = args[0]
+	}
+
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path: %w", err)
+	}
+
+	cueModDir := filepath.Join(absDir, "cue.mod")
+
+	// Parse existing module.cue
+	f, err := cuemod.ParseModuleFile(cueModDir)
+	if err != nil {
+		return err
+	}
+
+	// Resolve latest version from OCI registry
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	latestVersion, err := cuemod.ResolveLatestVersion(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to resolve latest module version: %w", err)
+	}
+
+	// Update deps
+	results, err := cuemod.UpdateDeps(f, latestVersion)
+	if err != nil {
+		return err
+	}
+
+	// Display results
+	for _, r := range results {
+		if r.Updated {
+			cmd.Printf("%s: %s -> %s\n", r.ModulePath, r.OldVersion, r.NewVersion)
+		} else {
+			cmd.Printf("%s: already at latest (%s)\n", r.ModulePath, r.OldVersion)
+		}
+	}
+
+	if !cuemod.AnyUpdated(results) {
+		return nil
+	}
+
+	if updateDryRun {
+		return nil
+	}
+
+	// Format and write
+	data, err := cuemod.FormatModuleFile(f)
+	if err != nil {
+		return err
+	}
+
+	if err := cuemod.WriteModuleFileAtomic(cueModDir, data); err != nil {
+		return err
+	}
+
+	cmd.Printf("\nUpdated %s\n", cuemod.RelativePath(absDir, filepath.Join(cueModDir, "module.cue")))
+
+	// Hint about vendored modules
+	if cuemod.HasVendoredModules(absDir) {
+		cmd.Println()
+		cmd.Println("  Vendored modules detected. Run one of:")
+		cmd.Println("    cue mod tidy")
+		cmd.Println("    make vendor-cue")
+	}
+
+	return nil
+}

--- a/docs/cue-ecosystem.md
+++ b/docs/cue-ecosystem.md
@@ -116,7 +116,7 @@ deps: {
 }
 ```
 
-The `deps` version is resolved at `tomei cue init` time by querying the OCI registry (ghcr.io) for the latest published tag. This pins the exact patch version for reproducibility. To update, run `cue mod tidy`.
+The `deps` version is resolved at `tomei cue init` time by querying the OCI registry (ghcr.io) for the latest published tag. This pins the exact patch version for reproducibility. To update, run `tomei cue update`.
 
 **tomei_platform.cue:**
 ```cue
@@ -132,6 +132,20 @@ _headless: bool | *false @tag(headless,type=bool)
 ## CUE Subcommands
 
 `tomei` provides CUE subcommands that integrate with the tomei registry and `@tag()` configuration.
+
+### tomei cue update
+
+Update tomei module dependencies to the latest version:
+
+```bash
+$ tomei cue update
+tomei.terassyi.net@v0: v0.0.1 -> v0.0.3
+
+Updated cue.mod/module.cue
+
+# Preview without writing
+$ tomei cue update --dry-run
+```
 
 ### tomei cue scaffold
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -58,6 +58,31 @@ eval $(tomei env)
 
 See [CUE Ecosystem Integration](cue-ecosystem.md) for details.
 
+## tomei cue update
+
+Update tomei module dependencies in `cue.mod/module.cue` to the latest published version.
+
+```
+tomei cue update [dir] [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Show updates without writing changes |
+
+Scans the `deps` block for first-party `tomei.terassyi.net` dependencies and updates their version to the latest available from the OCI registry.
+
+```bash
+# Update in current directory
+tomei cue update
+
+# Preview changes without writing
+tomei cue update --dry-run
+
+# Update in specified directory
+tomei cue update ./manifests
+```
+
 ## tomei cue scaffold
 
 Generate a CUE manifest scaffold for a resource kind.

--- a/internal/cuemod/init_test.go
+++ b/internal/cuemod/init_test.go
@@ -2,7 +2,6 @@ package cuemod
 
 import (
 	"context"
-	"maps"
 	"os"
 	"path/filepath"
 	"testing"
@@ -136,30 +135,8 @@ func TestRelativePath(t *testing.T) {
 }
 
 func TestResolveLatestVersion(t *testing.T) {
-	// Helper to build a minimal CUE module for the mock registry.
-	buildModuleFS := func(version string) fstest.MapFS {
-		prefix := "tomei.terassyi.net_" + version + "/"
-		return fstest.MapFS{
-			prefix + "cue.mod/module.cue": &fstest.MapFile{
-				Data: []byte("module: \"tomei.terassyi.net@v0\"\nlanguage: version: \"v0.9.0\"\n"),
-			},
-			prefix + "schema/schema.cue": &fstest.MapFile{
-				Data: []byte("package schema\n"),
-			},
-		}
-	}
-
-	// Merge multiple version FSes into one.
-	mergeFS := func(versions ...string) fstest.MapFS {
-		merged := fstest.MapFS{}
-		for _, v := range versions {
-			maps.Copy(merged, buildModuleFS(v))
-		}
-		return merged
-	}
-
 	t.Run("returns latest version from multiple", func(t *testing.T) {
-		reg, err := modregistrytest.New(mergeFS("v0.0.1", "v0.0.2", "v0.0.3"), "")
+		reg, err := modregistrytest.New(mergeMockModuleFS("v0.0.1", "v0.0.2", "v0.0.3"), "")
 		require.NoError(t, err)
 		defer reg.Close()
 
@@ -171,7 +148,7 @@ func TestResolveLatestVersion(t *testing.T) {
 	})
 
 	t.Run("returns single version", func(t *testing.T) {
-		reg, err := modregistrytest.New(buildModuleFS("v0.0.1"), "")
+		reg, err := modregistrytest.New(buildMockModuleFS("v0.0.1"), "")
 		require.NoError(t, err)
 		defer reg.Close()
 

--- a/internal/cuemod/testhelper_test.go
+++ b/internal/cuemod/testhelper_test.go
@@ -1,0 +1,28 @@
+package cuemod
+
+import (
+	"maps"
+	"testing/fstest"
+)
+
+// buildMockModuleFS creates a minimal CUE module FS for the mock registry.
+func buildMockModuleFS(version string) fstest.MapFS {
+	prefix := "tomei.terassyi.net_" + version + "/"
+	return fstest.MapFS{
+		prefix + "cue.mod/module.cue": &fstest.MapFile{
+			Data: []byte("module: \"tomei.terassyi.net@v0\"\nlanguage: version: \"v0.9.0\"\n"),
+		},
+		prefix + "schema/schema.cue": &fstest.MapFile{
+			Data: []byte("package schema\n"),
+		},
+	}
+}
+
+// mergeMockModuleFS merges multiple version FSes into one.
+func mergeMockModuleFS(versions ...string) fstest.MapFS {
+	merged := fstest.MapFS{}
+	for _, v := range versions {
+		maps.Copy(merged, buildMockModuleFS(v))
+	}
+	return merged
+}

--- a/internal/cuemod/update.go
+++ b/internal/cuemod/update.go
@@ -1,0 +1,109 @@
+package cuemod
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"cuelang.org/go/mod/modfile"
+	"github.com/terassyi/tomei/internal/verify"
+)
+
+// UpdateResult represents the result of updating a single dependency.
+type UpdateResult struct {
+	ModulePath string
+	OldVersion string
+	NewVersion string
+	Updated    bool
+}
+
+// ParseModuleFile reads and parses cue.mod/module.cue from the given cue.mod directory.
+// Unlike verify.ParseModuleFile, this returns a user-friendly error when the file is missing.
+func ParseModuleFile(cueModDir string) (*modfile.File, error) {
+	f, err := verify.ParseModuleFile(cueModDir)
+	if err != nil {
+		return nil, err
+	}
+	if f == nil {
+		return nil, fmt.Errorf("module.cue not found in %s (run 'tomei cue init' first)", cueModDir)
+	}
+	return f, nil
+}
+
+// UpdateDeps updates first-party (tomei.terassyi.net) dependencies in the module file
+// to the given latest version. Returns the list of update results.
+func UpdateDeps(f *modfile.File, latestVersion string) ([]UpdateResult, error) {
+	// Collect first-party module paths for deterministic order.
+	var firstPartyPaths []string
+	for modPath := range f.Deps {
+		if verify.IsFirstParty(modPath) {
+			firstPartyPaths = append(firstPartyPaths, modPath)
+		}
+	}
+
+	if len(firstPartyPaths) == 0 {
+		return nil, fmt.Errorf("no first-party tomei dependencies found in module.cue")
+	}
+
+	slices.Sort(firstPartyPaths)
+
+	var results []UpdateResult
+	for _, modPath := range firstPartyPaths {
+		dep := f.Deps[modPath]
+		oldVersion := dep.Version
+		updated := oldVersion != latestVersion
+		if updated {
+			dep.Version = latestVersion
+		}
+		results = append(results, UpdateResult{
+			ModulePath: modPath,
+			OldVersion: oldVersion,
+			NewVersion: latestVersion,
+			Updated:    updated,
+		})
+	}
+
+	return results, nil
+}
+
+// FormatModuleFile formats a parsed module file back to CUE source bytes.
+func FormatModuleFile(f *modfile.File) ([]byte, error) {
+	data, err := modfile.Format(f)
+	if err != nil {
+		return nil, fmt.Errorf("failed to format module.cue: %w", err)
+	}
+	return data, nil
+}
+
+// WriteModuleFileAtomic atomically writes module.cue in the given cue.mod directory.
+// It writes to a temporary file first, then renames for atomicity.
+func WriteModuleFileAtomic(cueModDir string, data []byte) error {
+	moduleCuePath := filepath.Join(cueModDir, "module.cue")
+	tmpPath := moduleCuePath + ".tmp"
+
+	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write temporary module.cue: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, moduleCuePath); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to rename temporary module.cue: %w", err)
+	}
+
+	return nil
+}
+
+// HasVendoredModules returns true if vendored tomei modules exist under the directory.
+func HasVendoredModules(dir string) bool {
+	vendorPath := filepath.Join(dir, "cue.mod", "pkg", verify.FirstPartyPrefix)
+	info, err := os.Stat(vendorPath)
+	return err == nil && info.IsDir()
+}
+
+// AnyUpdated returns true if any dependency was actually updated.
+func AnyUpdated(results []UpdateResult) bool {
+	return slices.ContainsFunc(results, func(r UpdateResult) bool {
+		return r.Updated
+	})
+}

--- a/internal/cuemod/update_test.go
+++ b/internal/cuemod/update_test.go
@@ -1,0 +1,318 @@
+package cuemod
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"cuelang.org/go/mod/modfile"
+	"cuelang.org/go/mod/modregistrytest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/terassyi/tomei/internal/config"
+)
+
+func TestParseModuleFile(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T, dir string)
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "valid module file",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				cueModDir := filepath.Join(dir, "cue.mod")
+				require.NoError(t, os.MkdirAll(cueModDir, 0755))
+				data := []byte(`module: "manifests.local@v0"
+language: version: "v0.9.0"
+deps: {
+	"tomei.terassyi.net@v0": v: "v0.0.1"
+}
+`)
+				require.NoError(t, os.WriteFile(filepath.Join(cueModDir, "module.cue"), data, 0644))
+			},
+		},
+		{
+			name:      "file not found",
+			setup:     func(_ *testing.T, _ string) {},
+			wantErr:   true,
+			errSubstr: "module.cue not found",
+		},
+		{
+			name: "invalid CUE syntax",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				cueModDir := filepath.Join(dir, "cue.mod")
+				require.NoError(t, os.MkdirAll(cueModDir, 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(cueModDir, "module.cue"), []byte("invalid {{{"), 0644))
+			},
+			wantErr:   true,
+			errSubstr: "failed to parse",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			tt.setup(t, dir)
+
+			cueModDir := filepath.Join(dir, "cue.mod")
+			f, err := ParseModuleFile(cueModDir)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, f)
+			assert.Equal(t, "manifests.local@v0", f.Module)
+		})
+	}
+}
+
+func TestUpdateDeps(t *testing.T) {
+	t.Parallel()
+
+	parseTestModule := func(t *testing.T, version string) *modfile.File {
+		t.Helper()
+		data := []byte(`module: "manifests.local@v0"
+language: version: "v0.9.0"
+deps: {
+	"tomei.terassyi.net@v0": v: "` + version + `"
+}
+`)
+		f, err := modfile.Parse(data, "module.cue")
+		require.NoError(t, err)
+		return f
+	}
+
+	tests := []struct {
+		name          string
+		file          func(t *testing.T) *modfile.File
+		latestVersion string
+		wantResults   []UpdateResult
+		wantErr       bool
+		errSubstr     string
+	}{
+		{
+			name: "version updated",
+			file: func(t *testing.T) *modfile.File {
+				return parseTestModule(t, "v0.0.1")
+			},
+			latestVersion: "v0.0.3",
+			wantResults: []UpdateResult{
+				{
+					ModulePath: "tomei.terassyi.net@v0",
+					OldVersion: "v0.0.1",
+					NewVersion: "v0.0.3",
+					Updated:    true,
+				},
+			},
+		},
+		{
+			name: "already at latest",
+			file: func(t *testing.T) *modfile.File {
+				return parseTestModule(t, "v0.0.3")
+			},
+			latestVersion: "v0.0.3",
+			wantResults: []UpdateResult{
+				{
+					ModulePath: "tomei.terassyi.net@v0",
+					OldVersion: "v0.0.3",
+					NewVersion: "v0.0.3",
+					Updated:    false,
+				},
+			},
+		},
+		{
+			name: "no first-party deps",
+			file: func(t *testing.T) *modfile.File {
+				t.Helper()
+				data := []byte(`module: "manifests.local@v0"
+language: version: "v0.9.0"
+`)
+				f, err := modfile.Parse(data, "module.cue")
+				require.NoError(t, err)
+				return f
+			},
+			latestVersion: "v0.0.3",
+			wantErr:       true,
+			errSubstr:     "no first-party",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			f := tt.file(t)
+			results, err := UpdateDeps(f, tt.latestVersion)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantResults, results)
+		})
+	}
+}
+
+func TestFormatModuleFile(t *testing.T) {
+	t.Parallel()
+
+	// Parse → update → format round trip
+	data := []byte(`module: "manifests.local@v0"
+language: version: "v0.9.0"
+deps: {
+	"tomei.terassyi.net@v0": v: "v0.0.1"
+}
+`)
+	f, err := modfile.Parse(data, "module.cue")
+	require.NoError(t, err)
+
+	// Update the dep
+	f.Deps["tomei.terassyi.net@v0"].Version = "v0.0.5"
+
+	out, err := FormatModuleFile(f)
+	require.NoError(t, err)
+	assert.Contains(t, string(out), `"v0.0.5"`)
+	assert.NotContains(t, string(out), `"v0.0.1"`)
+}
+
+func TestWriteModuleFileAtomic(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, dir string)
+	}{
+		{
+			name: "new file",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				require.NoError(t, os.MkdirAll(filepath.Join(dir, "cue.mod"), 0755))
+			},
+		},
+		{
+			name: "overwrite existing",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				cueModDir := filepath.Join(dir, "cue.mod")
+				require.NoError(t, os.MkdirAll(cueModDir, 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(cueModDir, "module.cue"), []byte("old"), 0644))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			tt.setup(t, dir)
+
+			cueModDir := filepath.Join(dir, "cue.mod")
+			content := []byte("new content")
+			err := WriteModuleFileAtomic(cueModDir, content)
+			require.NoError(t, err)
+
+			got, err := os.ReadFile(filepath.Join(cueModDir, "module.cue"))
+			require.NoError(t, err)
+			assert.Equal(t, content, got)
+		})
+	}
+}
+
+func TestHasVendoredModules(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, dir string)
+		want  bool
+	}{
+		{
+			name: "vendor exists",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				vendorDir := filepath.Join(dir, "cue.mod", "pkg", "tomei.terassyi.net")
+				require.NoError(t, os.MkdirAll(vendorDir, 0755))
+			},
+			want: true,
+		},
+		{
+			name:  "no vendor",
+			setup: func(_ *testing.T, _ string) {},
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			tt.setup(t, dir)
+
+			got := HasVendoredModules(dir)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestUpdateIntegration(t *testing.T) {
+	t.Run("full update flow", func(t *testing.T) {
+		reg, err := modregistrytest.New(mergeMockModuleFS("v0.0.1", "v0.0.2", "v0.0.3"), "")
+		require.NoError(t, err)
+		defer reg.Close()
+
+		t.Setenv(config.EnvCUERegistry, reg.Host()+"+insecure")
+
+		// Set up a module.cue with v0.0.1
+		dir := t.TempDir()
+		cueModDir := filepath.Join(dir, "cue.mod")
+		require.NoError(t, os.MkdirAll(cueModDir, 0755))
+
+		initial := []byte(`module: "manifests.local@v0"
+language: version: "v0.9.0"
+deps: {
+	"tomei.terassyi.net@v0": v: "v0.0.1"
+}
+`)
+		require.NoError(t, os.WriteFile(filepath.Join(cueModDir, "module.cue"), initial, 0644))
+
+		// Parse
+		f, err := ParseModuleFile(cueModDir)
+		require.NoError(t, err)
+
+		// Resolve latest
+		latestVersion, err := ResolveLatestVersion(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "v0.0.3", latestVersion)
+
+		// Update deps
+		results, err := UpdateDeps(f, latestVersion)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.True(t, results[0].Updated)
+		assert.Equal(t, "v0.0.1", results[0].OldVersion)
+		assert.Equal(t, "v0.0.3", results[0].NewVersion)
+
+		// Format and write
+		data, err := FormatModuleFile(f)
+		require.NoError(t, err)
+		err = WriteModuleFileAtomic(cueModDir, data)
+		require.NoError(t, err)
+
+		// Verify the written file
+		written, err := os.ReadFile(filepath.Join(cueModDir, "module.cue"))
+		require.NoError(t, err)
+		assert.Contains(t, string(written), `"v0.0.3"`)
+		assert.NotContains(t, string(written), `"v0.0.1"`)
+	})
+}

--- a/internal/verify/deps.go
+++ b/internal/verify/deps.go
@@ -10,10 +10,9 @@ import (
 	"cuelang.org/go/mod/module"
 )
 
-// ExtractFirstPartyDeps reads cue.mod/module.cue from the given cue.mod directory
-// and returns the list of first-party (tomei.terassyi.net) module dependencies.
-// Returns nil (no error) if the directory does not exist.
-func ExtractFirstPartyDeps(cueModDir string) ([]module.Version, error) {
+// ParseModuleFile reads and parses the cue.mod/module.cue file from the given cue.mod directory.
+// Returns (nil, nil) if the file does not exist.
+func ParseModuleFile(cueModDir string) (*modfile.File, error) {
 	moduleCuePath := filepath.Join(cueModDir, "module.cue")
 
 	data, err := os.ReadFile(moduleCuePath)
@@ -27,6 +26,21 @@ func ExtractFirstPartyDeps(cueModDir string) ([]module.Version, error) {
 	f, err := modfile.Parse(data, moduleCuePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse module.cue: %w", err)
+	}
+
+	return f, nil
+}
+
+// ExtractFirstPartyDeps reads cue.mod/module.cue from the given cue.mod directory
+// and returns the list of first-party (tomei.terassyi.net) module dependencies.
+// Returns nil (no error) if the directory does not exist.
+func ExtractFirstPartyDeps(cueModDir string) ([]module.Version, error) {
+	f, err := ParseModuleFile(cueModDir)
+	if err != nil {
+		return nil, err
+	}
+	if f == nil {
+		return nil, nil
 	}
 
 	var deps []module.Version

--- a/internal/verify/deps_test.go
+++ b/internal/verify/deps_test.go
@@ -10,6 +10,71 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestParseModuleFile(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T, dir string)
+		wantNil   bool
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "valid module file",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				require.NoError(t, os.MkdirAll(dir, 0755))
+				data := []byte("module: \"manifests.local@v0\"\nlanguage: version: \"v0.9.0\"\n")
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "module.cue"), data, 0644))
+			},
+		},
+		{
+			name:    "file not found returns nil",
+			setup:   func(_ *testing.T, _ string) {},
+			wantNil: true,
+		},
+		{
+			name: "invalid CUE syntax",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				require.NoError(t, os.MkdirAll(dir, 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "module.cue"), []byte("invalid {{{"), 0644))
+			},
+			wantErr:   true,
+			errSubstr: "failed to parse",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			cueModDir := filepath.Join(dir, "cue.mod")
+			tt.setup(t, cueModDir)
+
+			f, err := ParseModuleFile(cueModDir)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tt.wantNil {
+				assert.Nil(t, f)
+				return
+			}
+
+			require.NotNil(t, f)
+			assert.Equal(t, "manifests.local@v0", f.Module)
+		})
+	}
+}
+
 func TestExtractFirstPartyDeps(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Add a new subcommand that updates first-party tomei module dependencies
in cue.mod/module.cue to the latest version from the OCI registry,
eliminating the need for manual version edits or destructive re-init.

- Core logic: ParseModuleFile, UpdateDeps, FormatModuleFile,
  WriteModuleFileAtomic, HasVendoredModules in internal/cuemod/
- ParseModuleFile delegates to verify.ParseModuleFile (deduplication)
- Cobra command with --dry-run flag
- Docs: usage.md, cue-ecosystem.md, README.md updated
- Table-driven unit tests + mock registry integration test

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: terashima <iscale821@gmail.com>
