### PR TITLE
feat(aqua): support title, tolower, toupper template functions

### DIFF
--- a/internal/registry/aqua/template.go
+++ b/internal/registry/aqua/template.go
@@ -5,6 +5,8 @@ import (
 	"bytes"
 	"strings"
 	"text/template"
+	"unicode"
+	"unicode/utf8"
 )
 
 // TemplateVars holds variables for rendering asset name templates.
@@ -18,6 +20,7 @@ type TemplateVars struct {
 }
 
 // templateFuncs defines custom functions available in templates.
+// These are compatible with aqua's Sprig-based template engine.
 var templateFuncs = template.FuncMap{
 	// trimV removes the "v" prefix from a version string.
 	// Example: {{trimV .Version}} with "v2.86.0" returns "2.86.0"
@@ -32,10 +35,30 @@ var templateFuncs = template.FuncMap{
 	// trimSuffix removes a suffix from a string.
 	// Example: {{trimSuffix .Format ".gz"}} with "tar.gz" returns "tar"
 	"trimSuffix": strings.TrimSuffix,
+
+	// title uppercases the first character of a string.
+	// Used by aqua-registry (e.g., goreleaser, porter): {{title .OS}} "linux" → "Linux".
+	// Note: unlike Sprig's title (strings.Title), this only uppercases the first rune,
+	// not each word. Sufficient for aqua-registry where inputs are single-word OS names.
+	"title": func(s string) string {
+		r, size := utf8.DecodeRuneInString(s)
+		if r == utf8.RuneError {
+			return s
+		}
+		return string(unicode.ToUpper(r)) + s[size:]
+	},
+
+	// tolower converts a string to lowercase.
+	// Example: {{tolower .OS}} with "Darwin" returns "darwin"
+	"tolower": strings.ToLower,
+
+	// toupper converts a string to uppercase.
+	// Example: {{toupper .OS}} with "linux" returns "LINUX"
+	"toupper": strings.ToUpper,
 }
 
 // RenderTemplate renders a template string with the given variables.
-// It supports custom functions: trimV, trimPrefix, trimSuffix.
+// It supports custom functions: trimV, trimPrefix, trimSuffix, title, tolower, toupper.
 func RenderTemplate(tmpl string, vars TemplateVars) (string, error) {
 	t, err := template.New("asset").Funcs(templateFuncs).Parse(tmpl)
 	if err != nil {

--- a/internal/registry/aqua/template_test.go
+++ b/internal/registry/aqua/template_test.go
@@ -134,6 +134,76 @@ func TestRenderTemplate(t *testing.T) {
 			want: "ripgrep-14.0.0-x86_64-unknown-linux-musl.tar.gz",
 		},
 		{
+			name:     "title function - goreleaser pattern",
+			template: "goreleaser_{{title .OS}}_{{.Arch}}.{{.Format}}",
+			vars: TemplateVars{
+				OS:     "linux",
+				Arch:   "x86_64",
+				Format: "tar.gz",
+			},
+			want: "goreleaser_Linux_x86_64.tar.gz",
+		},
+		{
+			name:     "title function - darwin",
+			template: "{{title .OS}}",
+			vars:     TemplateVars{OS: "darwin"},
+			want:     "Darwin",
+		},
+		{
+			name:     "title function - empty string",
+			template: "{{title .OS}}",
+			vars:     TemplateVars{OS: ""},
+			want:     "",
+		},
+		{
+			name:     "title function - single character",
+			template: "{{title .OS}}",
+			vars:     TemplateVars{OS: "a"},
+			want:     "A",
+		},
+		{
+			name:     "title function - already capitalized",
+			template: "{{title .OS}}",
+			vars:     TemplateVars{OS: "Linux"},
+			want:     "Linux",
+		},
+		{
+			name:     "title function - all uppercase",
+			template: "{{title .OS}}",
+			vars:     TemplateVars{OS: "LINUX"},
+			want:     "LINUX",
+		},
+		{
+			// Note: unlike Sprig's title (strings.Title) which uppercases each word,
+			// our title only uppercases the first rune. This is sufficient for
+			// aqua-registry where inputs are single-word OS names.
+			name:     "title function - multi-word differs from Sprig",
+			template: "{{title .OS}}",
+			vars:     TemplateVars{OS: "hello world"},
+			want:     "Hello world",
+		},
+		{
+			name:     "tolower function",
+			template: "{{tolower .OS}}",
+			vars:     TemplateVars{OS: "Darwin"},
+			want:     "darwin",
+		},
+		{
+			name:     "toupper function",
+			template: "{{toupper .OS}}",
+			vars:     TemplateVars{OS: "linux"},
+			want:     "LINUX",
+		},
+		{
+			name:     "title with trimV combined - porter pattern",
+			template: "porter_{{.Version}}_{{title .OS}}_x86_64.zip",
+			vars: TemplateVars{
+				Version: "v1.0.0",
+				OS:      "linux",
+			},
+			want: "porter_v1.0.0_Linux_x86_64.zip",
+		},
+		{
 			name:     "invalid template syntax",
 			template: "{{.Invalid",
 			vars:     TemplateVars{},


### PR DESCRIPTION
Add Sprig-compatible template functions to resolve aqua-registry
packages that use {{title .OS}} (e.g., goreleaser, porter).

- title: uppercases first rune (UTF-8 safe via unicode/utf8)
- tolower/toupper: delegates to strings.ToLower/ToUpper

Closes #111

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: terashima <iscale821@gmail.com>
