### PR TITLE
chore: bump CUE module dependency to v0.1.7

### DIFF
--- a/demo/manifests/cue.mod/module.cue
+++ b/demo/manifests/cue.mod/module.cue
@@ -1,5 +1,5 @@
 module: "manifests.local@v0"
 language: version: "v0.9.0"
 deps: {
-	"tomei.terassyi.net@v0": v: "v0.1.6"
+	"tomei.terassyi.net@v0": v: "v0.1.7"
 }

--- a/examples/real-world/cue.mod/module.cue
+++ b/examples/real-world/cue.mod/module.cue
@@ -4,6 +4,6 @@ language: {
 }
 deps: {
 	"tomei.terassyi.net@v0": {
-		v: "v0.1.6"
+		v: "v0.1.7"
 	}
 }


### PR DESCRIPTION
Update tomei.terassyi.net dep to v0.1.7 (adds binDir field to
#Installer schema) in demo/manifests and examples/real-world.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: terashima <iscale821@gmail.com>
