### PR TITLE
fix(release): use github-native changelog to avoid CUE tag interference

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,13 +28,9 @@ checksum:
   algorithm: sha256
 
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
-      - "^ci:"
-      - "^chore:"
+  # Use GitHub's native release notes generation to avoid previous_tag
+  # misdetection caused by CUE module tags (tomei-cue-v*).
+  use: github-native
 
 release:
   github:


### PR DESCRIPTION
goreleaser was picking up CUE module tags (tomei-cue-v*) as previous_tag,
resulting in an empty changelog. Switch to github-native release notes
generation which correctly resolves previous tags by version prefix.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: terashima <iscale821@gmail.com>
