### PR TITLE
fix(release): migrate CUE module tag naming from tomei-cue-v* to cuemodule/v*

### DIFF
--- a/.github/workflows/publish-module.yaml
+++ b/.github/workflows/publish-module.yaml
@@ -3,7 +3,7 @@ name: Publish CUE Module
 on:
   push:
     tags:
-      - "tomei-cue-v*"
+      - "cuemodule/v*"
   workflow_dispatch:
 
 permissions:
@@ -22,14 +22,14 @@ jobs:
         id: version
         uses: ./.github/actions/determine-version
         with:
-          tag-prefix: "tomei-cue-"
+          tag-prefix: "cuemodule/"
 
       - name: Verify git tag exists
         if: github.event_name == 'workflow_dispatch'
         uses: ./.github/actions/verify-tag
         with:
           version: ${{ steps.version.outputs.version }}
-          tag-prefix: "tomei-cue-"
+          tag-prefix: "cuemodule/"
 
       - name: Validate CUE module
         uses: ./.github/actions/cue-validate

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,9 +28,25 @@ checksum:
   algorithm: sha256
 
 changelog:
-  # Use GitHub's native release notes generation to avoid previous_tag
-  # misdetection caused by CUE module tags (tomei-cue-v*).
-  use: github-native
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+      - "^chore:"
+
+git:
+  ignore_tags:
+    - tomei-cue-v0.0.1
+    - tomei-cue-v0.1.0
+    - tomei-cue-v0.1.1
+    - tomei-cue-v0.1.2
+    - tomei-cue-v0.1.3
+    - tomei-cue-v0.1.4
+    - tomei-cue-v0.1.5
+    - tomei-cue-v0.1.6
+    - tomei-cue-v0.1.7
 
 release:
   github:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -328,7 +328,7 @@ The `tomei` binary version follows semver and is tracked via `v*` git tags (e.g.
 
 ### CUE module versioning
 
-The CUE module (`tomei.terassyi.net@v0`) version is **independent of the binary version**. Module versions follow semver and are tracked via `tomei-cue-v*` git tags (e.g., `tomei-cue-v0.0.1`).
+The CUE module (`tomei.terassyi.net@v0`) version is **independent of the binary version**. Module versions follow semver and are tracked via `cuemodule/v*` git tags (e.g., `cuemodule/v0.0.1`).
 
 This separation allows schema and presets to evolve on their own cadence without forcing a tomei binary release. While in `@v0`, breaking changes to the module are permitted.
 
@@ -360,6 +360,6 @@ See [Releasing](releasing.md) for the release process.
 
 ### publish-module.yaml
 
-Triggered on `tomei-cue-v*` tag push (dry run) or manual `workflow_dispatch` (publish).
+Triggered on `cuemodule/v*` tag push (dry run) or manual `workflow_dispatch` (publish).
 
 See [Module Publishing](module-publishing.md) for details.

--- a/docs/module-publishing.md
+++ b/docs/module-publishing.md
@@ -4,11 +4,11 @@ The CUE module `tomei.terassyi.net@v0` is published to `ghcr.io/terassyi` as an 
 
 ## Versioning
 
-The module version is **independent of the tomei binary version**. Module versions follow semver and are tracked via git tags with the `tomei-cue-` prefix:
+The module version is **independent of the tomei binary version**. Module versions follow semver and are tracked via git tags with the `cuemodule/` prefix (following Go multi-module convention, matching the `cuemodule/` directory):
 
 ```
-tomei-cue-v0.0.1   # CUE module version
-v0.1.0              # tomei binary version (separate)
+cuemodule/v0.0.1   # CUE module version
+v0.1.0             # tomei binary version (separate)
 ```
 
 While in `@v0`, breaking changes are permitted.
@@ -31,18 +31,18 @@ This pins the exact version for reproducibility. To update to a newer module ver
 
 | Trigger | Action |
 |---------|--------|
-| `git push` tag `tomei-cue-v*` | Dry run only (`cue fmt --check` + `cue vet`) |
-| `workflow_dispatch` on tag `tomei-cue-v*` | Verify tag exists, then publish to ghcr.io |
+| `git push` tag `cuemodule/v*` | Dry run only (`cue fmt --check` + `cue vet`) |
+| `workflow_dispatch` on tag `cuemodule/v*` | Verify tag exists, then publish to ghcr.io |
 
 ### Steps
 
 1. Create and push a tag:
    ```bash
-   git tag tomei-cue-v0.0.1
-   git push origin tomei-cue-v0.0.1
+   git tag cuemodule/v0.0.1
+   git push origin cuemodule/v0.0.1
    ```
 2. CI runs dry-run validation automatically (formatting + schema validation)
-3. Trigger `workflow_dispatch` on `Publish CUE Module` workflow, selecting the `tomei-cue-v0.0.1` tag
+3. Trigger `workflow_dispatch` on `Publish CUE Module` workflow, selecting the `cuemodule/v0.0.1` tag
 
 ### Validation
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -64,8 +64,8 @@ When releasing both the binary and the CUE module, tag the CUE module first so t
 
 ```bash
 # 1. CUE module
-git tag tomei-cue-v0.1.0
-git push origin tomei-cue-v0.1.0
+git tag cuemodule/v0.1.0
+git push origin cuemodule/v0.1.0
 # Then trigger workflow_dispatch on "Publish CUE Module" workflow
 
 # 2. Binary


### PR DESCRIPTION
The tomei-cue-v* tags were picked up by goreleaser as previous_tag,
causing empty changelogs. Rename to cuemodule/v* (Go multi-module
convention) so they no longer match goreleaser's v* glob. Revert
changelog strategy from github-native back to git with filters, and
add ignore_tags for the 9 legacy tomei-cue-v* tags.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: terashima <iscale821@gmail.com>
