### PR TITLE
fix(release): use GORELEASER_PREVIOUS_TAG to avoid CUE module tag interference

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,9 +63,24 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Compute previous release tag
+        id: prev-tag
+        run: |
+          CURRENT_TAG="${{ github.ref_name }}"
+          PREV_TAG=$(git tag --list 'v*' --sort=v:refname \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | awk -v current="$CURRENT_TAG" '$0 == current {print prev; exit} {prev=$0}')
+          if [ -n "$PREV_TAG" ]; then
+            echo "previous_tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
+            echo "Computed previous release tag: $PREV_TAG"
+          else
+            echo "No previous release tag found (first release or non-release tag)"
+          fi
+
       - uses: goreleaser/goreleaser-action@v7
         with:
           version: latest
           args: ${{ (github.event_name == 'push' || inputs.dry-run) && 'release --snapshot --clean' || 'release --clean' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_PREVIOUS_TAG: ${{ steps.prev-tag.outputs.previous_tag }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,18 +36,6 @@ changelog:
       - "^ci:"
       - "^chore:"
 
-git:
-  ignore_tags:
-    - tomei-cue-v0.0.1
-    - tomei-cue-v0.1.0
-    - tomei-cue-v0.1.1
-    - tomei-cue-v0.1.2
-    - tomei-cue-v0.1.3
-    - tomei-cue-v0.1.4
-    - tomei-cue-v0.1.5
-    - tomei-cue-v0.1.6
-    - tomei-cue-v0.1.7
-
 release:
   github:
     owner: terassyi


### PR DESCRIPTION
goreleaser auto-detects previous_tag from all git tags, which picks up
CUE module tags (cuemodule/v*) instead of the actual previous release.
Compute previous release tag explicitly from v* tags with semver filter
and pass it via GORELEASER_PREVIOUS_TAG environment variable.

Remove git.ignore_tags from .goreleaser.yaml as it is no longer needed
when previous_tag is explicitly specified.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: terashima <iscale821@gmail.com>
