### PR TITLE
feat(cue): add `tomei cue presets` command to list presets from OCI registry

### DIFF
--- a/cmd/tomei/cue/cue.go
+++ b/cmd/tomei/cue/cue.go
@@ -14,6 +14,7 @@ Subcommands:
   scaffold   Generate a CUE manifest scaffold for a resource kind
   eval       Evaluate CUE manifests with tomei configuration
   export     Export CUE manifests as JSON with tomei configuration
+  presets    List available preset manifests from the OCI registry
 
 Writing manifests:
   Manifests are CUE files in "package tomei". Each resource has apiVersion,
@@ -77,4 +78,5 @@ func init() {
 	Cmd.AddCommand(scaffoldCmd)
 	Cmd.AddCommand(evalCmd)
 	Cmd.AddCommand(exportCmd)
+	Cmd.AddCommand(presetsCmd)
 }

--- a/cmd/tomei/cue/presets.go
+++ b/cmd/tomei/cue/presets.go
@@ -121,7 +121,9 @@ func runPresets(cmd *cobra.Command, args []string) error {
 		for _, p := range presets {
 			fmt.Fprintf(w, "%s\t%s\t%s\n", p.Name, p.ImportPath, strings.Join(p.Definitions, ", "))
 		}
-		w.Flush()
+		if err := w.Flush(); err != nil {
+			return fmt.Errorf("failed to flush output: %w", err)
+		}
 
 	case "json":
 		enc := json.NewEncoder(out)

--- a/cmd/tomei/cue/presets.go
+++ b/cmd/tomei/cue/presets.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/terassyi/tomei/internal/config"
 	"github.com/terassyi/tomei/internal/cuemod"
 )
 
@@ -31,7 +32,9 @@ Use --definition (-d) to further narrow to a single definition.
 Output formats:
   table  Tabular summary with preset name, import path, and definitions (default)
   json   JSON array of preset objects
-  cue    Raw CUE source of each preset, separated by "---"`,
+  cue    Raw CUE source of each preset, separated by "---"
+         When --definition is used, only the definition snippet is shown
+         (without the package clause or imports).`,
 	Args:              cobra.MaximumNArgs(1),
 	ValidArgsFunction: completePresetNames,
 	RunE:              runPresets,
@@ -115,7 +118,7 @@ func runPresets(cmd *cobra.Command, args []string) error {
 
 	switch presetsOutput {
 	case "table":
-		fmt.Fprintf(out, "Presets from tomei.terassyi.net@v0 (%s)\n\n", version)
+		fmt.Fprintf(out, "Presets from %s (%s)\n\n", config.TomeiModulePath, version)
 		w := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
 		fmt.Fprintln(w, "PRESET\tIMPORT_PATH\tDEFINITIONS")
 		for _, p := range presets {

--- a/cmd/tomei/cue/presets.go
+++ b/cmd/tomei/cue/presets.go
@@ -1,0 +1,91 @@
+package cue
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/terassyi/tomei/internal/cuemod"
+)
+
+var (
+	presetsVersion    string
+	presetsOutput     string
+	presetsPreRelease bool
+)
+
+var presetsCmd = &cobra.Command{
+	Use:   "presets",
+	Short: "List available preset manifests from the OCI registry",
+	Long: `Fetches the tomei CUE module from the OCI registry and lists available
+preset packages with their exported definitions.
+
+Output formats:
+  table  Tabular summary with preset name, import path, and definitions (default)
+  json   JSON array of preset objects
+  cue    Raw CUE source of each preset, separated by "---"`,
+	Args: cobra.NoArgs,
+	RunE: runPresets,
+}
+
+func init() {
+	presetsCmd.Flags().StringVar(&presetsVersion, "version", "", "Module version to inspect (default: latest)")
+	presetsCmd.Flags().StringVarP(&presetsOutput, "output", "o", "table", "Output format: table, cue, json")
+	presetsCmd.Flags().BoolVar(&presetsPreRelease, "pre", false, "Include pre-release versions")
+
+	_ = presetsCmd.RegisterFlagCompletionFunc("output", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"table", "cue", "json"}, cobra.ShellCompDirectiveNoFileComp
+	})
+}
+
+func runPresets(cmd *cobra.Command, _ []string) error {
+	switch presetsOutput {
+	case "table", "cue", "json":
+	default:
+		return fmt.Errorf("unsupported output format %q (must be table, cue, or json)", presetsOutput)
+	}
+
+	var opts []cuemod.ResolveOption
+	if presetsPreRelease {
+		opts = append(opts, cuemod.WithPreRelease())
+	}
+
+	presets, version, err := cuemod.FetchPresets(cmd.Context(), presetsVersion, opts...)
+	if err != nil {
+		return err
+	}
+
+	out := cmd.OutOrStdout()
+
+	switch presetsOutput {
+	case "table":
+		fmt.Fprintf(out, "Presets from tomei.terassyi.net@v0 (%s)\n\n", version)
+		w := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
+		fmt.Fprintln(w, "PRESET\tIMPORT_PATH\tDEFINITIONS")
+		for _, p := range presets {
+			fmt.Fprintf(w, "%s\t%s\t%s\n", p.Name, p.ImportPath, strings.Join(p.Definitions, ", "))
+		}
+		w.Flush()
+
+	case "json":
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(presets); err != nil {
+			return fmt.Errorf("failed to encode JSON: %w", err)
+		}
+
+	case "cue":
+		for i, p := range presets {
+			if i > 0 {
+				fmt.Fprintln(out, "---")
+			}
+			fmt.Fprintf(out, "// preset: %s (%s)\n", p.Name, p.ImportPath)
+			fmt.Fprintln(out, p.Source)
+		}
+	}
+
+	return nil
+}

--- a/cmd/tomei/cue/presets.go
+++ b/cmd/tomei/cue/presets.go
@@ -3,6 +3,7 @@ package cue
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"text/tabwriter"
 
@@ -15,37 +16,47 @@ var (
 	presetsVersion    string
 	presetsOutput     string
 	presetsPreRelease bool
+	presetsDefinition string
 )
 
 var presetsCmd = &cobra.Command{
-	Use:   "presets",
+	Use:   "presets [name]",
 	Short: "List available preset manifests from the OCI registry",
 	Long: `Fetches the tomei CUE module from the OCI registry and lists available
 preset packages with their exported definitions.
+
+When a preset name is given, only that preset is shown.
+Use --definition (-d) to further narrow to a single definition.
 
 Output formats:
   table  Tabular summary with preset name, import path, and definitions (default)
   json   JSON array of preset objects
   cue    Raw CUE source of each preset, separated by "---"`,
-	Args: cobra.NoArgs,
-	RunE: runPresets,
+	Args:              cobra.MaximumNArgs(1),
+	ValidArgsFunction: completePresetNames,
+	RunE:              runPresets,
 }
 
 func init() {
 	presetsCmd.Flags().StringVar(&presetsVersion, "version", "", "Module version to inspect (default: latest)")
 	presetsCmd.Flags().StringVarP(&presetsOutput, "output", "o", "table", "Output format: table, cue, json")
 	presetsCmd.Flags().BoolVar(&presetsPreRelease, "pre", false, "Include pre-release versions")
+	presetsCmd.Flags().StringVarP(&presetsDefinition, "definition", "d", "", "Filter by definition name (e.g. GoRuntime or #GoRuntime)")
 
 	_ = presetsCmd.RegisterFlagCompletionFunc("output", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"table", "cue", "json"}, cobra.ShellCompDirectiveNoFileComp
 	})
 }
 
-func runPresets(cmd *cobra.Command, _ []string) error {
+func runPresets(cmd *cobra.Command, args []string) error {
 	switch presetsOutput {
 	case "table", "cue", "json":
 	default:
 		return fmt.Errorf("unsupported output format %q (must be table, cue, or json)", presetsOutput)
+	}
+
+	if presetsDefinition != "" && len(args) == 0 {
+		return fmt.Errorf("--definition requires a preset name argument (e.g., tomei cue presets go -d GoRuntime)")
 	}
 
 	var opts []cuemod.ResolveOption
@@ -56,6 +67,48 @@ func runPresets(cmd *cobra.Command, _ []string) error {
 	presets, version, err := cuemod.FetchPresets(cmd.Context(), presetsVersion, opts...)
 	if err != nil {
 		return err
+	}
+
+	// Filter by preset name if specified.
+	if len(args) > 0 {
+		name := args[0]
+		var filtered []cuemod.PresetInfo
+		for _, p := range presets {
+			if p.Name == name {
+				filtered = append(filtered, p)
+			}
+		}
+		if len(filtered) == 0 {
+			available := make([]string, len(presets))
+			for i, p := range presets {
+				available[i] = p.Name
+			}
+			return fmt.Errorf("preset %q not found (available: %s)", name, strings.Join(available, ", "))
+		}
+		presets = filtered
+	}
+
+	// Normalize definition name to include "#" prefix.
+	defName := presetsDefinition
+	if defName != "" && !strings.HasPrefix(defName, "#") {
+		defName = "#" + defName
+	}
+
+	// Filter by definition name if specified.
+	if defName != "" {
+		p := presets[0] // guaranteed single preset by name filter above
+		if !slices.Contains(p.Definitions, defName) {
+			return fmt.Errorf("definition %s not found in preset %q (available: %s)",
+				defName, p.Name, strings.Join(p.Definitions, ", "))
+		}
+		p.Definitions = []string{defName}
+		// Narrow source to the requested definition block.
+		defSource, err := cuemod.ExtractDefinition(p.Source, defName)
+		if err != nil {
+			return fmt.Errorf("failed to extract definition %s from preset %q: %w", defName, p.Name, err)
+		}
+		p.Source = defSource
+		presets = []cuemod.PresetInfo{p}
 	}
 
 	out := cmd.OutOrStdout()
@@ -82,10 +135,18 @@ func runPresets(cmd *cobra.Command, _ []string) error {
 			if i > 0 {
 				fmt.Fprintln(out, "---")
 			}
-			fmt.Fprintf(out, "// preset: %s (%s)\n", p.Name, p.ImportPath)
+			if defName != "" {
+				fmt.Fprintf(out, "// definition: %s from %s (%s)\n", defName, p.Name, p.ImportPath)
+			} else {
+				fmt.Fprintf(out, "// preset: %s (%s)\n", p.Name, p.ImportPath)
+			}
 			fmt.Fprintln(out, p.Source)
 		}
 	}
 
 	return nil
+}
+
+func completePresetNames(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return cuemod.KnownPresetNames(), cobra.ShellCompDirectiveNoFileComp
 }

--- a/internal/cuemod/init.go
+++ b/internal/cuemod/init.go
@@ -12,9 +12,13 @@ import (
 
 	"cuelang.org/go/mod/modconfig"
 	"cuelang.org/go/mod/modregistry"
+	"cuelang.org/go/mod/module"
 	"github.com/terassyi/tomei/internal/config"
 	"golang.org/x/mod/semver"
 )
+
+// ErrRegistryDisabled is returned when CUE_REGISTRY is set to "none".
+var ErrRegistryDisabled = fmt.Errorf("registry access disabled: CUE_REGISTRY is set to %q", "none")
 
 //go:embed templates/module.cue.tmpl
 var moduleTmpl string
@@ -70,16 +74,13 @@ func WithPreRelease() ResolveOption {
 	}
 }
 
-// ResolveLatestVersion queries the OCI registry for the latest published
-// version of the tomei module (tomei.terassyi.net).
-// By default, pre-release versions are excluded. Use WithPreRelease() to include them.
-func ResolveLatestVersion(ctx context.Context, opts ...ResolveOption) (string, error) {
-	var cfg resolveConfig
-	for _, o := range opts {
-		o(&cfg)
-	}
-
+// newRegistryClient creates a modregistry.Client configured from CUE_REGISTRY.
+// Returns ErrRegistryDisabled when CUE_REGISTRY is "none" (vendor mode).
+func newRegistryClient() (*modregistry.Client, error) {
 	cueRegistry := os.Getenv(config.EnvCUERegistry)
+	if cueRegistry == "none" {
+		return nil, ErrRegistryDisabled
+	}
 	if cueRegistry == "" {
 		cueRegistry = config.DefaultCUERegistry
 	}
@@ -88,10 +89,35 @@ func ResolveLatestVersion(ctx context.Context, opts ...ResolveOption) (string, e
 		CUERegistry: cueRegistry,
 	})
 	if err != nil {
-		return "", fmt.Errorf("failed to create registry resolver: %w", err)
+		return nil, fmt.Errorf("failed to create registry resolver: %w", err)
 	}
 
-	client := modregistry.NewClientWithResolver(resolver)
+	return modregistry.NewClientWithResolver(resolver), nil
+}
+
+// newModuleVersion creates a module.Version for the tomei module with the given version string.
+func newModuleVersion(version string) (module.Version, error) {
+	return module.NewVersion(config.TomeiModulePath, version)
+}
+
+// ResolveLatestVersion queries the OCI registry for the latest published
+// version of the tomei module (tomei.terassyi.net).
+// By default, pre-release versions are excluded. Use WithPreRelease() to include them.
+func ResolveLatestVersion(ctx context.Context, opts ...ResolveOption) (string, error) {
+	client, err := newRegistryClient()
+	if err != nil {
+		return "", err
+	}
+	return resolveLatestVersionWithClient(ctx, client, opts...)
+}
+
+// resolveLatestVersionWithClient is the shared implementation that accepts a pre-built client.
+func resolveLatestVersionWithClient(ctx context.Context, client *modregistry.Client, opts ...ResolveOption) (string, error) {
+	var cfg resolveConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
+
 	versions, err := client.ModuleVersions(ctx, "tomei.terassyi.net")
 	if err != nil {
 		return "", fmt.Errorf("failed to query module versions: %w", err)

--- a/internal/cuemod/presets.go
+++ b/internal/cuemod/presets.go
@@ -34,10 +34,91 @@ type PresetInfo struct {
 	Source      string   `json:"source,omitempty"`
 }
 
+// KnownPresetNames returns the list of well-known preset package names.
+// Used for shell completion; the canonical source is the OCI registry,
+// but a network fetch at completion time is too slow.
+func KnownPresetNames() []string {
+	return []string{"aqua", "brew", "bun", "deno", "go", "node", "python", "rust", "zig"}
+}
+
 // definitionRe matches top-level CUE definitions (e.g. "#GoRuntime:").
 // Only #-prefixed identifiers at column 0 are matched; hidden definitions (_#Name)
 // and indented definitions are intentionally excluded.
 var definitionRe = regexp.MustCompile(`(?m)^(#\w+):`)
+
+// ExtractDefinition extracts a single top-level definition block from CUE source.
+// defName should include the "#" prefix (e.g. "#GoRuntime").
+// Returns the full definition text including the name and braces.
+//
+// The parser is aware of line comments (//) and quoted strings so that braces
+// inside comments or string literals do not affect depth tracking.
+func ExtractDefinition(source, defName string) (string, error) {
+	lines := strings.Split(source, "\n")
+	prefix := defName + ":"
+
+	startIdx := -1
+	for i, line := range lines {
+		if strings.HasPrefix(line, prefix) {
+			startIdx = i
+			break
+		}
+	}
+	if startIdx < 0 {
+		return "", fmt.Errorf("definition %s not found", defName)
+	}
+
+	// Count braces to find the end of the definition block.
+	// Skip braces inside // comments and "..." string literals.
+	depth := 0
+	endIdx := startIdx
+	for i := startIdx; i < len(lines); i++ {
+		countBraces(lines[i], &depth)
+		endIdx = i
+		if depth == 0 && i > startIdx {
+			break
+		}
+		// Single-line definition without braces (e.g. "#Foo: string").
+		if depth == 0 && i == startIdx && !strings.Contains(lines[i], "{") {
+			break
+		}
+	}
+
+	if depth != 0 {
+		return "", fmt.Errorf("unbalanced braces in definition %s (depth %d)", defName, depth)
+	}
+
+	return strings.Join(lines[startIdx:endIdx+1], "\n"), nil
+}
+
+// countBraces counts unquoted, uncommented braces in a single line,
+// updating *depth in place.
+func countBraces(line string, depth *int) {
+	inString := false
+	for i := 0; i < len(line); i++ {
+		ch := line[i]
+		if inString {
+			switch ch {
+			case '\\':
+				i++ // skip escaped character
+			case '"':
+				inString = false
+			}
+			continue
+		}
+		switch ch {
+		case '/':
+			if i+1 < len(line) && line[i+1] == '/' {
+				return // rest of line is a comment
+			}
+		case '"':
+			inString = true
+		case '{':
+			*depth++
+		case '}':
+			*depth--
+		}
+	}
+}
 
 // FetchPresets fetches the module zip from the OCI registry and extracts preset info.
 // If version is empty, resolves to the latest version.

--- a/internal/cuemod/presets.go
+++ b/internal/cuemod/presets.go
@@ -74,11 +74,13 @@ func ExtractDefinition(source, defName string) (string, error) {
 	for i := startIdx; i < len(lines); i++ {
 		countBraces(lines[i], &depth)
 		endIdx = i
-		if depth == 0 && i > startIdx {
+		// Single-line definitions should stop immediately once the starting line
+		// has been processed and brace depth has returned to zero, including
+		// braced forms like `#Foo: { x: 1 }`.
+		if depth == 0 && i == startIdx {
 			break
 		}
-		// Single-line definition without braces (e.g. "#Foo: string").
-		if depth == 0 && i == startIdx && !strings.Contains(lines[i], "{") {
+		if depth == 0 && i > startIdx {
 			break
 		}
 	}
@@ -216,7 +218,7 @@ func extractPresetsFromZip(r io.ReaderAt, size int64) ([]PresetInfo, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to open %s in zip: %w", f.Name, err)
 		}
-		content, err := io.ReadAll(io.LimitReader(rc, maxCUEFileSize))
+		content, err := io.ReadAll(io.LimitReader(rc, maxCUEFileSize+1))
 		closeErr := rc.Close()
 		if err != nil {
 			if closeErr != nil {
@@ -226,6 +228,9 @@ func extractPresetsFromZip(r io.ReaderAt, size int64) ([]PresetInfo, error) {
 		}
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to close %s in zip: %w", f.Name, closeErr)
+		}
+		if int64(len(content)) > maxCUEFileSize {
+			return nil, fmt.Errorf("CUE file %s exceeds size limit of %d bytes", f.Name, maxCUEFileSize)
 		}
 
 		info, ok := presetMap[pkgName]

--- a/internal/cuemod/presets.go
+++ b/internal/cuemod/presets.go
@@ -23,6 +23,10 @@ const maxModuleZipSize = 50 << 20
 // maxCUEFileSize is the upper bound for a single CUE file in the zip (1 MB).
 const maxCUEFileSize = 1 << 20
 
+// maxTotalExtractedSize is the upper bound for total extracted content from the zip (100 MB).
+// This limits zip bomb impact where many small compressed entries expand to large sizes.
+const maxTotalExtractedSize = 100 << 20
+
 // fetchPresetsTimeout is the default timeout for FetchPresets network operations.
 const fetchPresetsTimeout = 30 * time.Second
 
@@ -108,15 +112,26 @@ func ExtractDefinition(source, defName string) (string, error) {
 }
 
 // hasBodyContent returns true if line contains meaningful content
-// (not just whitespace or comments).
+// (not just whitespace, line comments, or self-contained block comments).
 func hasBodyContent(line string) bool {
+	inBlock := false
 	for i := 0; i < len(line); i++ {
 		ch := line[i]
+		if inBlock {
+			if ch == '*' && i+1 < len(line) && line[i+1] == '/' {
+				inBlock = false
+				i++ // skip '/'
+			}
+			continue
+		}
 		switch {
 		case ch == ' ' || ch == '\t' || ch == '\r':
 			continue
 		case ch == '/' && i+1 < len(line) && line[i+1] == '/':
 			return false // line comment — no body content
+		case ch == '/' && i+1 < len(line) && line[i+1] == '*':
+			inBlock = true
+			i++ // skip '*'
 		default:
 			return true
 		}
@@ -166,6 +181,9 @@ func countBraces(line string, depth *int, inBlockComment bool) bool {
 			*depth++
 		case '}':
 			*depth--
+			if *depth < 0 {
+				return inBlockComment // unmatched closing brace
+			}
 		}
 	}
 	return inBlockComment
@@ -237,6 +255,7 @@ func extractPresetsFromZip(r io.ReaderAt, size int64) ([]PresetInfo, error) {
 
 	// Map preset name to collected info.
 	presetMap := make(map[string]*PresetInfo)
+	var totalExtracted int64
 
 	for _, f := range zr.File {
 		// Zip entries are bare relative paths: presets/go/go.cue
@@ -280,6 +299,10 @@ func extractPresetsFromZip(r io.ReaderAt, size int64) ([]PresetInfo, error) {
 		}
 		if int64(len(content)) > maxCUEFileSize {
 			return nil, fmt.Errorf("CUE file %s exceeds size limit of %d bytes", f.Name, maxCUEFileSize)
+		}
+		totalExtracted += int64(len(content))
+		if totalExtracted > maxTotalExtractedSize {
+			return nil, fmt.Errorf("total extracted content exceeds size limit of %d bytes", maxTotalExtractedSize)
 		}
 
 		info, ok := presetMap[pkgName]

--- a/internal/cuemod/presets.go
+++ b/internal/cuemod/presets.go
@@ -220,7 +220,7 @@ func extractPresetsFromZip(r io.ReaderAt, size int64) ([]PresetInfo, error) {
 		closeErr := rc.Close()
 		if err != nil {
 			if closeErr != nil {
-				return nil, fmt.Errorf("failed to read %s in zip: %v (and failed to close: %w)", f.Name, err, closeErr)
+				return nil, fmt.Errorf("failed to read %s in zip: %w (and failed to close: %w)", f.Name, err, closeErr)
 			}
 			return nil, fmt.Errorf("failed to read %s in zip: %w", f.Name, err)
 		}

--- a/internal/cuemod/presets.go
+++ b/internal/cuemod/presets.go
@@ -160,9 +160,12 @@ func FetchPresets(ctx context.Context, version string, opts ...ResolveOption) (p
 		}
 	}()
 
-	zipData, err := io.ReadAll(io.LimitReader(zipReader, maxModuleZipSize))
+	zipData, err := io.ReadAll(io.LimitReader(zipReader, maxModuleZipSize+1))
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to read module zip: %w", err)
+	}
+	if int64(len(zipData)) > maxModuleZipSize {
+		return nil, "", fmt.Errorf("module zip exceeds size limit of %d bytes", maxModuleZipSize)
 	}
 
 	presets, err = extractPresetsFromZip(bytes.NewReader(zipData), int64(len(zipData)))
@@ -214,9 +217,15 @@ func extractPresetsFromZip(r io.ReaderAt, size int64) ([]PresetInfo, error) {
 			return nil, fmt.Errorf("failed to open %s in zip: %w", f.Name, err)
 		}
 		content, err := io.ReadAll(io.LimitReader(rc, maxCUEFileSize))
-		rc.Close()
+		closeErr := rc.Close()
 		if err != nil {
+			if closeErr != nil {
+				return nil, fmt.Errorf("failed to read %s in zip: %v (and failed to close: %w)", f.Name, err, closeErr)
+			}
 			return nil, fmt.Errorf("failed to read %s in zip: %w", f.Name, err)
+		}
+		if closeErr != nil {
+			return nil, fmt.Errorf("failed to close %s in zip: %w", f.Name, closeErr)
 		}
 
 		info, ok := presetMap[pkgName]

--- a/internal/cuemod/presets.go
+++ b/internal/cuemod/presets.go
@@ -50,8 +50,9 @@ var definitionRe = regexp.MustCompile(`(?m)^(#\w+):`)
 // defName should include the "#" prefix (e.g. "#GoRuntime").
 // Returns the full definition text including the name and braces.
 //
-// The parser is aware of line comments (//) and quoted strings so that braces
-// inside comments or string literals do not affect depth tracking.
+// The parser is aware of line comments (//), block comments (/* */),
+// and quoted strings so that braces inside comments or string literals
+// do not affect depth tracking.
 func ExtractDefinition(source, defName string) (string, error) {
 	lines := strings.Split(source, "\n")
 	prefix := defName + ":"
@@ -68,19 +69,33 @@ func ExtractDefinition(source, defName string) (string, error) {
 	}
 
 	// Count braces to find the end of the definition block.
-	// Skip braces inside // comments and "..." string literals.
+	// Skip braces inside comments and string literals.
 	depth := 0
 	endIdx := startIdx
+	inBlock := false // tracks block comment state across lines
+	seenBody := false
 	for i := startIdx; i < len(lines); i++ {
-		countBraces(lines[i], &depth)
-		endIdx = i
-		// Single-line definitions should stop immediately once the starting line
-		// has been processed and brace depth has returned to zero, including
-		// braced forms like `#Foo: { x: 1 }`.
-		if depth == 0 && i == startIdx {
-			break
+		line := lines[i]
+		// Check if body content exists on or after the definition line.
+		if i == startIdx {
+			if hasBodyContent(line[len(prefix):]) {
+				seenBody = true
+			}
+		} else if hasBodyContent(line) {
+			seenBody = true
 		}
-		if depth == 0 && i > startIdx {
+
+		inBlock = countBraces(line, &depth, inBlock)
+		endIdx = i
+
+		// Only stop once we've actually seen definition body content.
+		// This preserves single-line forms like `#Foo: 1` and `#Foo: { x: 1 }`,
+		// while allowing valid multiline formatting such as:
+		//   #Foo:
+		//   {
+		//     x: 1
+		//   }
+		if depth == 0 && seenBody {
 			break
 		}
 	}
@@ -92,12 +107,38 @@ func ExtractDefinition(source, defName string) (string, error) {
 	return strings.Join(lines[startIdx:endIdx+1], "\n"), nil
 }
 
+// hasBodyContent returns true if line contains meaningful content
+// (not just whitespace or comments).
+func hasBodyContent(line string) bool {
+	for i := 0; i < len(line); i++ {
+		ch := line[i]
+		switch {
+		case ch == ' ' || ch == '\t' || ch == '\r':
+			continue
+		case ch == '/' && i+1 < len(line) && line[i+1] == '/':
+			return false // line comment — no body content
+		default:
+			return true
+		}
+	}
+	return false
+}
+
 // countBraces counts unquoted, uncommented braces in a single line,
-// updating *depth in place.
-func countBraces(line string, depth *int) {
+// updating *depth in place. inBlockComment tracks block comment state
+// across lines and is returned for the caller to pass to the next line.
+func countBraces(line string, depth *int, inBlockComment bool) bool {
 	inString := false
 	for i := 0; i < len(line); i++ {
 		ch := line[i]
+		// Inside block comment — look for closing */
+		if inBlockComment {
+			if ch == '*' && i+1 < len(line) && line[i+1] == '/' {
+				inBlockComment = false
+				i++ // skip '/'
+			}
+			continue
+		}
 		if inString {
 			switch ch {
 			case '\\':
@@ -109,8 +150,15 @@ func countBraces(line string, depth *int) {
 		}
 		switch ch {
 		case '/':
-			if i+1 < len(line) && line[i+1] == '/' {
-				return // rest of line is a comment
+			if i+1 < len(line) {
+				switch line[i+1] {
+				case '/':
+					return inBlockComment // rest of line is a line comment
+				case '*':
+					inBlockComment = true
+					i++ // skip '*'
+					continue
+				}
 			}
 		case '"':
 			inString = true
@@ -120,6 +168,7 @@ func countBraces(line string, depth *int) {
 			*depth--
 		}
 	}
+	return inBlockComment
 }
 
 // FetchPresets fetches the module zip from the OCI registry and extracts preset info.

--- a/internal/cuemod/presets.go
+++ b/internal/cuemod/presets.go
@@ -1,0 +1,177 @@
+package cuemod
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"path"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+)
+
+// tomeiImportBase is the module path without the major version suffix,
+// used for constructing CUE import paths (e.g. "tomei.terassyi.net/presets/go").
+const tomeiImportBase = "tomei.terassyi.net"
+
+// maxModuleZipSize is the upper bound for module zip size (50 MB).
+const maxModuleZipSize = 50 << 20
+
+// maxCUEFileSize is the upper bound for a single CUE file in the zip (1 MB).
+const maxCUEFileSize = 1 << 20
+
+// fetchPresetsTimeout is the default timeout for FetchPresets network operations.
+const fetchPresetsTimeout = 30 * time.Second
+
+// PresetInfo describes a preset package and its exported definitions.
+type PresetInfo struct {
+	Name        string   `json:"name"`
+	ImportPath  string   `json:"importPath"`
+	Definitions []string `json:"definitions"`
+	Source      string   `json:"source,omitempty"`
+}
+
+// definitionRe matches top-level CUE definitions (e.g. "#GoRuntime:").
+// Only #-prefixed identifiers at column 0 are matched; hidden definitions (_#Name)
+// and indented definitions are intentionally excluded.
+var definitionRe = regexp.MustCompile(`(?m)^(#\w+):`)
+
+// FetchPresets fetches the module zip from the OCI registry and extracts preset info.
+// If version is empty, resolves to the latest version.
+// Returns (presets, resolvedVersion, error).
+func FetchPresets(ctx context.Context, version string, opts ...ResolveOption) (presets []PresetInfo, resolvedVersion string, err error) {
+	ctx, cancel := context.WithTimeout(ctx, fetchPresetsTimeout)
+	defer cancel()
+
+	client, err := newRegistryClient()
+	if err != nil {
+		return nil, "", err
+	}
+
+	if version == "" {
+		resolved, err := resolveLatestVersionWithClient(ctx, client, opts...)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to resolve latest version: %w", err)
+		}
+		version = resolved
+	}
+
+	modVer, err := newModuleVersion(version)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create module version: %w", err)
+	}
+
+	mod, err := client.GetModule(ctx, modVer)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to get module from registry: %w", err)
+	}
+
+	zipReader, err := mod.GetZip(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to get module zip: %w", err)
+	}
+	defer func() {
+		if cerr := zipReader.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("zip integrity check failed: %w", cerr)
+		}
+	}()
+
+	zipData, err := io.ReadAll(io.LimitReader(zipReader, maxModuleZipSize))
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to read module zip: %w", err)
+	}
+
+	presets, err = extractPresetsFromZip(bytes.NewReader(zipData), int64(len(zipData)))
+	if err != nil {
+		return nil, "", err
+	}
+
+	return presets, version, nil
+}
+
+// extractPresetsFromZip reads a zip archive and extracts preset info from presets/*/*.cue files.
+// CUE module zips contain bare relative paths (e.g. "presets/go/go.cue").
+func extractPresetsFromZip(r io.ReaderAt, size int64) ([]PresetInfo, error) {
+	zr, err := zip.NewReader(r, size)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open zip: %w", err)
+	}
+
+	// Map preset name to collected info.
+	presetMap := make(map[string]*PresetInfo)
+
+	for _, f := range zr.File {
+		// Zip entries are bare relative paths: presets/go/go.cue
+		// Find the "presets/" segment.
+		parts := strings.Split(f.Name, "/")
+		presetsIdx := -1
+		for i, p := range parts {
+			if p == "presets" {
+				presetsIdx = i
+				break
+			}
+		}
+		if presetsIdx < 0 {
+			continue
+		}
+
+		// Expect: presets/<pkg>/<file>.cue
+		if len(parts) != presetsIdx+3 {
+			continue
+		}
+		pkgName := parts[presetsIdx+1]
+		fileName := parts[presetsIdx+2]
+		if !strings.HasSuffix(fileName, ".cue") {
+			continue
+		}
+
+		rc, err := f.Open()
+		if err != nil {
+			return nil, fmt.Errorf("failed to open %s in zip: %w", f.Name, err)
+		}
+		content, err := io.ReadAll(io.LimitReader(rc, maxCUEFileSize))
+		rc.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read %s in zip: %w", f.Name, err)
+		}
+
+		info, ok := presetMap[pkgName]
+		if !ok {
+			info = &PresetInfo{
+				Name:       pkgName,
+				ImportPath: path.Join(tomeiImportBase, "presets", pkgName),
+			}
+			presetMap[pkgName] = info
+		}
+
+		src := string(content)
+
+		// Append source content.
+		if info.Source != "" {
+			info.Source += "\n"
+		}
+		info.Source += src
+
+		// Extract exported definition names (#-prefixed, top-level only).
+		matches := definitionRe.FindAllStringSubmatch(src, -1)
+		for _, m := range matches {
+			info.Definitions = append(info.Definitions, m[1])
+		}
+	}
+
+	// Collect, deduplicate definitions, and sort.
+	presets := make([]PresetInfo, 0, len(presetMap))
+	for _, info := range presetMap {
+		slices.Sort(info.Definitions)
+		info.Definitions = slices.Compact(info.Definitions)
+		presets = append(presets, *info)
+	}
+	slices.SortFunc(presets, func(a, b PresetInfo) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	return presets, nil
+}

--- a/internal/cuemod/presets_test.go
+++ b/internal/cuemod/presets_test.go
@@ -171,6 +171,127 @@ func TestExtractPresetsFromZip(t *testing.T) {
 	}
 }
 
+func TestExtractDefinition(t *testing.T) {
+	t.Parallel()
+
+	source := `package gopreset
+
+#GoRuntime: {
+	kind: "Runtime"
+	spec: {
+		version: "1.22"
+	}
+}
+
+#GoTool: {
+	kind: "Tool"
+}
+
+#GoVersion: string
+`
+
+	tests := []struct {
+		name    string
+		source  string
+		defName string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "extracts multi-line definition",
+			source:  source,
+			defName: "#GoRuntime",
+			want: `#GoRuntime: {
+	kind: "Runtime"
+	spec: {
+		version: "1.22"
+	}
+}`,
+		},
+		{
+			name:    "extracts simple definition",
+			source:  source,
+			defName: "#GoTool",
+			want: `#GoTool: {
+	kind: "Tool"
+}`,
+		},
+		{
+			name:    "extracts single-line definition",
+			source:  source,
+			defName: "#GoVersion",
+			want:    `#GoVersion: string`,
+		},
+		{
+			name:    "definition not found",
+			source:  source,
+			defName: "#NotExist",
+			wantErr: true,
+		},
+		{
+			name:    "empty source",
+			source:  "",
+			defName: "#Foo",
+			wantErr: true,
+		},
+		{
+			name:    "definition at end of file without trailing newline",
+			source:  "#Foo: {\n\tfield: true\n}",
+			defName: "#Foo",
+			want:    "#Foo: {\n\tfield: true\n}",
+		},
+		{
+			name:    "consecutive definitions without blank lines",
+			source:  "#A: {\n\tx: 1\n}\n#B: {\n\ty: 2\n}",
+			defName: "#A",
+			want:    "#A: {\n\tx: 1\n}",
+		},
+		{
+			name:    "consecutive definitions extracts second",
+			source:  "#A: {\n\tx: 1\n}\n#B: {\n\ty: 2\n}",
+			defName: "#B",
+			want:    "#B: {\n\ty: 2\n}",
+		},
+		{
+			name:    "prefix name does not match longer name",
+			source:  "#GoRuntime: {\n\tkind: \"Runtime\"\n}\n#Go: string",
+			defName: "#Go",
+			want:    "#Go: string",
+		},
+		{
+			name:    "braces inside string literal are ignored",
+			source:  "#Foo: {\n\tmsg: \"hello {world}\"\n}",
+			defName: "#Foo",
+			want:    "#Foo: {\n\tmsg: \"hello {world}\"\n}",
+		},
+		{
+			name:    "braces inside comment are ignored",
+			source:  "#Foo: {\n\t// TODO: handle {edge case}\n\tx: 1\n}",
+			defName: "#Foo",
+			want:    "#Foo: {\n\t// TODO: handle {edge case}\n\tx: 1\n}",
+		},
+		{
+			name:    "unbalanced braces returns error",
+			source:  "#Foo: {\n\tx: 1\n",
+			defName: "#Foo",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ExtractDefinition(tt.source, tt.defName)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 // createTestZip creates a zip archive in memory from the given file map.
 func createTestZip(t *testing.T, files map[string]string) []byte {
 	t.Helper()

--- a/internal/cuemod/presets_test.go
+++ b/internal/cuemod/presets_test.go
@@ -277,6 +277,24 @@ func TestExtractDefinition(t *testing.T) {
 			want:    "#Foo: { x: 1 }",
 		},
 		{
+			name:    "multiline definition with body on next line",
+			source:  "#Foo:\n{\n\tx: 1\n}\n#Bar: string",
+			defName: "#Foo",
+			want:    "#Foo:\n{\n\tx: 1\n}",
+		},
+		{
+			name:    "braces inside block comment are ignored",
+			source:  "#Foo: {\n\t/* { nested } */\n\tx: 1\n}",
+			defName: "#Foo",
+			want:    "#Foo: {\n\t/* { nested } */\n\tx: 1\n}",
+		},
+		{
+			name:    "multiline block comment spanning lines",
+			source:  "#Foo: {\n\t/*\n\t{ nested }\n\t*/\n\tx: 1\n}",
+			defName: "#Foo",
+			want:    "#Foo: {\n\t/*\n\t{ nested }\n\t*/\n\tx: 1\n}",
+		},
+		{
 			name:    "unbalanced braces returns error",
 			source:  "#Foo: {\n\tx: 1\n",
 			defName: "#Foo",

--- a/internal/cuemod/presets_test.go
+++ b/internal/cuemod/presets_test.go
@@ -271,6 +271,12 @@ func TestExtractDefinition(t *testing.T) {
 			want:    "#Foo: {\n\t// TODO: handle {edge case}\n\tx: 1\n}",
 		},
 		{
+			name:    "single-line braced definition",
+			source:  "#Foo: { x: 1 }\n#Bar: {\n\ty: 2\n}",
+			defName: "#Foo",
+			want:    "#Foo: { x: 1 }",
+		},
+		{
 			name:    "unbalanced braces returns error",
 			source:  "#Foo: {\n\tx: 1\n",
 			defName: "#Foo",

--- a/internal/cuemod/presets_test.go
+++ b/internal/cuemod/presets_test.go
@@ -1,0 +1,187 @@
+package cuemod
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"maps"
+	"testing"
+	"testing/fstest"
+
+	"cuelang.org/go/mod/modregistrytest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/terassyi/tomei/internal/config"
+)
+
+// presetExtraFiles returns extra CUE preset files for mock module FS.
+var presetExtraFiles = fstest.MapFS{
+	"presets/go/go.cue": &fstest.MapFile{
+		Data: []byte("package gopreset\n\n#GoRuntime: {\n\tkind: \"Runtime\"\n}\n\n#GoTool: {\n\tkind: \"Tool\"\n}\n\n#GoToolSet: {\n\tkind: \"Tool\"\n}\n"),
+	},
+	"presets/aqua/aqua.cue": &fstest.MapFile{
+		Data: []byte("package aqua\n\n#AquaTool: {\n\tkind: \"Tool\"\n}\n\n#AquaToolSet: {\n\tkind: \"Tool\"\n}\n"),
+	},
+}
+
+func setupMockRegistryWithPresets(t *testing.T, versions ...string) {
+	t.Helper()
+	merged := fstest.MapFS{}
+	for _, v := range versions {
+		maps.Copy(merged, buildMockModuleFS(v, presetExtraFiles))
+	}
+	reg, err := modregistrytest.New(merged, "")
+	require.NoError(t, err)
+	t.Cleanup(reg.Close)
+	t.Setenv(config.EnvCUERegistry, reg.Host()+"+insecure")
+}
+
+func TestFetchPresets(t *testing.T) {
+	tests := []struct {
+		name        string
+		version     string
+		wantPresets []string
+		wantVersion string
+	}{
+		{
+			name:        "fetches presets with latest version",
+			version:     "",
+			wantPresets: []string{"aqua", "go"},
+			wantVersion: "v0.0.2",
+		},
+		{
+			name:        "fetches presets with explicit version",
+			version:     "v0.0.1",
+			wantPresets: []string{"aqua", "go"},
+			wantVersion: "v0.0.1",
+		},
+	}
+
+	for _, tt := range tests {
+		// Subtests use t.Setenv via setupMockRegistryWithPresets, so they cannot be parallel.
+		t.Run(tt.name, func(t *testing.T) {
+			setupMockRegistryWithPresets(t, "v0.0.1", "v0.0.2")
+
+			presets, version, err := FetchPresets(context.Background(), tt.version)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantVersion, version)
+
+			var names []string
+			for _, p := range presets {
+				names = append(names, p.Name)
+			}
+			assert.Equal(t, tt.wantPresets, names)
+
+			for _, p := range presets {
+				assert.NotEmpty(t, p.Definitions, "definitions for %s", p.Name)
+				assert.NotEmpty(t, p.Source, "source for %s", p.Name)
+				assert.Contains(t, p.ImportPath, "presets/"+p.Name)
+			}
+		})
+	}
+}
+
+func TestFetchPresets_RegistryNone(t *testing.T) {
+	t.Setenv(config.EnvCUERegistry, "none")
+	_, _, err := FetchPresets(context.Background(), "")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrRegistryDisabled)
+}
+
+func TestExtractPresetsFromZip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		files      map[string]string
+		wantNames  []string
+		wantDefs   map[string][]string
+		wantSource bool
+	}{
+		{
+			name: "extracts presets from bare-path zip",
+			files: map[string]string{
+				"presets/go/go.cue":     "package gopreset\n#GoRuntime: {}\n#GoTool: {}\n",
+				"presets/aqua/aqua.cue": "package aqua\n#AquaTool: {}\n",
+				"schema/schema.cue":     "package schema\n",
+			},
+			wantNames: []string{"aqua", "go"},
+			wantDefs: map[string][]string{
+				"aqua": {"#AquaTool"},
+				"go":   {"#GoRuntime", "#GoTool"},
+			},
+			wantSource: true,
+		},
+		{
+			name: "empty presets directory",
+			files: map[string]string{
+				"schema/schema.cue": "package schema\n",
+			},
+			wantNames: nil,
+		},
+		{
+			name: "ignores non-cue files",
+			files: map[string]string{
+				"presets/go/go.cue":    "package gopreset\n#GoRuntime: {}\n",
+				"presets/go/README.md": "# Go preset\n",
+			},
+			wantNames: []string{"go"},
+			wantDefs: map[string][]string{
+				"go": {"#GoRuntime"},
+			},
+		},
+		{
+			name: "ignores deeply nested files",
+			files: map[string]string{
+				"presets/go/sub/nested.cue": "package sub\n#Nested: {}\n",
+			},
+			wantNames: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			zipData := createTestZip(t, tt.files)
+
+			presets, err := extractPresetsFromZip(
+				bytes.NewReader(zipData),
+				int64(len(zipData)),
+			)
+			require.NoError(t, err)
+
+			var names []string
+			for _, p := range presets {
+				names = append(names, p.Name)
+			}
+			assert.Equal(t, tt.wantNames, names)
+
+			if tt.wantDefs != nil {
+				for _, p := range presets {
+					assert.Equal(t, tt.wantDefs[p.Name], p.Definitions, "definitions for %s", p.Name)
+				}
+			}
+
+			if tt.wantSource {
+				for _, p := range presets {
+					assert.NotEmpty(t, p.Source, "source for %s should not be empty", p.Name)
+				}
+			}
+		})
+	}
+}
+
+// createTestZip creates a zip archive in memory from the given file map.
+func createTestZip(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	for name, content := range files {
+		f, err := w.Create(name)
+		require.NoError(t, err)
+		_, err = f.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, w.Close())
+	return buf.Bytes()
+}

--- a/internal/cuemod/testhelper_test.go
+++ b/internal/cuemod/testhelper_test.go
@@ -6,9 +6,10 @@ import (
 )
 
 // buildMockModuleFS creates a minimal CUE module FS for the mock registry.
-func buildMockModuleFS(version string) fstest.MapFS {
+// Optional extra files are merged into the FS under the version prefix.
+func buildMockModuleFS(version string, extra ...fstest.MapFS) fstest.MapFS {
 	prefix := "tomei.terassyi.net_" + version + "/"
-	return fstest.MapFS{
+	fs := fstest.MapFS{
 		prefix + "cue.mod/module.cue": &fstest.MapFile{
 			Data: []byte("module: \"tomei.terassyi.net@v0\"\nlanguage: version: \"v0.9.0\"\n"),
 		},
@@ -16,6 +17,12 @@ func buildMockModuleFS(version string) fstest.MapFS {
 			Data: []byte("package schema\n"),
 		},
 	}
+	for _, e := range extra {
+		for k, v := range e {
+			fs[prefix+k] = v
+		}
+	}
+	return fs
 }
 
 // mergeMockModuleFS merges multiple version FSes into one.


### PR DESCRIPTION
Fetch the tomei CUE module from the OCI registry via modregistry.Client
and extract preset package names and exported definitions from the module
zip. Supports --output table/cue/json, --version, and --pre flags.

Key changes:
- internal/cuemod/presets.go: FetchPresets, extractPresetsFromZip, PresetInfo
- internal/cuemod/init.go: extract newRegistryClient (with ErrRegistryDisabled),
  newModuleVersion, resolveLatestVersionWithClient for client reuse
- cmd/tomei/cue/presets.go: cobra command with table/cue/json output
- Zip reads bounded by io.LimitReader (50 MB module, 1 MB per file)
- zipReader.Close() error checked for OCI integrity verification
- 30s context timeout for network operations

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Signed-off-by: terashima <iscale821@gmail.com>
