### PR TITLE
feat(apt): add SystemInstaller for APT package manager (#163)

### DIFF
--- a/internal/installer/apt/apt.go
+++ b/internal/installer/apt/apt.go
@@ -1,0 +1,31 @@
+// Package apt provides APT package manager integration for system package management.
+//
+// Currently implements InstallerInstaller for the SystemInstaller resource,
+// which detects APT availability and records the version.
+package apt
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/terassyi/tomei/internal/installer/command"
+)
+
+// commandRunner abstracts shell command execution for testability.
+// This is a subset of command.Executor's methods.
+type commandRunner interface {
+	ExecuteCapture(ctx context.Context, cmds []string, vars command.Vars, env map[string]string) (string, error)
+}
+
+// parseAptVersion extracts the version string from apt-get --version output.
+// Example input: "apt 2.4.12 (amd64)\nUsage: apt-get [options] command\n..."
+// Returns: "2.4.12"
+func parseAptVersion(output string) (string, error) {
+	firstLine := strings.SplitN(strings.TrimSpace(output), "\n", 2)[0]
+	fields := strings.Fields(firstLine)
+	if len(fields) < 2 {
+		return "", fmt.Errorf("unexpected apt-get --version output: %q", output)
+	}
+	return fields[1], nil
+}

--- a/internal/installer/apt/apt_test.go
+++ b/internal/installer/apt/apt_test.go
@@ -1,0 +1,62 @@
+package apt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAptVersion(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		output  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "standard version",
+			output: "apt 2.4.12 (amd64)",
+			want:   "2.4.12",
+		},
+		{
+			name:   "version with build suffix",
+			output: "apt 2.7.14build2 (amd64)",
+			want:   "2.7.14build2",
+		},
+		{
+			name:   "multiline output",
+			output: "apt 2.4.12 (amd64)\nUsage: apt-get [options] command\n",
+			want:   "2.4.12",
+		},
+		{
+			name:    "empty output",
+			output:  "",
+			wantErr: true,
+		},
+		{
+			name:    "single word",
+			output:  "apt",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace only",
+			output:  "   \n  ",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseAptVersion(tt.output)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/installer/apt/installer.go
+++ b/internal/installer/apt/installer.go
@@ -37,7 +37,7 @@ func (i *InstallerInstaller) Install(ctx context.Context, _ *resource.SystemInst
 
 	output, err := i.runner.ExecuteCapture(ctx, []string{"apt-get --version"}, command.Vars{}, nil)
 	if err != nil {
-		return nil, fmt.Errorf("apt-get not found: this installer requires a Debian-based system: %w", err)
+		return nil, fmt.Errorf("failed to run apt-get --version (is this a Debian-based system?): %w", err)
 	}
 
 	version, err := parseAptVersion(output)

--- a/internal/installer/apt/installer.go
+++ b/internal/installer/apt/installer.go
@@ -1,0 +1,59 @@
+package apt
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/terassyi/tomei/internal/installer/command"
+	"github.com/terassyi/tomei/internal/resource"
+)
+
+// InstallerInstaller handles the SystemInstaller resource for APT.
+// Install checks APT availability via "apt-get --version" and records the version in state.
+// Remove is a no-op since APT is a system package manager and is never removed by tomei.
+type InstallerInstaller struct {
+	runner commandRunner
+}
+
+// NewInstallerInstaller creates a new InstallerInstaller with the default command executor.
+func NewInstallerInstaller() *InstallerInstaller {
+	return &InstallerInstaller{
+		runner: command.NewExecutor(""),
+	}
+}
+
+// newInstallerInstallerWith creates a new InstallerInstaller with a custom runner (for testing).
+func newInstallerInstallerWith(runner commandRunner) *InstallerInstaller {
+	return &InstallerInstaller{
+		runner: runner,
+	}
+}
+
+// Install checks APT availability by running "apt-get --version" and records the version in state.
+func (i *InstallerInstaller) Install(ctx context.Context, _ *resource.SystemInstaller, name string) (*resource.SystemInstallerState, error) {
+	slog.Debug("checking apt availability", "name", name)
+
+	output, err := i.runner.ExecuteCapture(ctx, []string{"apt-get --version"}, command.Vars{}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("apt-get not found: this installer requires a Debian-based system: %w", err)
+	}
+
+	version, err := parseAptVersion(output)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse apt-get version: %w", err)
+	}
+
+	slog.Debug("apt detected", "name", name, "version", version)
+
+	return &resource.SystemInstallerState{
+		Version:   version,
+		UpdatedAt: time.Now(),
+	}, nil
+}
+
+// Remove is a no-op. APT is a system package manager and is never removed by tomei.
+func (i *InstallerInstaller) Remove(_ context.Context, _ *resource.SystemInstallerState, _ string) error {
+	return nil
+}

--- a/internal/installer/apt/installer_test.go
+++ b/internal/installer/apt/installer_test.go
@@ -63,7 +63,7 @@ func TestInstallerInstaller_Install(t *testing.T) {
 			name:       "apt-get not found",
 			captureErr: fmt.Errorf("exec: \"apt-get\": executable file not found in $PATH"),
 			wantErr:    true,
-			wantErrMsg: "apt-get not found",
+			wantErrMsg: "failed to run apt-get --version",
 		},
 	}
 

--- a/internal/installer/apt/installer_test.go
+++ b/internal/installer/apt/installer_test.go
@@ -15,10 +15,9 @@ import (
 // --- mock ---
 
 type captureCall struct {
-	cmds       []string
-	vars       command.Vars
-	env        map[string]string
-	privileged bool
+	cmds []string
+	vars command.Vars
+	env  map[string]string
 }
 
 type mockCommandRunner struct {
@@ -27,12 +26,11 @@ type mockCommandRunner struct {
 	calls         []captureCall
 }
 
-func (m *mockCommandRunner) ExecuteCapture(ctx context.Context, cmds []string, vars command.Vars, env map[string]string) (string, error) {
+func (m *mockCommandRunner) ExecuteCapture(_ context.Context, cmds []string, vars command.Vars, env map[string]string) (string, error) {
 	m.calls = append(m.calls, captureCall{
-		cmds:       cmds,
-		vars:       vars,
-		env:        env,
-		privileged: executor.PrivilegedFromContext(ctx),
+		cmds: cmds,
+		vars: vars,
+		env:  env,
 	})
 	return m.captureOutput, m.captureErr
 }
@@ -104,8 +102,6 @@ func TestInstallerInstaller_Install(t *testing.T) {
 			assert.Equal(t, []string{"apt-get --version"}, call.cmds)
 			assert.Equal(t, command.Vars{}, call.vars)
 			assert.Nil(t, call.env)
-			// apt-get --version does not require sudo
-			assert.False(t, call.privileged)
 		})
 	}
 }

--- a/internal/installer/apt/installer_test.go
+++ b/internal/installer/apt/installer_test.go
@@ -1,0 +1,130 @@
+package apt
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/terassyi/tomei/internal/installer/command"
+	"github.com/terassyi/tomei/internal/installer/executor"
+	"github.com/terassyi/tomei/internal/resource"
+)
+
+// --- mock ---
+
+type captureCall struct {
+	cmds       []string
+	vars       command.Vars
+	env        map[string]string
+	privileged bool
+}
+
+type mockCommandRunner struct {
+	captureOutput string
+	captureErr    error
+	calls         []captureCall
+}
+
+func (m *mockCommandRunner) ExecuteCapture(ctx context.Context, cmds []string, vars command.Vars, env map[string]string) (string, error) {
+	m.calls = append(m.calls, captureCall{
+		cmds:       cmds,
+		vars:       vars,
+		env:        env,
+		privileged: executor.PrivilegedFromContext(ctx),
+	})
+	return m.captureOutput, m.captureErr
+}
+
+// --- InstallerInstaller tests ---
+
+func TestInstallerInstaller_Install(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		captureOutput string
+		captureErr    error
+		wantVersion   string
+		wantErr       bool
+		wantErrMsg    string
+	}{
+		{
+			name:          "successful version detection",
+			captureOutput: "apt 2.4.12 (amd64)",
+			wantVersion:   "2.4.12",
+		},
+		{
+			name:          "version with build suffix",
+			captureOutput: "apt 2.7.14build2 (amd64)",
+			wantVersion:   "2.7.14build2",
+		},
+		{
+			name:       "apt-get not found",
+			captureErr: fmt.Errorf("exec: \"apt-get\": executable file not found in $PATH"),
+			wantErr:    true,
+			wantErrMsg: "apt-get not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mock := &mockCommandRunner{
+				captureOutput: tt.captureOutput,
+				captureErr:    tt.captureErr,
+			}
+			inst := newInstallerInstallerWith(mock)
+
+			res := &resource.SystemInstaller{
+				BaseResource: resource.BaseResource{
+					Metadata: resource.Metadata{Name: "apt"},
+				},
+				SystemInstallerSpec: &resource.SystemInstallerSpec{
+					Pattern:    "delegation",
+					Privileged: true,
+				},
+			}
+
+			state, err := inst.Install(context.Background(), res, "apt")
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+				return
+			}
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantVersion, state.Version)
+			assert.False(t, state.UpdatedAt.IsZero())
+
+			// Verify command arguments
+			require.Len(t, mock.calls, 1)
+			call := mock.calls[0]
+			assert.Equal(t, []string{"apt-get --version"}, call.cmds)
+			assert.Equal(t, command.Vars{}, call.vars)
+			assert.Nil(t, call.env)
+			// apt-get --version does not require sudo
+			assert.False(t, call.privileged)
+		})
+	}
+}
+
+func TestInstallerInstaller_Remove(t *testing.T) {
+	t.Parallel()
+	mock := &mockCommandRunner{}
+	inst := newInstallerInstallerWith(mock)
+
+	st := &resource.SystemInstallerState{
+		Version: "2.4.12",
+	}
+
+	err := inst.Remove(context.Background(), st, "apt")
+	require.NoError(t, err)
+
+	// Remove is a no-op — no commands should be executed
+	assert.Empty(t, mock.calls)
+}
+
+// Compile-time interface satisfaction check.
+var _ executor.Installer[*resource.SystemInstaller, *resource.SystemInstallerState] = (*InstallerInstaller)(nil)

--- a/tests/apt_installer_test.go
+++ b/tests/apt_installer_test.go
@@ -4,6 +4,7 @@ package tests
 
 import (
 	"context"
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,6 +16,10 @@ import (
 
 func TestInstallerInstaller_Install_RealAPT(t *testing.T) {
 	t.Parallel()
+
+	if _, err := exec.LookPath("apt-get"); err != nil {
+		t.Skip("apt-get not available")
+	}
 
 	installer := apt.NewInstallerInstaller()
 
@@ -39,6 +44,10 @@ func TestInstallerInstaller_Install_RealAPT(t *testing.T) {
 
 func TestInstallerInstaller_Remove_RealAPT(t *testing.T) {
 	t.Parallel()
+
+	if _, err := exec.LookPath("apt-get"); err != nil {
+		t.Skip("apt-get not available")
+	}
 
 	installer := apt.NewInstallerInstaller()
 

--- a/tests/apt_installer_test.go
+++ b/tests/apt_installer_test.go
@@ -1,0 +1,51 @@
+//go:build integration
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/terassyi/tomei/internal/installer/apt"
+	"github.com/terassyi/tomei/internal/resource"
+)
+
+func TestInstallerInstaller_Install_RealAPT(t *testing.T) {
+	t.Parallel()
+
+	installer := apt.NewInstallerInstaller()
+
+	res := &resource.SystemInstaller{
+		BaseResource: resource.BaseResource{
+			Metadata: resource.Metadata{Name: "apt"},
+		},
+		SystemInstallerSpec: &resource.SystemInstallerSpec{
+			Pattern:    "delegation",
+			Privileged: true,
+		},
+	}
+
+	state, err := installer.Install(context.Background(), res, "apt")
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, state.Version)
+	assert.False(t, state.UpdatedAt.IsZero())
+
+	t.Logf("detected APT version: %s", state.Version)
+}
+
+func TestInstallerInstaller_Remove_RealAPT(t *testing.T) {
+	t.Parallel()
+
+	installer := apt.NewInstallerInstaller()
+
+	st := &resource.SystemInstallerState{
+		Version: "2.4.12",
+	}
+
+	err := installer.Remove(context.Background(), st, "apt")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

Implement `apt.InstallerInstaller` for the `SystemInstaller` resource as part of #163 (APT installer).

- Detects APT availability via `apt-get --version` and records the version in state
- Remove is a no-op since APT is a system package manager managed by the OS
- Unit tests for `parseAptVersion` and `InstallerInstaller` (Install/Remove)
- Integration tests with `exec.LookPath` guard for non-Debian environments

## Scope

This PR implements **only the standalone installer component** (`internal/installer/apt/`). Engine wiring and removal of `rejectUnsupportedSystemKinds` in `cmd/tomei/apply.go` will be done in a follow-up PR as part of the remaining #163 subtasks.

## Test plan

- [x] `go test ./internal/installer/apt/...` — unit tests pass
- [x] `go test -tags integration ./tests/...` — integration tests pass (Debian), skip (non-Debian)
- [x] `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)