### PR TITLE
feat(preset/rust): add #RustupComponentInstaller and #RustupComponentToolSet (#173)

### DIFF
--- a/cuemodule/presets/rust/rust.cue
+++ b/cuemodule/presets/rust/rust.cue
@@ -125,7 +125,8 @@ import "tomei.terassyi.net/schema"
 //
 // Note: runtimeRef is used for DAG ordering only — the engine does not
 // inject the runtime's binDir onto PATH for installer-delegation
-// commands, so rustup is invoked by absolute path.
+// commands, so rustup is invoked by an explicit path (not relying on
+// PATH).
 //
 // Usage:
 //   rustupComponentInstaller: #RustupComponentInstaller

--- a/cuemodule/presets/rust/rust.cue
+++ b/cuemodule/presets/rust/rust.cue
@@ -111,3 +111,77 @@ import "tomei.terassyi.net/schema"
 		}}
 	}
 }
+
+// #RustupComponentInstaller declares an Installer that delegates to
+// `rustup component add/remove`. Depends on #RustRuntime (rustup ships
+// with the runtime).
+//
+// Toolchain selection: the commands operate on the rustup-active
+// toolchain, which is normally the default toolchain set by
+// #RustRuntime's bootstrap (`rustup install --default-toolchain`). A
+// project-local `rust-toolchain.toml` in the apply CWD will shadow the
+// default; if that's a concern, run `tomei apply` from a directory
+// without such an override.
+//
+// Note: runtimeRef is used for DAG ordering only — the engine does not
+// inject the runtime's binDir onto PATH for installer-delegation
+// commands, so rustup is invoked by absolute path.
+//
+// Usage:
+//   rustupComponentInstaller: #RustupComponentInstaller
+#RustupComponentInstaller: schema.#Installer & {
+	let _cargoBin = "~/.cargo/bin"
+
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "Installer"
+	metadata: {
+		name:        "rustup-component"
+		description: string | *"Install rustup-managed Rust components"
+	}
+	spec: {
+		type:       "delegation"
+		runtimeRef: "rust"
+		commands: {
+			install: ["\(_cargoBin)/rustup component add {{.Package}}"]
+			// `rustup component list --installed` prints `<component>` or
+			// `<component>-<host-triple>` depending on whether the component
+			// has per-target variants — match either form.
+			check: ["\(_cargoBin)/rustup component list --installed | grep -qE '^{{.Package}}(-|$)'"]
+			remove: ["\(_cargoBin)/rustup component remove {{.Package}}"]
+		}
+	}
+}
+
+// #RustupComponentToolSet declares a set of rustup-managed components.
+// Requires #RustRuntime and #RustupComponentInstaller to be declared.
+//
+// The map key is the component name; `package` defaults to the key, so
+// the common case is `"<component>": {}`.
+//
+// Common components (see `rustup component list`):
+//   rust-analyzer, rust-src, miri, llvm-tools, rustc-dev, rust-docs
+// (rustfmt and clippy are already provided by the default rustup profile.)
+//
+// Usage:
+//   rustComponents: #RustupComponentToolSet & {
+//       metadata: name: "rust-components"
+//       spec: tools: {
+//           "rust-analyzer": {}
+//           "rust-src":      {}
+//       }
+//   }
+#RustupComponentToolSet: schema.#ToolSet & {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "ToolSet"
+	metadata: {
+		name:        string
+		description: string | *"Rust components installed via rustup"
+	}
+	spec: {
+		installerRef: "rustup-component"
+		tools: {[Name=string]: {
+			package:  string | *Name
+			version?: _|_
+		}}
+	}
+}

--- a/examples/real-world/rust.cue
+++ b/examples/real-world/rust.cue
@@ -7,3 +7,17 @@ cargoBinstall: rust.#CargoBinstall
 
 // binstall Installer (delegation) — depends on cargo-binstall tool
 binstallInstaller: rust.#BinstallInstaller
+
+// rustup-component Installer — delegates to `rustup component add/remove`.
+// Operates on the rustup-active toolchain (default = the one rustRuntime set up).
+rustupComponentInstaller: rust.#RustupComponentInstaller
+
+// rustup-managed components (rust-analyzer, etc.). Map keys double as
+// the rustup component name.
+rustComponents: rust.#RustupComponentToolSet & {
+	metadata: name: "rust-components"
+	spec: tools: {
+		"rust-analyzer": {}
+		"rust-src":      {}
+	}
+}

--- a/tests/cue_ecosystem_integration_test.go
+++ b/tests/cue_ecosystem_integration_test.go
@@ -500,6 +500,115 @@ binstallInstaller: rust.#BinstallInstaller
 	}
 }
 
+// TestCueEcosystem_MockRegistry_RustupComponentToolSet verifies that the
+// rustup-component preset (#RustupComponentInstaller + #RustupComponentToolSet)
+// resolves through the mock OCI registry, deserializes with the expected
+// shell commands, and expands the ToolSet so each component's `package`
+// defaults to the map key.
+func TestCueEcosystem_MockRegistry_RustupComponentToolSet(t *testing.T) {
+	reg := startMockRegistry(t)
+	dir := setupMockRegistryDir(t, reg)
+
+	manifest := `package tomei
+
+import "tomei.terassyi.net/presets/rust"
+
+rustRuntime:              rust.#RustRuntime
+rustupComponentInstaller: rust.#RustupComponentInstaller
+rustComponents: rust.#RustupComponentToolSet & {
+	metadata: name: "rust-components"
+	spec: tools: {
+		"rust-analyzer": {}
+		"rust-src":      {}
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tools.cue"), []byte(manifest), 0644))
+
+	loader := config.NewLoader(nil)
+	resources, err := loader.Load(dir)
+	require.NoError(t, err)
+	require.Len(t, resources, 3)
+
+	var (
+		installer *resource.Installer
+		toolset   *resource.ToolSet
+	)
+	for _, r := range resources {
+		switch v := r.(type) {
+		case *resource.Installer:
+			if v.Name() == "rustup-component" {
+				installer = v
+			}
+		case *resource.ToolSet:
+			if v.Name() == "rust-components" {
+				toolset = v
+			}
+		}
+	}
+	require.NotNil(t, installer, "rustup-component installer not found")
+	require.NotNil(t, toolset, "rust-components toolset not found")
+
+	// Installer shape: delegation + runtimeRef "rust" + the three rustup commands.
+	assert.True(t, installer.InstallerSpec.Type.IsDelegation())
+	assert.Equal(t, "rust", installer.InstallerSpec.RuntimeRef)
+	require.NotNil(t, installer.InstallerSpec.Commands)
+	require.Len(t, installer.InstallerSpec.Commands.Install, 1)
+	assert.Contains(t, installer.InstallerSpec.Commands.Install[0], "rustup component add")
+	assert.Contains(t, installer.InstallerSpec.Commands.Install[0], "{{.Package}}")
+	require.Len(t, installer.InstallerSpec.Commands.Check, 1)
+	assert.Contains(t, installer.InstallerSpec.Commands.Check[0], "rustup component list --installed")
+	// Regex must accept both bare-name and `<name>-<host-triple>` forms;
+	// rustup prints the latter for components with per-target variants.
+	assert.Contains(t, installer.InstallerSpec.Commands.Check[0], "grep -qE")
+	assert.Contains(t, installer.InstallerSpec.Commands.Check[0], "(-|$)")
+	require.Len(t, installer.InstallerSpec.Commands.Remove, 1)
+	assert.Contains(t, installer.InstallerSpec.Commands.Remove[0], "rustup component remove")
+
+	// ToolSet expansion: package defaults to the map key.
+	assert.Equal(t, "rustup-component", toolset.ToolSetSpec.InstallerRef)
+	expanded, err := toolset.Expand()
+	require.NoError(t, err)
+	require.Len(t, expanded, 2)
+	pkgs := make(map[string]string)
+	for _, r := range expanded {
+		tool, ok := r.(*resource.Tool)
+		require.True(t, ok)
+		assert.Equal(t, "rustup-component", tool.ToolSpec.InstallerRef)
+		require.NotNil(t, tool.ToolSpec.Package)
+		pkgs[tool.Name()] = tool.ToolSpec.Package.String()
+	}
+	assert.Equal(t, "rust-analyzer", pkgs["rust-analyzer"])
+	assert.Equal(t, "rust-src", pkgs["rust-src"])
+}
+
+// TestCueEcosystem_MockRegistry_RustupComponentToolSet_RejectsVersion verifies
+// that #RustupComponentToolSet's `version?: _|_` guard rejects any attempt to
+// set a per-tool version, since rustup components track the active toolchain.
+func TestCueEcosystem_MockRegistry_RustupComponentToolSet_RejectsVersion(t *testing.T) {
+	reg := startMockRegistry(t)
+	dir := setupMockRegistryDir(t, reg)
+
+	manifest := `package tomei
+
+import "tomei.terassyi.net/presets/rust"
+
+rustRuntime:              rust.#RustRuntime
+rustupComponentInstaller: rust.#RustupComponentInstaller
+rustComponents: rust.#RustupComponentToolSet & {
+	metadata: name: "rust-components"
+	spec: tools: {
+		"rust-analyzer": {version: "1.0"}
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tools.cue"), []byte(manifest), 0644))
+
+	loader := config.NewLoader(nil)
+	_, err := loader.Load(dir)
+	require.Error(t, err, "setting version on a rustup component should fail CUE evaluation")
+}
+
 // TestCueEcosystem_MockRegistry_MultiplePresetImports verifies that go + aqua
 // presets can be imported together via the mock OCI registry.
 func TestCueEcosystem_MockRegistry_MultiplePresetImports(t *testing.T) {


### PR DESCRIPTION
Introduce a delegation Installer + ToolSet pair that installs rustup-managed
components (rust-analyzer, rust-src, miri, llvm-tools, rustc-dev, rust-docs)
via `rustup component add/remove`. Mirrors the existing #BinstallInstaller /
#BinstallToolSet shape; map keys default to the rustup component name so
declaring `tools: {"rust-analyzer": {}}` is sufficient. `version` is hard-
rejected via `_|_` since components track the active toolchain.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
