### PR TITLE
feat(reconciler): add system resource reconcilers (#165)

### DIFF
--- a/internal/installer/reconciler/system_installer.go
+++ b/internal/installer/reconciler/system_installer.go
@@ -1,0 +1,19 @@
+package reconciler
+
+import (
+	"github.com/terassyi/tomei/internal/resource"
+)
+
+// SystemInstallerComparator returns a comparator for SystemInstaller resources.
+// It always returns false because system installers are managed by the OS;
+// tomei only records the detected version and never upgrades them.
+func SystemInstallerComparator() Comparator[*resource.SystemInstaller, *resource.SystemInstallerState] {
+	return func(_ *resource.SystemInstaller, _ *resource.SystemInstallerState) (bool, string) {
+		return false, ""
+	}
+}
+
+// NewSystemInstallerReconciler creates a new Reconciler for SystemInstaller resources.
+func NewSystemInstallerReconciler() *Reconciler[*resource.SystemInstaller, *resource.SystemInstallerState] {
+	return New(SystemInstallerComparator())
+}

--- a/internal/installer/reconciler/system_installer.go
+++ b/internal/installer/reconciler/system_installer.go
@@ -5,8 +5,9 @@ import (
 )
 
 // SystemInstallerComparator returns a comparator for SystemInstaller resources.
-// It always returns false because system installers are managed by the OS;
-// tomei only records the detected version and never upgrades them.
+// It never triggers an upgrade because system installers are managed by the OS;
+// tomei only records the detected version. Install and remove actions are still
+// emitted by the generic Reconciler when a resource is added to or removed from the spec.
 func SystemInstallerComparator() Comparator[*resource.SystemInstaller, *resource.SystemInstallerState] {
 	return func(_ *resource.SystemInstaller, _ *resource.SystemInstallerState) (bool, string) {
 		return false, ""

--- a/internal/installer/reconciler/system_installer_test.go
+++ b/internal/installer/reconciler/system_installer_test.go
@@ -1,0 +1,79 @@
+package reconciler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/terassyi/tomei/internal/resource"
+)
+
+func newSystemInstaller(name string) *resource.SystemInstaller {
+	return &resource.SystemInstaller{
+		BaseResource: resource.BaseResource{
+			APIVersion:   "tomei.terassyi.net/v1beta1",
+			ResourceKind: resource.KindSystemInstaller,
+			Metadata:     resource.Metadata{Name: name},
+		},
+		SystemInstallerSpec: &resource.SystemInstallerSpec{
+			Pattern: "delegation",
+		},
+	}
+}
+
+func TestSystemInstallerReconciler_Install(t *testing.T) {
+	t.Parallel()
+	installers := []*resource.SystemInstaller{newSystemInstaller("apt")}
+	states := make(map[string]*resource.SystemInstallerState)
+
+	r := NewSystemInstallerReconciler()
+	actions := r.Reconcile(installers, states)
+
+	require.Len(t, actions, 1)
+	assert.Equal(t, resource.ActionInstall, actions[0].Type)
+	assert.Equal(t, "apt", actions[0].Name)
+}
+
+func TestSystemInstallerReconciler_NoChange(t *testing.T) {
+	t.Parallel()
+	installers := []*resource.SystemInstaller{newSystemInstaller("apt")}
+	states := map[string]*resource.SystemInstallerState{
+		"apt": {Version: "2.6.1", UpdatedAt: time.Now()},
+	}
+
+	r := NewSystemInstallerReconciler()
+	actions := r.Reconcile(installers, states)
+
+	require.Empty(t, actions)
+}
+
+func TestSystemInstallerReconciler_VersionChanged_StillNoOp(t *testing.T) {
+	t.Parallel()
+	installers := []*resource.SystemInstaller{newSystemInstaller("apt")}
+	states := map[string]*resource.SystemInstallerState{
+		"apt": {Version: "2.4.0", UpdatedAt: time.Now()},
+	}
+
+	// Even if the detected version changes, the comparator returns false
+	// because SystemInstaller is OS-managed; tomei does not upgrade it.
+	r := NewSystemInstallerReconciler()
+	actions := r.Reconcile(installers, states)
+
+	require.Empty(t, actions)
+}
+
+func TestSystemInstallerReconciler_Remove(t *testing.T) {
+	t.Parallel()
+	installers := []*resource.SystemInstaller{} // empty spec
+	states := map[string]*resource.SystemInstallerState{
+		"apt": {Version: "2.6.1", UpdatedAt: time.Now()},
+	}
+
+	r := NewSystemInstallerReconciler()
+	actions := r.Reconcile(installers, states)
+
+	require.Len(t, actions, 1)
+	assert.Equal(t, resource.ActionRemove, actions[0].Type)
+	assert.Equal(t, "apt", actions[0].Name)
+}

--- a/internal/installer/reconciler/system_package_repository.go
+++ b/internal/installer/reconciler/system_package_repository.go
@@ -1,0 +1,36 @@
+package reconciler
+
+import (
+	"maps"
+
+	"github.com/terassyi/tomei/internal/resource"
+)
+
+// SystemPackageRepositoryComparator returns a comparator for SystemPackageRepository resources.
+// It detects changes in the repository source configuration that require re-setup.
+func SystemPackageRepositoryComparator() Comparator[*resource.SystemPackageRepository, *resource.SystemPackageRepositoryState] {
+	return func(res *resource.SystemPackageRepository, state *resource.SystemPackageRepositoryState) (bool, string) {
+		spec := res.SystemPackageRepositorySpec
+		if spec.InstallerRef != state.InstallerRef {
+			return true, "installerRef changed: " + state.InstallerRef + " -> " + spec.InstallerRef
+		}
+		if spec.Source.URL != state.Source.URL {
+			return true, "source URL changed: " + state.Source.URL + " -> " + spec.Source.URL
+		}
+		if spec.Source.KeyURL != state.Source.KeyURL {
+			return true, "source key URL changed: " + state.Source.KeyURL + " -> " + spec.Source.KeyURL
+		}
+		if spec.Source.KeyHash != state.Source.KeyHash {
+			return true, "source key hash changed: " + state.Source.KeyHash + " -> " + spec.Source.KeyHash
+		}
+		if !maps.Equal(spec.Source.Options, state.Source.Options) {
+			return true, "source options changed"
+		}
+		return false, ""
+	}
+}
+
+// NewSystemPackageRepositoryReconciler creates a new Reconciler for SystemPackageRepository resources.
+func NewSystemPackageRepositoryReconciler() *Reconciler[*resource.SystemPackageRepository, *resource.SystemPackageRepositoryState] {
+	return New(SystemPackageRepositoryComparator())
+}

--- a/internal/installer/reconciler/system_package_repository_test.go
+++ b/internal/installer/reconciler/system_package_repository_test.go
@@ -78,6 +78,28 @@ func TestSystemPackageRepositoryReconciler_NoChange(t *testing.T) {
 	require.Empty(t, actions)
 }
 
+func TestSystemPackageRepositoryReconciler_NoChange_NilVsEmptyOptions(t *testing.T) {
+	t.Parallel()
+	repo := newSystemPackageRepository("simple", "apt", "https://example.com/repo", "", "", nil)
+
+	repos := []*resource.SystemPackageRepository{repo}
+	states := map[string]*resource.SystemPackageRepositoryState{
+		"simple": {
+			InstallerRef: "apt",
+			Source: resource.SourceConfig{
+				URL:     "https://example.com/repo",
+				Options: map[string]string{},
+			},
+			UpdatedAt: time.Now(),
+		},
+	}
+
+	r := NewSystemPackageRepositoryReconciler()
+	actions := r.Reconcile(repos, states)
+
+	require.Empty(t, actions)
+}
+
 func TestSystemPackageRepositoryReconciler_Upgrade_URLChanged(t *testing.T) {
 	t.Parallel()
 	repo := dockerRepo()

--- a/internal/installer/reconciler/system_package_repository_test.go
+++ b/internal/installer/reconciler/system_package_repository_test.go
@@ -1,0 +1,184 @@
+package reconciler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/terassyi/tomei/internal/resource"
+)
+
+func newSystemPackageRepository(name, installerRef, url, keyURL, keyHash string, options map[string]string) *resource.SystemPackageRepository {
+	return &resource.SystemPackageRepository{
+		BaseResource: resource.BaseResource{
+			APIVersion:   "tomei.terassyi.net/v1beta1",
+			ResourceKind: resource.KindSystemPackageRepository,
+			Metadata:     resource.Metadata{Name: name},
+		},
+		SystemPackageRepositorySpec: &resource.SystemPackageRepositorySpec{
+			InstallerRef: installerRef,
+			Source: resource.SourceConfig{
+				URL:     url,
+				KeyURL:  keyURL,
+				KeyHash: keyHash,
+				Options: options,
+			},
+		},
+	}
+}
+
+func dockerRepo() *resource.SystemPackageRepository {
+	return newSystemPackageRepository(
+		"docker", "apt",
+		"https://download.docker.com/linux/ubuntu",
+		"https://download.docker.com/linux/ubuntu/gpg",
+		"sha256:1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570",
+		map[string]string{"arch": "amd64"},
+	)
+}
+
+func dockerRepoState() *resource.SystemPackageRepositoryState {
+	return &resource.SystemPackageRepositoryState{
+		InstallerRef: "apt",
+		Source: resource.SourceConfig{
+			URL:     "https://download.docker.com/linux/ubuntu",
+			KeyURL:  "https://download.docker.com/linux/ubuntu/gpg",
+			KeyHash: "sha256:1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570",
+			Options: map[string]string{"arch": "amd64"},
+		},
+		InstalledFiles: []string{"/usr/share/keyrings/docker.gpg"},
+		UpdatedAt:      time.Now(),
+	}
+}
+
+func TestSystemPackageRepositoryReconciler_Install(t *testing.T) {
+	t.Parallel()
+	repos := []*resource.SystemPackageRepository{dockerRepo()}
+	states := make(map[string]*resource.SystemPackageRepositoryState)
+
+	r := NewSystemPackageRepositoryReconciler()
+	actions := r.Reconcile(repos, states)
+
+	require.Len(t, actions, 1)
+	assert.Equal(t, resource.ActionInstall, actions[0].Type)
+	assert.Equal(t, "docker", actions[0].Name)
+}
+
+func TestSystemPackageRepositoryReconciler_NoChange(t *testing.T) {
+	t.Parallel()
+	repos := []*resource.SystemPackageRepository{dockerRepo()}
+	states := map[string]*resource.SystemPackageRepositoryState{
+		"docker": dockerRepoState(),
+	}
+
+	r := NewSystemPackageRepositoryReconciler()
+	actions := r.Reconcile(repos, states)
+
+	require.Empty(t, actions)
+}
+
+func TestSystemPackageRepositoryReconciler_Upgrade_URLChanged(t *testing.T) {
+	t.Parallel()
+	repo := dockerRepo()
+	repo.SystemPackageRepositorySpec.Source.URL = "https://download.docker.com/linux/debian"
+
+	repos := []*resource.SystemPackageRepository{repo}
+	states := map[string]*resource.SystemPackageRepositoryState{
+		"docker": dockerRepoState(),
+	}
+
+	r := NewSystemPackageRepositoryReconciler()
+	actions := r.Reconcile(repos, states)
+
+	require.Len(t, actions, 1)
+	assert.Equal(t, resource.ActionUpgrade, actions[0].Type)
+	assert.Contains(t, actions[0].Reason, "source URL changed")
+}
+
+func TestSystemPackageRepositoryReconciler_Upgrade_KeyURLChanged(t *testing.T) {
+	t.Parallel()
+	repo := dockerRepo()
+	repo.SystemPackageRepositorySpec.Source.KeyURL = "https://new-key-server.example.com/gpg"
+
+	repos := []*resource.SystemPackageRepository{repo}
+	states := map[string]*resource.SystemPackageRepositoryState{
+		"docker": dockerRepoState(),
+	}
+
+	r := NewSystemPackageRepositoryReconciler()
+	actions := r.Reconcile(repos, states)
+
+	require.Len(t, actions, 1)
+	assert.Equal(t, resource.ActionUpgrade, actions[0].Type)
+	assert.Contains(t, actions[0].Reason, "source key URL changed")
+}
+
+func TestSystemPackageRepositoryReconciler_Upgrade_KeyHashChanged(t *testing.T) {
+	t.Parallel()
+	repo := dockerRepo()
+	repo.SystemPackageRepositorySpec.Source.KeyHash = "sha256:aaaa"
+
+	repos := []*resource.SystemPackageRepository{repo}
+	states := map[string]*resource.SystemPackageRepositoryState{
+		"docker": dockerRepoState(),
+	}
+
+	r := NewSystemPackageRepositoryReconciler()
+	actions := r.Reconcile(repos, states)
+
+	require.Len(t, actions, 1)
+	assert.Equal(t, resource.ActionUpgrade, actions[0].Type)
+	assert.Contains(t, actions[0].Reason, "source key hash changed")
+}
+
+func TestSystemPackageRepositoryReconciler_Upgrade_OptionsChanged(t *testing.T) {
+	t.Parallel()
+	repo := dockerRepo()
+	repo.SystemPackageRepositorySpec.Source.Options = map[string]string{"arch": "arm64"}
+
+	repos := []*resource.SystemPackageRepository{repo}
+	states := map[string]*resource.SystemPackageRepositoryState{
+		"docker": dockerRepoState(),
+	}
+
+	r := NewSystemPackageRepositoryReconciler()
+	actions := r.Reconcile(repos, states)
+
+	require.Len(t, actions, 1)
+	assert.Equal(t, resource.ActionUpgrade, actions[0].Type)
+	assert.Contains(t, actions[0].Reason, "source options changed")
+}
+
+func TestSystemPackageRepositoryReconciler_Upgrade_InstallerRefChanged(t *testing.T) {
+	t.Parallel()
+	repo := dockerRepo()
+	repo.SystemPackageRepositorySpec.InstallerRef = "dnf"
+
+	repos := []*resource.SystemPackageRepository{repo}
+	states := map[string]*resource.SystemPackageRepositoryState{
+		"docker": dockerRepoState(),
+	}
+
+	r := NewSystemPackageRepositoryReconciler()
+	actions := r.Reconcile(repos, states)
+
+	require.Len(t, actions, 1)
+	assert.Equal(t, resource.ActionUpgrade, actions[0].Type)
+	assert.Contains(t, actions[0].Reason, "installerRef changed")
+}
+
+func TestSystemPackageRepositoryReconciler_Remove(t *testing.T) {
+	t.Parallel()
+	repos := []*resource.SystemPackageRepository{} // empty spec
+	states := map[string]*resource.SystemPackageRepositoryState{
+		"docker": dockerRepoState(),
+	}
+
+	r := NewSystemPackageRepositoryReconciler()
+	actions := r.Reconcile(repos, states)
+
+	require.Len(t, actions, 1)
+	assert.Equal(t, resource.ActionRemove, actions[0].Type)
+	assert.Equal(t, "docker", actions[0].Name)
+}

--- a/internal/installer/reconciler/system_package_set.go
+++ b/internal/installer/reconciler/system_package_set.go
@@ -1,6 +1,7 @@
 package reconciler
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/terassyi/tomei/internal/resource"
@@ -30,6 +31,7 @@ func NewSystemPackageSetReconciler() *Reconciler[*resource.SystemPackageSet, *re
 }
 
 // packageDiff returns packages added to and removed from the spec compared to state.
+// Both inputs are treated as sets; duplicates are ignored and output is sorted.
 func packageDiff(spec, state []string) (added, removed []string) {
 	specSet := make(map[string]bool, len(spec))
 	for _, p := range spec {
@@ -40,16 +42,18 @@ func packageDiff(spec, state []string) (added, removed []string) {
 		stateSet[p] = true
 	}
 
-	for _, p := range spec {
+	for p := range specSet {
 		if !stateSet[p] {
 			added = append(added, p)
 		}
 	}
-	for _, p := range state {
+	for p := range stateSet {
 		if !specSet[p] {
 			removed = append(removed, p)
 		}
 	}
+	slices.Sort(added)
+	slices.Sort(removed)
 	return added, removed
 }
 

--- a/internal/installer/reconciler/system_package_set.go
+++ b/internal/installer/reconciler/system_package_set.go
@@ -1,0 +1,66 @@
+package reconciler
+
+import (
+	"strings"
+
+	"github.com/terassyi/tomei/internal/resource"
+)
+
+// SystemPackageSetComparator returns a comparator for SystemPackageSet resources.
+// It detects changes in the package list (order-insensitive) and installer/repository references.
+func SystemPackageSetComparator() Comparator[*resource.SystemPackageSet, *resource.SystemPackageSetState] {
+	return func(res *resource.SystemPackageSet, state *resource.SystemPackageSetState) (bool, string) {
+		spec := res.SystemPackageSetSpec
+		if spec.InstallerRef != state.InstallerRef {
+			return true, "installerRef changed: " + state.InstallerRef + " -> " + spec.InstallerRef
+		}
+		if spec.RepositoryRef != state.RepositoryRef {
+			return true, "repositoryRef changed: " + state.RepositoryRef + " -> " + spec.RepositoryRef
+		}
+		if added, removed := packageDiff(spec.Packages, state.Packages); len(added) > 0 || len(removed) > 0 {
+			return true, formatPackageDiffReason(added, removed)
+		}
+		return false, ""
+	}
+}
+
+// NewSystemPackageSetReconciler creates a new Reconciler for SystemPackageSet resources.
+func NewSystemPackageSetReconciler() *Reconciler[*resource.SystemPackageSet, *resource.SystemPackageSetState] {
+	return New(SystemPackageSetComparator())
+}
+
+// packageDiff returns packages added to and removed from the spec compared to state.
+func packageDiff(spec, state []string) (added, removed []string) {
+	specSet := make(map[string]bool, len(spec))
+	for _, p := range spec {
+		specSet[p] = true
+	}
+	stateSet := make(map[string]bool, len(state))
+	for _, p := range state {
+		stateSet[p] = true
+	}
+
+	for _, p := range spec {
+		if !stateSet[p] {
+			added = append(added, p)
+		}
+	}
+	for _, p := range state {
+		if !specSet[p] {
+			removed = append(removed, p)
+		}
+	}
+	return added, removed
+}
+
+// formatPackageDiffReason formats added/removed packages into a human-readable reason string.
+func formatPackageDiffReason(added, removed []string) string {
+	var parts []string
+	for _, p := range added {
+		parts = append(parts, "+"+p)
+	}
+	for _, p := range removed {
+		parts = append(parts, "-"+p)
+	}
+	return "packages changed: " + strings.Join(parts, ", ")
+}

--- a/internal/installer/reconciler/system_package_set_test.go
+++ b/internal/installer/reconciler/system_package_set_test.go
@@ -1,0 +1,193 @@
+package reconciler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/terassyi/tomei/internal/resource"
+)
+
+func newSystemPackageSet(name, installerRef, repoRef string, packages []string) *resource.SystemPackageSet {
+	return &resource.SystemPackageSet{
+		BaseResource: resource.BaseResource{
+			APIVersion:   "tomei.terassyi.net/v1beta1",
+			ResourceKind: resource.KindSystemPackageSet,
+			Metadata:     resource.Metadata{Name: name},
+		},
+		SystemPackageSetSpec: &resource.SystemPackageSetSpec{
+			InstallerRef:  installerRef,
+			RepositoryRef: repoRef,
+			Packages:      packages,
+		},
+	}
+}
+
+func dockerPackageSet() *resource.SystemPackageSet {
+	return newSystemPackageSet("docker-packages", "apt", "docker",
+		[]string{"docker-ce", "docker-ce-cli", "containerd.io"},
+	)
+}
+
+func dockerPackageSetState() *resource.SystemPackageSetState {
+	return &resource.SystemPackageSetState{
+		InstallerRef:  "apt",
+		RepositoryRef: "docker",
+		Packages:      []string{"docker-ce", "docker-ce-cli", "containerd.io"},
+		InstalledVersions: map[string]string{
+			"docker-ce":     "5:24.0.7-1~ubuntu.22.04~jammy",
+			"docker-ce-cli": "5:24.0.7-1~ubuntu.22.04~jammy",
+			"containerd.io": "1.6.28-1",
+		},
+		UpdatedAt: time.Now(),
+	}
+}
+
+func TestSystemPackageSetReconciler_Install(t *testing.T) {
+	t.Parallel()
+	sets := []*resource.SystemPackageSet{dockerPackageSet()}
+	states := make(map[string]*resource.SystemPackageSetState)
+
+	r := NewSystemPackageSetReconciler()
+	actions := r.Reconcile(sets, states)
+
+	require.Len(t, actions, 1)
+	assert.Equal(t, resource.ActionInstall, actions[0].Type)
+	assert.Equal(t, "docker-packages", actions[0].Name)
+}
+
+func TestSystemPackageSetReconciler_NoChange(t *testing.T) {
+	t.Parallel()
+	sets := []*resource.SystemPackageSet{dockerPackageSet()}
+	states := map[string]*resource.SystemPackageSetState{
+		"docker-packages": dockerPackageSetState(),
+	}
+
+	r := NewSystemPackageSetReconciler()
+	actions := r.Reconcile(sets, states)
+
+	require.Empty(t, actions)
+}
+
+func TestSystemPackageSetReconciler_NoChange_Reordered(t *testing.T) {
+	t.Parallel()
+	set := dockerPackageSet()
+	set.SystemPackageSetSpec.Packages = []string{"containerd.io", "docker-ce-cli", "docker-ce"}
+
+	sets := []*resource.SystemPackageSet{set}
+	states := map[string]*resource.SystemPackageSetState{
+		"docker-packages": dockerPackageSetState(),
+	}
+
+	r := NewSystemPackageSetReconciler()
+	actions := r.Reconcile(sets, states)
+
+	require.Empty(t, actions)
+}
+
+func TestSystemPackageSetReconciler_Upgrade_PackageAdded(t *testing.T) {
+	t.Parallel()
+	set := dockerPackageSet()
+	set.SystemPackageSetSpec.Packages = append(set.SystemPackageSetSpec.Packages, "docker-buildx-plugin")
+
+	sets := []*resource.SystemPackageSet{set}
+	states := map[string]*resource.SystemPackageSetState{
+		"docker-packages": dockerPackageSetState(),
+	}
+
+	r := NewSystemPackageSetReconciler()
+	actions := r.Reconcile(sets, states)
+
+	require.Len(t, actions, 1)
+	assert.Equal(t, resource.ActionUpgrade, actions[0].Type)
+	assert.Contains(t, actions[0].Reason, "+docker-buildx-plugin")
+}
+
+func TestSystemPackageSetReconciler_Upgrade_PackageRemoved(t *testing.T) {
+	t.Parallel()
+	set := dockerPackageSet()
+	set.SystemPackageSetSpec.Packages = []string{"docker-ce", "docker-ce-cli"} // removed containerd.io
+
+	sets := []*resource.SystemPackageSet{set}
+	states := map[string]*resource.SystemPackageSetState{
+		"docker-packages": dockerPackageSetState(),
+	}
+
+	r := NewSystemPackageSetReconciler()
+	actions := r.Reconcile(sets, states)
+
+	require.Len(t, actions, 1)
+	assert.Equal(t, resource.ActionUpgrade, actions[0].Type)
+	assert.Contains(t, actions[0].Reason, "-containerd.io")
+}
+
+func TestSystemPackageSetReconciler_Upgrade_PackageAddedAndRemoved(t *testing.T) {
+	t.Parallel()
+	set := dockerPackageSet()
+	set.SystemPackageSetSpec.Packages = []string{"docker-ce", "docker-ce-cli", "docker-buildx-plugin"}
+
+	sets := []*resource.SystemPackageSet{set}
+	states := map[string]*resource.SystemPackageSetState{
+		"docker-packages": dockerPackageSetState(),
+	}
+
+	r := NewSystemPackageSetReconciler()
+	actions := r.Reconcile(sets, states)
+
+	require.Len(t, actions, 1)
+	assert.Equal(t, resource.ActionUpgrade, actions[0].Type)
+	assert.Contains(t, actions[0].Reason, "+docker-buildx-plugin")
+	assert.Contains(t, actions[0].Reason, "-containerd.io")
+}
+
+func TestSystemPackageSetReconciler_Upgrade_InstallerRefChanged(t *testing.T) {
+	t.Parallel()
+	set := dockerPackageSet()
+	set.SystemPackageSetSpec.InstallerRef = "dnf"
+
+	sets := []*resource.SystemPackageSet{set}
+	states := map[string]*resource.SystemPackageSetState{
+		"docker-packages": dockerPackageSetState(),
+	}
+
+	r := NewSystemPackageSetReconciler()
+	actions := r.Reconcile(sets, states)
+
+	require.Len(t, actions, 1)
+	assert.Equal(t, resource.ActionUpgrade, actions[0].Type)
+	assert.Contains(t, actions[0].Reason, "installerRef changed")
+}
+
+func TestSystemPackageSetReconciler_Upgrade_RepositoryRefChanged(t *testing.T) {
+	t.Parallel()
+	set := dockerPackageSet()
+	set.SystemPackageSetSpec.RepositoryRef = "docker-new"
+
+	sets := []*resource.SystemPackageSet{set}
+	states := map[string]*resource.SystemPackageSetState{
+		"docker-packages": dockerPackageSetState(),
+	}
+
+	r := NewSystemPackageSetReconciler()
+	actions := r.Reconcile(sets, states)
+
+	require.Len(t, actions, 1)
+	assert.Equal(t, resource.ActionUpgrade, actions[0].Type)
+	assert.Contains(t, actions[0].Reason, "repositoryRef changed")
+}
+
+func TestSystemPackageSetReconciler_Remove(t *testing.T) {
+	t.Parallel()
+	sets := []*resource.SystemPackageSet{} // empty spec
+	states := map[string]*resource.SystemPackageSetState{
+		"docker-packages": dockerPackageSetState(),
+	}
+
+	r := NewSystemPackageSetReconciler()
+	actions := r.Reconcile(sets, states)
+
+	require.Len(t, actions, 1)
+	assert.Equal(t, resource.ActionRemove, actions[0].Type)
+	assert.Equal(t, "docker-packages", actions[0].Name)
+}


### PR DESCRIPTION
Add three reconcilers for system resource types using the existing
generic Reconciler[R, S] + Comparator pattern:

- SystemInstallerReconciler: upgrade is always no-op (OS-managed); install/remove actions are still emitted
- SystemPackageRepositoryReconciler: detects changes in InstallerRef and Source fields (URL, KeyURL, KeyHash, Options)
- SystemPackageSetReconciler: detects changes in InstallerRef, RepositoryRef, and set-based package list diff