### PR TITLE
feat(engine): add SystemEngine for system resource execution (#166)

### DIFF
--- a/internal/installer/engine/engine.go
+++ b/internal/installer/engine/engine.go
@@ -238,6 +238,12 @@ func (e *Engine) SkippedPrivileged() int {
 	return e.skippedPrivileged
 }
 
+// eventEmitter is an unexported interface for emitting engine events.
+// Both Engine and SystemEngine satisfy this interface.
+type eventEmitter interface {
+	emitEvent(event Event)
+}
+
 // emitEvent emits an event to the handler if set.
 func (e *Engine) emitEvent(event Event) {
 	if e.eventHandler != nil {
@@ -1331,7 +1337,7 @@ func collectRemovalNodes[R resource.Resource, S resource.State](
 // executeRemovals iterates over actions, executing removals with PhaseRemove events.
 func executeRemovals[R resource.Resource, S resource.State](
 	ctx context.Context,
-	e *Engine,
+	emitter eventEmitter,
 	kind resource.Kind,
 	actions []reconciler.Action[R, S],
 	exec *executor.Executor[R, S],
@@ -1341,7 +1347,7 @@ func executeRemovals[R resource.Resource, S resource.State](
 		if action.Type != resource.ActionRemove {
 			continue
 		}
-		e.emitEvent(Event{
+		emitter.emitEvent(Event{
 			Type:   EventStart,
 			Phase:  PhaseRemove,
 			Kind:   kind,
@@ -1349,7 +1355,7 @@ func executeRemovals[R resource.Resource, S resource.State](
 			Action: action.Type,
 		})
 		if err := exec.Execute(ctx, action); err != nil {
-			e.emitEvent(Event{
+			emitter.emitEvent(Event{
 				Type:   EventError,
 				Phase:  PhaseRemove,
 				Kind:   kind,
@@ -1359,7 +1365,7 @@ func executeRemovals[R resource.Resource, S resource.State](
 			})
 			return fmt.Errorf("failed to remove %s %s: %w", kind, action.Name, err)
 		}
-		e.emitEvent(Event{
+		emitter.emitEvent(Event{
 			Type:   EventComplete,
 			Phase:  PhaseRemove,
 			Kind:   kind,

--- a/internal/installer/engine/system_engine.go
+++ b/internal/installer/engine/system_engine.go
@@ -342,13 +342,29 @@ func (e *SystemEngine) handleSystemRemovals(
 		LayerNodes: layerNodes,
 	})
 
-	// Execute removals in reverse dependency order
+	// Execute removals in reverse dependency order.
+	// Flush after each batch so that successfully removed resources are persisted
+	// even if a later batch fails — preventing state drift.
 	if err := executeRemovals(ctx, e, resource.KindSystemPackageSet, packageActions, e.packageExecutor, totalActions); err != nil {
+		if flushErr := e.stateCache.Flush(); flushErr != nil {
+			slog.Warn("failed to flush state after package removal error", "error", flushErr)
+		}
 		return err
 	}
+	if err := e.stateCache.Flush(); err != nil {
+		return fmt.Errorf("failed to flush state after package removals: %w", err)
+	}
+
 	if err := executeRemovals(ctx, e, resource.KindSystemPackageRepository, repoActions, e.repoExecutor, totalActions); err != nil {
+		if flushErr := e.stateCache.Flush(); flushErr != nil {
+			slog.Warn("failed to flush state after repo removal error", "error", flushErr)
+		}
 		return err
 	}
+	if err := e.stateCache.Flush(); err != nil {
+		return fmt.Errorf("failed to flush state after repo removals: %w", err)
+	}
+
 	return executeRemovals(ctx, e, resource.KindSystemInstaller, installerActions, e.installerExecutor, totalActions)
 }
 

--- a/internal/installer/engine/system_engine.go
+++ b/internal/installer/engine/system_engine.go
@@ -164,10 +164,20 @@ func (e *SystemEngine) Apply(ctx context.Context, resources []resource.Resource)
 		}
 	}
 
+	// flushAndReturn is a helper that flushes the state cache (best-effort)
+	// before returning an error, so that successfully applied changes are
+	// persisted even when a later operation fails or the context is canceled.
+	flushAndReturn := func(err error) error {
+		if flushErr := e.stateCache.Flush(); flushErr != nil {
+			slog.Warn("failed to flush state before returning error", "error", flushErr)
+		}
+		return err
+	}
+
 	// Execute layer by layer (sequential within each layer)
 	for i, layer := range layers {
 		if ctx.Err() != nil {
-			return ctx.Err()
+			return flushAndReturn(ctx.Err())
 		}
 
 		slog.Debug("executing system layer", "layer", i, "nodes", len(layer.Nodes))
@@ -182,7 +192,7 @@ func (e *SystemEngine) Apply(ctx context.Context, resources []resource.Resource)
 
 		for _, node := range layer.Nodes {
 			if ctx.Err() != nil {
-				return ctx.Err()
+				return flushAndReturn(ctx.Err())
 			}
 
 			if err := e.executeSystemNode(ctx, node, resourceMap, &totalActions); err != nil {
@@ -202,7 +212,7 @@ func (e *SystemEngine) Apply(ctx context.Context, resources []resource.Resource)
 
 	// Handle removals: resources in state but not in config
 	if ctx.Err() != nil {
-		return ctx.Err()
+		return flushAndReturn(ctx.Err())
 	}
 	if err := e.handleSystemRemovals(ctx, installers, repos, packages, &totalActions); err != nil {
 		return err
@@ -365,7 +375,13 @@ func (e *SystemEngine) handleSystemRemovals(
 		return fmt.Errorf("failed to flush state after repo removals: %w", err)
 	}
 
-	return executeRemovals(ctx, e, resource.KindSystemInstaller, installerActions, e.installerExecutor, totalActions)
+	if err := executeRemovals(ctx, e, resource.KindSystemInstaller, installerActions, e.installerExecutor, totalActions); err != nil {
+		if flushErr := e.stateCache.Flush(); flushErr != nil {
+			slog.Warn("failed to flush state after installer removal error", "error", flushErr)
+		}
+		return err
+	}
+	return nil
 }
 
 // validateSystemRemovalDeps checks that no remaining resources reference resources being removed.

--- a/internal/installer/engine/system_engine.go
+++ b/internal/installer/engine/system_engine.go
@@ -381,6 +381,9 @@ func (e *SystemEngine) handleSystemRemovals(
 		}
 		return err
 	}
+	if err := e.stateCache.Flush(); err != nil {
+		return fmt.Errorf("failed to flush state after installer removals: %w", err)
+	}
 	return nil
 }
 

--- a/internal/installer/engine/system_engine.go
+++ b/internal/installer/engine/system_engine.go
@@ -1,0 +1,485 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/terassyi/tomei/internal/graph"
+	"github.com/terassyi/tomei/internal/installer/executor"
+	"github.com/terassyi/tomei/internal/installer/reconciler"
+	"github.com/terassyi/tomei/internal/resource"
+	"github.com/terassyi/tomei/internal/state"
+)
+
+// SystemInstallerAction is an alias for system-installer-specific action type.
+type SystemInstallerAction = reconciler.Action[*resource.SystemInstaller, *resource.SystemInstallerState]
+
+// SystemPackageRepositoryAction is an alias for system-package-repository-specific action type.
+type SystemPackageRepositoryAction = reconciler.Action[*resource.SystemPackageRepository, *resource.SystemPackageRepositoryState]
+
+// SystemPackageSetAction is an alias for system-package-set-specific action type.
+type SystemPackageSetAction = reconciler.Action[*resource.SystemPackageSet, *resource.SystemPackageSetState]
+
+// SystemEngine orchestrates the apply process for system-privilege resources.
+// It follows the same pattern as Engine but operates on state.SystemState
+// and handles SystemInstaller, SystemPackageRepository, and SystemPackageSet resources.
+type SystemEngine struct {
+	store      *state.Store[state.SystemState]
+	stateCache *executor.StateCache[state.SystemState]
+
+	installerStore executor.StateStore[*resource.SystemInstallerState]
+	repoStore      executor.StateStore[*resource.SystemPackageRepositoryState]
+	packageStore   executor.StateStore[*resource.SystemPackageSetState]
+
+	installerInstaller executor.Installer[*resource.SystemInstaller, *resource.SystemInstallerState]
+	repoInstaller      executor.Installer[*resource.SystemPackageRepository, *resource.SystemPackageRepositoryState]
+	packageInstaller   executor.Installer[*resource.SystemPackageSet, *resource.SystemPackageSetState]
+
+	installerReconciler *reconciler.Reconciler[*resource.SystemInstaller, *resource.SystemInstallerState]
+	repoReconciler      *reconciler.Reconciler[*resource.SystemPackageRepository, *resource.SystemPackageRepositoryState]
+	packageReconciler   *reconciler.Reconciler[*resource.SystemPackageSet, *resource.SystemPackageSetState]
+
+	installerExecutor *executor.Executor[*resource.SystemInstaller, *resource.SystemInstallerState]
+	repoExecutor      *executor.Executor[*resource.SystemPackageRepository, *resource.SystemPackageRepositoryState]
+	packageExecutor   *executor.Executor[*resource.SystemPackageSet, *resource.SystemPackageSetState]
+
+	privilegeHandler PrivilegeHandler
+	eventHandler     EventHandler
+}
+
+// NewSystemEngine creates a new SystemEngine.
+func NewSystemEngine(
+	installerInstaller executor.Installer[*resource.SystemInstaller, *resource.SystemInstallerState],
+	repoInstaller executor.Installer[*resource.SystemPackageRepository, *resource.SystemPackageRepositoryState],
+	packageInstaller executor.Installer[*resource.SystemPackageSet, *resource.SystemPackageSetState],
+	store *state.Store[state.SystemState],
+) *SystemEngine {
+	sc := executor.NewStateCache[state.SystemState](store)
+	installerStore := executor.NewSystemInstallerStore(sc)
+	repoStore := executor.NewSystemPackageRepositoryStore(sc)
+	packageStore := executor.NewSystemPackageSetStore(sc)
+	return &SystemEngine{
+		store:               store,
+		stateCache:          sc,
+		installerStore:      installerStore,
+		repoStore:           repoStore,
+		packageStore:        packageStore,
+		installerInstaller:  installerInstaller,
+		repoInstaller:       repoInstaller,
+		packageInstaller:    packageInstaller,
+		installerReconciler: reconciler.NewSystemInstallerReconciler(),
+		repoReconciler:      reconciler.NewSystemPackageRepositoryReconciler(),
+		packageReconciler:   reconciler.NewSystemPackageSetReconciler(),
+		installerExecutor:   executor.New(resource.KindSystemInstaller, installerInstaller, installerStore),
+		repoExecutor:        executor.New(resource.KindSystemPackageRepository, repoInstaller, repoStore),
+		packageExecutor:     executor.New(resource.KindSystemPackageSet, packageInstaller, packageStore),
+	}
+}
+
+// SetPrivilegeHandler sets the handler used to indicate that privileged
+// operations are allowed. SystemEngine.Apply does not call Acquire or Release;
+// the privilege lifecycle is managed by the caller (cmd layer). Presence
+// of a handler signals the engine that privileged operations may proceed.
+func (e *SystemEngine) SetPrivilegeHandler(handler PrivilegeHandler) {
+	e.privilegeHandler = handler
+}
+
+// SetEventHandler sets a callback for engine events.
+func (e *SystemEngine) SetEventHandler(handler EventHandler) {
+	e.eventHandler = handler
+}
+
+// emitEvent emits an event to the handler if set.
+func (e *SystemEngine) emitEvent(event Event) {
+	if e.eventHandler != nil {
+		e.eventHandler(event)
+	}
+}
+
+// Apply reconciles system resources with state and executes actions using DAG-based ordering.
+func (e *SystemEngine) Apply(ctx context.Context, resources []resource.Resource) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	// Extract system resources
+	installers := extractByKind[*resource.SystemInstaller](resources)
+	repos := extractByKind[*resource.SystemPackageRepository](resources)
+	packages := extractByKind[*resource.SystemPackageSet](resources)
+
+	slog.Debug("applying system configuration",
+		"installers", len(installers), "repos", len(repos), "packages", len(packages))
+
+	// Build dependency graph
+	resolver := graph.NewResolver()
+	for _, res := range resources {
+		if resource.IsSystemKind(res.Kind()) {
+			resolver.AddResource(res)
+		}
+	}
+
+	layers, err := resolver.Resolve()
+	if err != nil {
+		return fmt.Errorf("failed to resolve system resource dependencies: %w", err)
+	}
+
+	slog.Debug("system dependency resolution completed", "layers", len(layers))
+
+	// System resources require privilege escalation
+	if e.privilegeHandler == nil {
+		return fmt.Errorf("privilege handler is required for system resource operations")
+	}
+
+	// Acquire lock for execution
+	if err := e.store.Lock(); err != nil {
+		return fmt.Errorf("failed to acquire system state lock: %w", err)
+	}
+	defer func() { _ = e.store.Unlock() }()
+
+	// Load current state
+	st, err := e.store.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load system state: %w", err)
+	}
+
+	// Backup state before changes (non-fatal if fails)
+	if err := state.CreateBackup(e.store); err != nil {
+		slog.Warn("failed to create system state backup", "error", err)
+	}
+
+	// Initialize the in-memory state cache for batch writes
+	e.stateCache.Init(st)
+
+	// Build resource map for quick lookup
+	resourceMap := buildResourceMap(resources)
+
+	totalActions := 0
+
+	// Build node names for all layers (for event reporting)
+	allLayerNodes := make([][]string, len(layers))
+	for i, layer := range layers {
+		for _, node := range layer.Nodes {
+			allLayerNodes[i] = append(allLayerNodes[i], node.ID.String())
+		}
+	}
+
+	// Execute layer by layer (sequential within each layer)
+	for i, layer := range layers {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		slog.Debug("executing system layer", "layer", i, "nodes", len(layer.Nodes))
+
+		e.emitEvent(Event{
+			Type:          EventLayerStart,
+			Layer:         i,
+			TotalLayers:   len(layers),
+			LayerNodes:    allLayerNodes[i],
+			AllLayerNodes: allLayerNodes,
+		})
+
+		for _, node := range layer.Nodes {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+
+			if err := e.executeSystemNode(ctx, node, resourceMap, &totalActions); err != nil {
+				// Flush what we have before returning
+				if flushErr := e.stateCache.Flush(); flushErr != nil {
+					slog.Warn("failed to flush state after error", "error", flushErr)
+				}
+				return err
+			}
+		}
+
+		// Flush cached state changes to disk after each layer
+		if err := e.stateCache.Flush(); err != nil {
+			return fmt.Errorf("failed to flush system state after layer %d: %w", i, err)
+		}
+	}
+
+	// Handle removals: resources in state but not in config
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if err := e.handleSystemRemovals(ctx, installers, repos, packages, &totalActions); err != nil {
+		return err
+	}
+
+	// Final flush to persist any changes from removals
+	if err := e.stateCache.Flush(); err != nil {
+		return fmt.Errorf("failed to flush final system state: %w", err)
+	}
+
+	slog.Debug("system apply completed", "total_actions", totalActions)
+	return nil
+}
+
+// executeSystemNode dispatches a single DAG node to the appropriate handler.
+func (e *SystemEngine) executeSystemNode(
+	ctx context.Context,
+	node *graph.Node,
+	resourceMap map[string]resource.Resource,
+	totalActions *int,
+) error {
+	res, ok := resourceMap[graph.NewNodeID(node.Kind, node.Name).String()]
+	if !ok {
+		slog.Debug("skipping system node not in resources", "kind", node.Kind, "name", node.Name)
+		return nil
+	}
+
+	switch node.Kind {
+	case resource.KindSystemInstaller:
+		return reconcileAndExecute(ctx, e, node.Kind,
+			res.(*resource.SystemInstaller), e.installerStore, e.installerReconciler, e.installerExecutor, totalActions)
+	case resource.KindSystemPackageRepository:
+		return reconcileAndExecute(ctx, e, node.Kind,
+			res.(*resource.SystemPackageRepository), e.repoStore, e.repoReconciler, e.repoExecutor, totalActions)
+	case resource.KindSystemPackageSet:
+		return reconcileAndExecute(ctx, e, node.Kind,
+			res.(*resource.SystemPackageSet), e.packageStore, e.packageReconciler, e.packageExecutor, totalActions)
+	default:
+		slog.Debug("skipping non-system resource kind", "kind", node.Kind, "name", node.Name)
+		return nil
+	}
+}
+
+// reconcileAndExecute reconciles a single resource against its state and executes the resulting action.
+// It is a generic function shared by all three system resource types.
+func reconcileAndExecute[R resource.Resource, S resource.State](
+	ctx context.Context,
+	emitter eventEmitter,
+	kind resource.Kind,
+	res R,
+	store executor.StateStore[S],
+	rec *reconciler.Reconciler[R, S],
+	exec *executor.Executor[R, S],
+	totalActions *int,
+) error {
+	singleState := make(map[string]S)
+	st, exists, err := store.Load(res.Name())
+	if err != nil {
+		return fmt.Errorf("failed to load %s state for %s: %w", kind, res.Name(), err)
+	}
+	if exists {
+		singleState[res.Name()] = st
+	}
+
+	actions := rec.Reconcile([]R{res}, singleState)
+	if len(actions) == 0 {
+		return nil
+	}
+
+	action := actions[0]
+	if action.Type == resource.ActionNone {
+		return nil
+	}
+
+	emitter.emitEvent(Event{
+		Type:   EventStart,
+		Kind:   kind,
+		Name:   action.Name,
+		Action: action.Type,
+	})
+
+	if err := exec.Execute(ctx, action); err != nil {
+		emitter.emitEvent(Event{
+			Type:   EventError,
+			Kind:   kind,
+			Name:   action.Name,
+			Action: action.Type,
+			Error:  err,
+		})
+		return fmt.Errorf("failed to execute action %s for %s %s: %w", action.Type, kind, action.Name, err)
+	}
+
+	emitter.emitEvent(Event{
+		Type:   EventComplete,
+		Kind:   kind,
+		Name:   action.Name,
+		Action: action.Type,
+	})
+
+	*totalActions++
+	return nil
+}
+
+// handleSystemRemovals handles removal of system resources that are in state but not in config.
+// Removals happen in reverse dependency order: packages → repos → installers.
+func (e *SystemEngine) handleSystemRemovals(
+	ctx context.Context,
+	installers []*resource.SystemInstaller,
+	repos []*resource.SystemPackageRepository,
+	packages []*resource.SystemPackageSet,
+	totalActions *int,
+) error {
+	st := e.stateCache.Snapshot()
+
+	packageActions := e.packageReconciler.Reconcile(packages, st.SystemPackages)
+	repoActions := e.repoReconciler.Reconcile(repos, st.SystemPackageRepositories)
+	installerActions := e.installerReconciler.Reconcile(installers, st.SystemInstallers)
+
+	// Validate removal dependencies
+	if err := validateSystemRemovalDeps(installerActions, repoActions, repos, packages); err != nil {
+		return err
+	}
+
+	// Collect all removal node names for the layer header
+	var layerNodes []string
+	layerNodes = collectRemovalNodes(layerNodes, resource.KindSystemPackageSet, packageActions)
+	layerNodes = collectRemovalNodes(layerNodes, resource.KindSystemPackageRepository, repoActions)
+	layerNodes = collectRemovalNodes(layerNodes, resource.KindSystemInstaller, installerActions)
+
+	if len(layerNodes) == 0 {
+		return nil
+	}
+
+	e.emitEvent(Event{
+		Type:       EventLayerStart,
+		Phase:      PhaseRemove,
+		LayerNodes: layerNodes,
+	})
+
+	// Execute removals in reverse dependency order
+	if err := executeRemovals(ctx, e, resource.KindSystemPackageSet, packageActions, e.packageExecutor, totalActions); err != nil {
+		return err
+	}
+	if err := executeRemovals(ctx, e, resource.KindSystemPackageRepository, repoActions, e.repoExecutor, totalActions); err != nil {
+		return err
+	}
+	return executeRemovals(ctx, e, resource.KindSystemInstaller, installerActions, e.installerExecutor, totalActions)
+}
+
+// validateSystemRemovalDeps checks that no remaining resources reference resources being removed.
+func validateSystemRemovalDeps(
+	installerActions []SystemInstallerAction,
+	repoActions []SystemPackageRepositoryAction,
+	remainingRepos []*resource.SystemPackageRepository,
+	remainingPackages []*resource.SystemPackageSet,
+) error {
+	// Check installer removals
+	var installerRemovals []string
+	for _, action := range installerActions {
+		if action.Type == resource.ActionRemove {
+			installerRemovals = append(installerRemovals, action.Name)
+		}
+	}
+	if len(installerRemovals) > 0 {
+		if err := checkSystemInstallerRemovalDeps(installerRemovals, remainingRepos, remainingPackages); err != nil {
+			return err
+		}
+	}
+
+	// Check repo removals
+	var repoRemovals []string
+	for _, action := range repoActions {
+		if action.Type == resource.ActionRemove {
+			repoRemovals = append(repoRemovals, action.Name)
+		}
+	}
+	if len(repoRemovals) > 0 {
+		if err := checkSystemRepoRemovalDeps(repoRemovals, remainingPackages); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// checkSystemInstallerRemovalDeps validates that no remaining repositories or package sets
+// reference a system installer being removed.
+func checkSystemInstallerRemovalDeps(
+	installerRemovals []string,
+	remainingRepos []*resource.SystemPackageRepository,
+	remainingPackages []*resource.SystemPackageSet,
+) error {
+	removals := make(map[string]bool, len(installerRemovals))
+	for _, name := range installerRemovals {
+		removals[name] = true
+	}
+
+	for _, repo := range remainingRepos {
+		if removals[repo.SystemPackageRepositorySpec.InstallerRef] {
+			return fmt.Errorf(
+				"cannot remove SystemInstaller %q: SystemPackageRepository %q still references it",
+				repo.SystemPackageRepositorySpec.InstallerRef, repo.Name(),
+			)
+		}
+	}
+	for _, pkg := range remainingPackages {
+		if removals[pkg.SystemPackageSetSpec.InstallerRef] {
+			return fmt.Errorf(
+				"cannot remove SystemInstaller %q: SystemPackageSet %q still references it",
+				pkg.SystemPackageSetSpec.InstallerRef, pkg.Name(),
+			)
+		}
+	}
+	return nil
+}
+
+// checkSystemRepoRemovalDeps validates that no remaining package sets
+// reference a system package repository being removed.
+func checkSystemRepoRemovalDeps(
+	repoRemovals []string,
+	remainingPackages []*resource.SystemPackageSet,
+) error {
+	removals := make(map[string]bool, len(repoRemovals))
+	for _, name := range repoRemovals {
+		removals[name] = true
+	}
+
+	for _, pkg := range remainingPackages {
+		if pkg.SystemPackageSetSpec.RepositoryRef != "" && removals[pkg.SystemPackageSetSpec.RepositoryRef] {
+			return fmt.Errorf(
+				"cannot remove SystemPackageRepository %q: SystemPackageSet %q still references it",
+				pkg.SystemPackageSetSpec.RepositoryRef, pkg.Name(),
+			)
+		}
+	}
+	return nil
+}
+
+// PlanAll returns system installer, repository, and package set actions
+// based on resources and current state.
+func (e *SystemEngine) PlanAll(ctx context.Context, resources []resource.Resource) (
+	[]SystemInstallerAction,
+	[]SystemPackageRepositoryAction,
+	[]SystemPackageSetAction,
+	error,
+) {
+	slog.Debug("planning system configuration", "resources", len(resources))
+
+	installers := extractByKind[*resource.SystemInstaller](resources)
+	repos := extractByKind[*resource.SystemPackageRepository](resources)
+	packages := extractByKind[*resource.SystemPackageSet](resources)
+
+	// Acquire lock for state read
+	if err := e.store.Lock(); err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to acquire system state lock: %w", err)
+	}
+	defer func() { _ = e.store.Unlock() }()
+
+	st, err := e.store.Load()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to load system state: %w", err)
+	}
+
+	// Reconcile each resource type
+	installerActions := e.installerReconciler.Reconcile(installers, st.SystemInstallers)
+	repoActions := e.repoReconciler.Reconcile(repos, st.SystemPackageRepositories)
+	packageActions := e.packageReconciler.Reconcile(packages, st.SystemPackages)
+
+	// Validate removal dependencies
+	if err := validateSystemRemovalDeps(installerActions, repoActions, repos, packages); err != nil {
+		return nil, nil, nil, err
+	}
+
+	slog.Debug("system plan completed",
+		"installerActions", len(installerActions),
+		"repoActions", len(repoActions),
+		"packageActions", len(packageActions),
+	)
+	return installerActions, repoActions, packageActions, nil
+}

--- a/internal/installer/engine/system_engine_test.go
+++ b/internal/installer/engine/system_engine_test.go
@@ -797,3 +797,57 @@ func TestSystemEngine_Apply_RemoveError(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, st.SystemPackages["failing-pkg"], "failed removal should leave state intact")
 }
+
+func TestSystemEngine_Apply_RemoveErrorFlushesSuccessful(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	store, err := state.NewStore[state.SystemState](stateDir)
+	require.NoError(t, err)
+
+	// Pre-populate state: one package set (will be removed successfully)
+	// and one repo (removal will fail).
+	// Removal order is packages → repos → installers, so packages should
+	// be removed and flushed before the repo removal fails.
+	require.NoError(t, store.Lock())
+	st := state.NewSystemState()
+	st.SystemPackages["good-pkg"] = &resource.SystemPackageSetState{
+		InstallerRef: "apt",
+		Packages:     []string{"a"},
+		UpdatedAt:    time.Now(),
+	}
+	st.SystemPackageRepositories["bad-repo"] = &resource.SystemPackageRepositoryState{
+		InstallerRef: "apt",
+		Source:       resource.SourceConfig{URL: "https://example.com"},
+		UpdatedAt:    time.Now(),
+	}
+	require.NoError(t, store.Save(st))
+	require.NoError(t, store.Unlock())
+
+	repoMock := &mockSysRepoInstaller{
+		installFn: defaultRepoInstallFn,
+		removeFn: func(_ context.Context, _ *resource.SystemPackageRepositoryState, name string) error {
+			return fmt.Errorf("remove failed for %s", name)
+		},
+	}
+
+	engine := NewSystemEngine(
+		&mockSysInstallerInstaller{installFn: defaultInstallerInstallFn},
+		repoMock,
+		&mockSysPackageInstaller{installFn: defaultPackageInstallFn},
+		store,
+	)
+	engine.SetPrivilegeHandler(&mockPrivilegeHandler{})
+
+	// Apply with empty resources → repo removal should fail
+	err = engine.Apply(context.Background(), []resource.Resource{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bad-repo")
+
+	// Verify: successful package removal was flushed despite the repo error
+	require.NoError(t, store.Lock())
+	defer func() { _ = store.Unlock() }()
+	st, err = store.Load()
+	require.NoError(t, err)
+	assert.Nil(t, st.SystemPackages["good-pkg"], "successful removal should be persisted even when later batch fails")
+	assert.NotNil(t, st.SystemPackageRepositories["bad-repo"], "failed removal should leave state intact")
+}

--- a/internal/installer/engine/system_engine_test.go
+++ b/internal/installer/engine/system_engine_test.go
@@ -1,0 +1,799 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/terassyi/tomei/internal/resource"
+	"github.com/terassyi/tomei/internal/state"
+)
+
+// --- Generic mock installer ---
+
+type mockInstaller[R any, S any] struct {
+	mu        sync.Mutex
+	calls     []string
+	installFn func(ctx context.Context, res R, name string) (S, error)
+	removeFn  func(ctx context.Context, st S, name string) error
+}
+
+func (m *mockInstaller[R, S]) Install(ctx context.Context, res R, name string) (S, error) {
+	m.mu.Lock()
+	m.calls = append(m.calls, "Install:"+name)
+	m.mu.Unlock()
+	if m.installFn != nil {
+		return m.installFn(ctx, res, name)
+	}
+	var zero S
+	return zero, fmt.Errorf("installFn not set")
+}
+
+func (m *mockInstaller[R, S]) Remove(ctx context.Context, st S, name string) error {
+	m.mu.Lock()
+	m.calls = append(m.calls, "Remove:"+name)
+	m.mu.Unlock()
+	if m.removeFn != nil {
+		return m.removeFn(ctx, st, name)
+	}
+	return nil
+}
+
+func (m *mockInstaller[R, S]) getCalls() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string{}, m.calls...)
+}
+
+// Concrete mock type aliases for readability.
+type mockSysInstallerInstaller = mockInstaller[*resource.SystemInstaller, *resource.SystemInstallerState]
+type mockSysRepoInstaller = mockInstaller[*resource.SystemPackageRepository, *resource.SystemPackageRepositoryState]
+type mockSysPackageInstaller = mockInstaller[*resource.SystemPackageSet, *resource.SystemPackageSetState]
+
+// --- Default install functions ---
+
+func defaultInstallerInstallFn(_ context.Context, _ *resource.SystemInstaller, _ string) (*resource.SystemInstallerState, error) {
+	return &resource.SystemInstallerState{Version: "1.0.0", UpdatedAt: time.Now()}, nil
+}
+
+func defaultRepoInstallFn(_ context.Context, res *resource.SystemPackageRepository, name string) (*resource.SystemPackageRepositoryState, error) {
+	return &resource.SystemPackageRepositoryState{
+		InstallerRef:   res.SystemPackageRepositorySpec.InstallerRef,
+		Source:         res.SystemPackageRepositorySpec.Source,
+		InstalledFiles: []string{"/usr/share/keyrings/" + name + ".gpg"},
+		UpdatedAt:      time.Now(),
+	}, nil
+}
+
+func defaultPackageInstallFn(_ context.Context, res *resource.SystemPackageSet, _ string) (*resource.SystemPackageSetState, error) {
+	versions := make(map[string]string, len(res.SystemPackageSetSpec.Packages))
+	for _, pkg := range res.SystemPackageSetSpec.Packages {
+		versions[pkg] = "1.0.0"
+	}
+	return &resource.SystemPackageSetState{
+		InstallerRef:      res.SystemPackageSetSpec.InstallerRef,
+		RepositoryRef:     res.SystemPackageSetSpec.RepositoryRef,
+		Packages:          res.SystemPackageSetSpec.Packages,
+		InstalledVersions: versions,
+		UpdatedAt:         time.Now(),
+	}, nil
+}
+
+// --- Mock privilege handler ---
+
+type mockPrivilegeHandler struct{}
+
+func (*mockPrivilegeHandler) Acquire(context.Context) error { return nil }
+func (*mockPrivilegeHandler) Release() error                { return nil }
+
+// --- Test resource helpers ---
+
+func testSystemInstaller(name string) *resource.SystemInstaller {
+	return &resource.SystemInstaller{
+		BaseResource: resource.BaseResource{
+			APIVersion:   resource.GroupVersion,
+			ResourceKind: resource.KindSystemInstaller,
+			Metadata:     resource.Metadata{Name: name},
+		},
+		SystemInstallerSpec: &resource.SystemInstallerSpec{
+			Pattern:    "delegation",
+			Privileged: true,
+			Commands: resource.SystemInstallerCommandsSpec{
+				Install: resource.CommandSpec{Command: name, Verb: "install"},
+				Remove:  resource.CommandSpec{Command: name, Verb: "remove"},
+				Check:   resource.CommandSpec{Command: "dpkg", Verb: "-s"},
+			},
+		},
+	}
+}
+
+func testSystemPackageRepository(name, installerRef string) *resource.SystemPackageRepository {
+	return &resource.SystemPackageRepository{
+		BaseResource: resource.BaseResource{
+			APIVersion:   resource.GroupVersion,
+			ResourceKind: resource.KindSystemPackageRepository,
+			Metadata:     resource.Metadata{Name: name},
+		},
+		SystemPackageRepositorySpec: &resource.SystemPackageRepositorySpec{
+			InstallerRef: installerRef,
+			Source: resource.SourceConfig{
+				URL:    "https://example.com/" + name + "/repo",
+				KeyURL: "https://example.com/" + name + "/gpg",
+			},
+		},
+	}
+}
+
+func testSystemPackageSet(name, installerRef, repoRef string, packages []string) *resource.SystemPackageSet {
+	return &resource.SystemPackageSet{
+		BaseResource: resource.BaseResource{
+			APIVersion:   resource.GroupVersion,
+			ResourceKind: resource.KindSystemPackageSet,
+			Metadata:     resource.Metadata{Name: name},
+		},
+		SystemPackageSetSpec: &resource.SystemPackageSetSpec{
+			InstallerRef:  installerRef,
+			RepositoryRef: repoRef,
+			Packages:      packages,
+		},
+	}
+}
+
+// --- Helper to create engine with mocks ---
+
+type systemEngineTestSetup struct {
+	engine        *SystemEngine
+	store         *state.Store[state.SystemState]
+	installerMock *mockSysInstallerInstaller
+	repoMock      *mockSysRepoInstaller
+	packageMock   *mockSysPackageInstaller
+	events        []Event
+	mu            sync.Mutex
+}
+
+func newSystemEngineTestSetup(t *testing.T) *systemEngineTestSetup {
+	t.Helper()
+	stateDir := t.TempDir()
+	store, err := state.NewStore[state.SystemState](stateDir)
+	require.NoError(t, err)
+
+	installerMock := &mockSysInstallerInstaller{installFn: defaultInstallerInstallFn}
+	repoMock := &mockSysRepoInstaller{installFn: defaultRepoInstallFn}
+	packageMock := &mockSysPackageInstaller{installFn: defaultPackageInstallFn}
+
+	engine := NewSystemEngine(installerMock, repoMock, packageMock, store)
+	engine.SetPrivilegeHandler(&mockPrivilegeHandler{})
+
+	s := &systemEngineTestSetup{
+		engine:        engine,
+		store:         store,
+		installerMock: installerMock,
+		repoMock:      repoMock,
+		packageMock:   packageMock,
+	}
+
+	engine.SetEventHandler(func(event Event) {
+		s.mu.Lock()
+		s.events = append(s.events, event)
+		s.mu.Unlock()
+	})
+
+	return s
+}
+
+func (s *systemEngineTestSetup) getEvents() []Event {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]Event{}, s.events...)
+}
+
+// --- Tests ---
+
+func TestNewSystemEngine(t *testing.T) {
+	t.Parallel()
+	s := newSystemEngineTestSetup(t)
+	assert.NotNil(t, s.engine)
+	assert.NotNil(t, s.engine.store)
+	assert.NotNil(t, s.engine.stateCache)
+	assert.NotNil(t, s.engine.installerReconciler)
+	assert.NotNil(t, s.engine.repoReconciler)
+	assert.NotNil(t, s.engine.packageReconciler)
+	assert.NotNil(t, s.engine.installerExecutor)
+	assert.NotNil(t, s.engine.repoExecutor)
+	assert.NotNil(t, s.engine.packageExecutor)
+}
+
+func TestSystemEngine_Apply(t *testing.T) {
+	t.Parallel()
+	s := newSystemEngineTestSetup(t)
+
+	resources := []resource.Resource{
+		testSystemInstaller("apt"),
+		testSystemPackageRepository("docker", "apt"),
+		testSystemPackageSet("docker-pkgs", "apt", "docker", []string{"docker-ce", "containerd.io"}),
+	}
+
+	err := s.engine.Apply(context.Background(), resources)
+	require.NoError(t, err)
+
+	// Verify all installers were called
+	assert.Equal(t, []string{"Install:apt"}, s.installerMock.getCalls())
+	assert.Equal(t, []string{"Install:docker"}, s.repoMock.getCalls())
+	assert.Equal(t, []string{"Install:docker-pkgs"}, s.packageMock.getCalls())
+
+	// Verify state was persisted
+	require.NoError(t, s.store.Lock())
+	defer func() { _ = s.store.Unlock() }()
+	st, err := s.store.Load()
+	require.NoError(t, err)
+	assert.NotNil(t, st.SystemInstallers["apt"])
+	assert.NotNil(t, st.SystemPackageRepositories["docker"])
+	assert.NotNil(t, st.SystemPackages["docker-pkgs"])
+}
+
+func TestSystemEngine_Apply_DAGOrder(t *testing.T) {
+	t.Parallel()
+
+	// Use a shared call log to track cross-installer ordering
+	var mu sync.Mutex
+	var allCalls []string
+	recordCall := func(call string) {
+		mu.Lock()
+		allCalls = append(allCalls, call)
+		mu.Unlock()
+	}
+
+	stateDir := t.TempDir()
+	store, err := state.NewStore[state.SystemState](stateDir)
+	require.NoError(t, err)
+
+	installerMock := &mockSysInstallerInstaller{
+		installFn: func(_ context.Context, _ *resource.SystemInstaller, name string) (*resource.SystemInstallerState, error) {
+			recordCall("installer:" + name)
+			return &resource.SystemInstallerState{Version: "1.0.0", UpdatedAt: time.Now()}, nil
+		},
+	}
+	repoMock := &mockSysRepoInstaller{
+		installFn: func(_ context.Context, res *resource.SystemPackageRepository, name string) (*resource.SystemPackageRepositoryState, error) {
+			recordCall("repo:" + name)
+			return &resource.SystemPackageRepositoryState{
+				InstallerRef: res.SystemPackageRepositorySpec.InstallerRef,
+				Source:       res.SystemPackageRepositorySpec.Source,
+				UpdatedAt:    time.Now(),
+			}, nil
+		},
+	}
+	packageMock := &mockSysPackageInstaller{
+		installFn: func(_ context.Context, res *resource.SystemPackageSet, name string) (*resource.SystemPackageSetState, error) {
+			recordCall("package:" + name)
+			return &resource.SystemPackageSetState{
+				InstallerRef:  res.SystemPackageSetSpec.InstallerRef,
+				RepositoryRef: res.SystemPackageSetSpec.RepositoryRef,
+				Packages:      res.SystemPackageSetSpec.Packages,
+				UpdatedAt:     time.Now(),
+			}, nil
+		},
+	}
+
+	engine := NewSystemEngine(installerMock, repoMock, packageMock, store)
+	engine.SetPrivilegeHandler(&mockPrivilegeHandler{})
+
+	resources := []resource.Resource{
+		testSystemInstaller("apt"),
+		testSystemPackageRepository("docker", "apt"),
+		testSystemPackageSet("docker-pkgs", "apt", "docker", []string{"docker-ce"}),
+	}
+
+	err = engine.Apply(context.Background(), resources)
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, allCalls, 3)
+	assert.Equal(t, "installer:apt", allCalls[0])
+	assert.Equal(t, "repo:docker", allCalls[1])
+	assert.Equal(t, "package:docker-pkgs", allCalls[2])
+}
+
+func TestSystemEngine_Apply_NoChanges(t *testing.T) {
+	t.Parallel()
+	s := newSystemEngineTestSetup(t)
+
+	// Pre-populate state
+	require.NoError(t, s.store.Lock())
+	st := state.NewSystemState()
+	st.SystemInstallers["apt"] = &resource.SystemInstallerState{
+		Version:   "1.0.0",
+		UpdatedAt: time.Now(),
+	}
+	st.SystemPackageRepositories["docker"] = &resource.SystemPackageRepositoryState{
+		InstallerRef: "apt",
+		Source: resource.SourceConfig{
+			URL:    "https://example.com/docker/repo",
+			KeyURL: "https://example.com/docker/gpg",
+		},
+		UpdatedAt: time.Now(),
+	}
+	st.SystemPackages["docker-pkgs"] = &resource.SystemPackageSetState{
+		InstallerRef:  "apt",
+		RepositoryRef: "docker",
+		Packages:      []string{"docker-ce", "containerd.io"},
+		UpdatedAt:     time.Now(),
+	}
+	require.NoError(t, s.store.Save(st))
+	require.NoError(t, s.store.Unlock())
+
+	resources := []resource.Resource{
+		testSystemInstaller("apt"),
+		testSystemPackageRepository("docker", "apt"),
+		testSystemPackageSet("docker-pkgs", "apt", "docker", []string{"docker-ce", "containerd.io"}),
+	}
+
+	err := s.engine.Apply(context.Background(), resources)
+	require.NoError(t, err)
+
+	// No install calls should have been made
+	assert.Empty(t, s.installerMock.getCalls())
+	assert.Empty(t, s.repoMock.getCalls())
+	assert.Empty(t, s.packageMock.getCalls())
+}
+
+func TestSystemEngine_Apply_Removals(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var removeCalls []string
+
+	stateDir := t.TempDir()
+	store, err := state.NewStore[state.SystemState](stateDir)
+	require.NoError(t, err)
+
+	// Pre-populate state with resources that will be removed
+	require.NoError(t, store.Lock())
+	st := state.NewSystemState()
+	st.SystemInstallers["apt"] = &resource.SystemInstallerState{
+		Version:   "1.0.0",
+		UpdatedAt: time.Now(),
+	}
+	st.SystemPackageRepositories["docker"] = &resource.SystemPackageRepositoryState{
+		InstallerRef: "apt",
+		Source:       resource.SourceConfig{URL: "https://example.com/docker/repo"},
+		UpdatedAt:    time.Now(),
+	}
+	st.SystemPackages["docker-pkgs"] = &resource.SystemPackageSetState{
+		InstallerRef:  "apt",
+		RepositoryRef: "docker",
+		Packages:      []string{"docker-ce"},
+		UpdatedAt:     time.Now(),
+	}
+	require.NoError(t, store.Save(st))
+	require.NoError(t, store.Unlock())
+
+	installerMock := &mockSysInstallerInstaller{
+		installFn: defaultInstallerInstallFn,
+		removeFn: func(_ context.Context, _ *resource.SystemInstallerState, name string) error {
+			mu.Lock()
+			removeCalls = append(removeCalls, "installer:"+name)
+			mu.Unlock()
+			return nil
+		},
+	}
+	repoMock := &mockSysRepoInstaller{
+		installFn: defaultRepoInstallFn,
+		removeFn: func(_ context.Context, _ *resource.SystemPackageRepositoryState, name string) error {
+			mu.Lock()
+			removeCalls = append(removeCalls, "repo:"+name)
+			mu.Unlock()
+			return nil
+		},
+	}
+	packageMock := &mockSysPackageInstaller{
+		installFn: defaultPackageInstallFn,
+		removeFn: func(_ context.Context, _ *resource.SystemPackageSetState, name string) error {
+			mu.Lock()
+			removeCalls = append(removeCalls, "package:"+name)
+			mu.Unlock()
+			return nil
+		},
+	}
+
+	engine := NewSystemEngine(installerMock, repoMock, packageMock, store)
+	engine.SetPrivilegeHandler(&mockPrivilegeHandler{})
+
+	// Apply with empty resources → all should be removed
+	err = engine.Apply(context.Background(), []resource.Resource{})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Reverse order: packages → repos → installers
+	require.Len(t, removeCalls, 3)
+	assert.Equal(t, "package:docker-pkgs", removeCalls[0])
+	assert.Equal(t, "repo:docker", removeCalls[1])
+	assert.Equal(t, "installer:apt", removeCalls[2])
+
+	// Verify state is cleared
+	require.NoError(t, store.Lock())
+	defer func() { _ = store.Unlock() }()
+	st, err = store.Load()
+	require.NoError(t, err)
+	assert.Empty(t, st.SystemInstallers)
+	assert.Empty(t, st.SystemPackageRepositories)
+	assert.Empty(t, st.SystemPackages)
+}
+
+func TestSystemEngine_Apply_RequiresPrivilegeHandler(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	store, err := state.NewStore[state.SystemState](stateDir)
+	require.NoError(t, err)
+
+	engine := NewSystemEngine(
+		&mockSysInstallerInstaller{installFn: defaultInstallerInstallFn},
+		&mockSysRepoInstaller{installFn: defaultRepoInstallFn},
+		&mockSysPackageInstaller{installFn: defaultPackageInstallFn},
+		store,
+	)
+	// Do NOT set privilege handler
+
+	resources := []resource.Resource{
+		testSystemInstaller("apt"),
+	}
+
+	err = engine.Apply(context.Background(), resources)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "privilege")
+}
+
+func TestSystemEngine_Apply_ContextCancellation(t *testing.T) {
+	t.Parallel()
+	s := newSystemEngineTestSetup(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	resources := []resource.Resource{
+		testSystemInstaller("apt"),
+	}
+
+	err := s.engine.Apply(ctx, resources)
+	require.Error(t, err)
+
+	// No installer should have been called
+	assert.Empty(t, s.installerMock.getCalls())
+}
+
+func TestSystemEngine_Apply_Events(t *testing.T) {
+	t.Parallel()
+	s := newSystemEngineTestSetup(t)
+
+	resources := []resource.Resource{
+		testSystemInstaller("apt"),
+		testSystemPackageRepository("docker", "apt"),
+	}
+
+	err := s.engine.Apply(context.Background(), resources)
+	require.NoError(t, err)
+
+	events := s.getEvents()
+
+	// Check for start and complete events for each resource
+	var starts, completes []Event
+	for _, e := range events {
+		switch e.Type {
+		case EventStart:
+			starts = append(starts, e)
+		case EventComplete:
+			completes = append(completes, e)
+		}
+	}
+
+	require.Len(t, starts, 2)
+	require.Len(t, completes, 2)
+
+	// Verify kinds are correct
+	assert.Equal(t, resource.KindSystemInstaller, starts[0].Kind)
+	assert.Equal(t, resource.KindSystemPackageRepository, starts[1].Kind)
+}
+
+func TestSystemEngine_Apply_UpgradeRepo(t *testing.T) {
+	t.Parallel()
+	s := newSystemEngineTestSetup(t)
+
+	// Pre-populate state with old URL
+	require.NoError(t, s.store.Lock())
+	st := state.NewSystemState()
+	st.SystemInstallers["apt"] = &resource.SystemInstallerState{
+		Version:   "1.0.0",
+		UpdatedAt: time.Now(),
+	}
+	st.SystemPackageRepositories["docker"] = &resource.SystemPackageRepositoryState{
+		InstallerRef: "apt",
+		Source: resource.SourceConfig{
+			URL:    "https://old.example.com/docker/repo",
+			KeyURL: "https://example.com/docker/gpg",
+		},
+		UpdatedAt: time.Now(),
+	}
+	require.NoError(t, s.store.Save(st))
+	require.NoError(t, s.store.Unlock())
+
+	resources := []resource.Resource{
+		testSystemInstaller("apt"),
+		testSystemPackageRepository("docker", "apt"),
+	}
+
+	err := s.engine.Apply(context.Background(), resources)
+	require.NoError(t, err)
+
+	// Installer should not be called (no change), repo should be called (URL changed)
+	assert.Empty(t, s.installerMock.getCalls())
+	assert.Equal(t, []string{"Install:docker"}, s.repoMock.getCalls())
+
+	// Verify updated state
+	require.NoError(t, s.store.Lock())
+	defer func() { _ = s.store.Unlock() }()
+	updatedSt, err := s.store.Load()
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com/docker/repo", updatedSt.SystemPackageRepositories["docker"].Source.URL)
+}
+
+func TestSystemEngine_Apply_MultipleInstallers(t *testing.T) {
+	t.Parallel()
+	s := newSystemEngineTestSetup(t)
+
+	resources := []resource.Resource{
+		testSystemInstaller("apt"),
+		testSystemInstaller("dnf"),
+		testSystemPackageRepository("docker", "apt"),
+		testSystemPackageRepository("kubernetes", "dnf"),
+		testSystemPackageSet("docker-pkgs", "apt", "docker", []string{"docker-ce"}),
+		testSystemPackageSet("k8s-pkgs", "dnf", "kubernetes", []string{"kubectl", "kubelet"}),
+	}
+
+	err := s.engine.Apply(context.Background(), resources)
+	require.NoError(t, err)
+
+	// Verify state was persisted for all resources
+	require.NoError(t, s.store.Lock())
+	defer func() { _ = s.store.Unlock() }()
+	st, err := s.store.Load()
+	require.NoError(t, err)
+	assert.Len(t, st.SystemInstallers, 2)
+	assert.Len(t, st.SystemPackageRepositories, 2)
+	assert.Len(t, st.SystemPackages, 2)
+}
+
+func TestSystemEngine_Apply_ErrorMidLayer(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	store, err := state.NewStore[state.SystemState](stateDir)
+	require.NoError(t, err)
+
+	// Repo installer fails
+	repoMock := &mockSysRepoInstaller{
+		installFn: func(_ context.Context, _ *resource.SystemPackageRepository, _ string) (*resource.SystemPackageRepositoryState, error) {
+			return nil, fmt.Errorf("repo install failed")
+		},
+	}
+
+	engine := NewSystemEngine(
+		&mockSysInstallerInstaller{installFn: defaultInstallerInstallFn},
+		repoMock,
+		&mockSysPackageInstaller{installFn: defaultPackageInstallFn},
+		store,
+	)
+	engine.SetPrivilegeHandler(&mockPrivilegeHandler{})
+
+	resources := []resource.Resource{
+		testSystemInstaller("apt"),
+		testSystemPackageRepository("docker", "apt"),
+		testSystemPackageSet("docker-pkgs", "apt", "docker", []string{"docker-ce"}),
+	}
+
+	err = engine.Apply(context.Background(), resources)
+	require.Error(t, err)
+
+	// The installer layer (apt) should have been persisted before the repo layer error
+	require.NoError(t, store.Lock())
+	defer func() { _ = store.Unlock() }()
+	st, err := store.Load()
+	require.NoError(t, err)
+	assert.NotNil(t, st.SystemInstallers["apt"], "installer state should be persisted before repo layer error")
+	assert.Nil(t, st.SystemPackageRepositories["docker"], "failed repo should not be in state")
+}
+
+func TestSystemEngine_Apply_EmptyResources(t *testing.T) {
+	t.Parallel()
+	s := newSystemEngineTestSetup(t)
+
+	err := s.engine.Apply(context.Background(), []resource.Resource{})
+	require.NoError(t, err)
+
+	assert.Empty(t, s.installerMock.getCalls())
+	assert.Empty(t, s.repoMock.getCalls())
+	assert.Empty(t, s.packageMock.getCalls())
+}
+
+func TestSystemEngine_PlanAll(t *testing.T) {
+	t.Parallel()
+	s := newSystemEngineTestSetup(t)
+
+	resources := []resource.Resource{
+		testSystemInstaller("apt"),
+		testSystemPackageRepository("docker", "apt"),
+		testSystemPackageSet("docker-pkgs", "apt", "docker", []string{"docker-ce"}),
+	}
+
+	installerActions, repoActions, packageActions, err := s.engine.PlanAll(context.Background(), resources)
+	require.NoError(t, err)
+
+	// All should be install actions (no prior state)
+	require.Len(t, installerActions, 1)
+	assert.Equal(t, resource.ActionInstall, installerActions[0].Type)
+	assert.Equal(t, "apt", installerActions[0].Name)
+
+	require.Len(t, repoActions, 1)
+	assert.Equal(t, resource.ActionInstall, repoActions[0].Type)
+	assert.Equal(t, "docker", repoActions[0].Name)
+
+	require.Len(t, packageActions, 1)
+	assert.Equal(t, resource.ActionInstall, packageActions[0].Type)
+	assert.Equal(t, "docker-pkgs", packageActions[0].Name)
+}
+
+func TestSystemEngine_PlanAll_NoChanges(t *testing.T) {
+	t.Parallel()
+	s := newSystemEngineTestSetup(t)
+
+	// Pre-populate state matching spec
+	require.NoError(t, s.store.Lock())
+	st := state.NewSystemState()
+	st.SystemInstallers["apt"] = &resource.SystemInstallerState{
+		Version:   "1.0.0",
+		UpdatedAt: time.Now(),
+	}
+	st.SystemPackageRepositories["docker"] = &resource.SystemPackageRepositoryState{
+		InstallerRef: "apt",
+		Source: resource.SourceConfig{
+			URL:    "https://example.com/docker/repo",
+			KeyURL: "https://example.com/docker/gpg",
+		},
+		UpdatedAt: time.Now(),
+	}
+	st.SystemPackages["docker-pkgs"] = &resource.SystemPackageSetState{
+		InstallerRef:  "apt",
+		RepositoryRef: "docker",
+		Packages:      []string{"docker-ce"},
+		UpdatedAt:     time.Now(),
+	}
+	require.NoError(t, s.store.Save(st))
+	require.NoError(t, s.store.Unlock())
+
+	resources := []resource.Resource{
+		testSystemInstaller("apt"),
+		testSystemPackageRepository("docker", "apt"),
+		testSystemPackageSet("docker-pkgs", "apt", "docker", []string{"docker-ce"}),
+	}
+
+	installerActions, repoActions, packageActions, err := s.engine.PlanAll(context.Background(), resources)
+	require.NoError(t, err)
+
+	assert.Empty(t, installerActions)
+	assert.Empty(t, repoActions)
+	assert.Empty(t, packageActions)
+}
+
+func TestSystemEngine_PlanAll_InstallerRemovalDependencyError(t *testing.T) {
+	t.Parallel()
+	s := newSystemEngineTestSetup(t)
+
+	// Pre-populate state: installer "apt" exists, repo "docker" depends on it
+	require.NoError(t, s.store.Lock())
+	st := state.NewSystemState()
+	st.SystemInstallers["apt"] = &resource.SystemInstallerState{
+		Version:   "1.0.0",
+		UpdatedAt: time.Now(),
+	}
+	st.SystemPackageRepositories["docker"] = &resource.SystemPackageRepositoryState{
+		InstallerRef: "apt",
+		Source:       resource.SourceConfig{URL: "https://example.com/docker/repo"},
+		UpdatedAt:    time.Now(),
+	}
+	require.NoError(t, s.store.Save(st))
+	require.NoError(t, s.store.Unlock())
+
+	// Spec keeps repo "docker" but removes installer "apt" → dependency error
+	resources := []resource.Resource{
+		testSystemPackageRepository("docker", "apt"),
+	}
+
+	_, _, _, err := s.engine.PlanAll(context.Background(), resources)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "apt")
+}
+
+func TestSystemEngine_PlanAll_RepoRemovalDependencyError(t *testing.T) {
+	t.Parallel()
+	s := newSystemEngineTestSetup(t)
+
+	// Pre-populate state: repo "docker" exists, package set depends on it
+	require.NoError(t, s.store.Lock())
+	st := state.NewSystemState()
+	st.SystemInstallers["apt"] = &resource.SystemInstallerState{
+		Version:   "1.0.0",
+		UpdatedAt: time.Now(),
+	}
+	st.SystemPackageRepositories["docker"] = &resource.SystemPackageRepositoryState{
+		InstallerRef: "apt",
+		Source:       resource.SourceConfig{URL: "https://example.com/docker/repo"},
+		UpdatedAt:    time.Now(),
+	}
+	st.SystemPackages["docker-pkgs"] = &resource.SystemPackageSetState{
+		InstallerRef:  "apt",
+		RepositoryRef: "docker",
+		Packages:      []string{"docker-ce"},
+		UpdatedAt:     time.Now(),
+	}
+	require.NoError(t, s.store.Save(st))
+	require.NoError(t, s.store.Unlock())
+
+	// Spec keeps installer and packages but removes repo → dependency error
+	resources := []resource.Resource{
+		testSystemInstaller("apt"),
+		testSystemPackageSet("docker-pkgs", "apt", "docker", []string{"docker-ce"}),
+	}
+
+	_, _, _, err := s.engine.PlanAll(context.Background(), resources)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "docker")
+}
+
+func TestSystemEngine_Apply_RemoveError(t *testing.T) {
+	t.Parallel()
+	stateDir := t.TempDir()
+	store, err := state.NewStore[state.SystemState](stateDir)
+	require.NoError(t, err)
+
+	// Pre-populate state with a single package set
+	require.NoError(t, store.Lock())
+	st := state.NewSystemState()
+	st.SystemPackages["failing-pkg"] = &resource.SystemPackageSetState{
+		InstallerRef: "apt",
+		Packages:     []string{"a"},
+		UpdatedAt:    time.Now(),
+	}
+	require.NoError(t, store.Save(st))
+	require.NoError(t, store.Unlock())
+
+	packageMock := &mockSysPackageInstaller{
+		installFn: defaultPackageInstallFn,
+		removeFn: func(_ context.Context, _ *resource.SystemPackageSetState, name string) error {
+			return fmt.Errorf("remove failed for %s", name)
+		},
+	}
+
+	engine := NewSystemEngine(
+		&mockSysInstallerInstaller{installFn: defaultInstallerInstallFn},
+		&mockSysRepoInstaller{installFn: defaultRepoInstallFn},
+		packageMock,
+		store,
+	)
+	engine.SetPrivilegeHandler(&mockPrivilegeHandler{})
+
+	// Apply with empty resources → removal should fail
+	err = engine.Apply(context.Background(), []resource.Resource{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failing-pkg")
+
+	// State should still contain the failed resource
+	require.NoError(t, store.Lock())
+	defer func() { _ = store.Unlock() }()
+	st, err = store.Load()
+	require.NoError(t, err)
+	assert.NotNil(t, st.SystemPackages["failing-pkg"], "failed removal should leave state intact")
+}

--- a/internal/installer/engine/system_engine_test.go
+++ b/internal/installer/engine/system_engine_test.go
@@ -185,6 +185,18 @@ func newSystemEngineTestSetup(t *testing.T) *systemEngineTestSetup {
 	return s
 }
 
+// setupState locks the store, applies fn to a fresh SystemState, saves, and
+// unlocks. The deferred unlock ensures the lock is released even if a require
+// assertion fails mid-setup.
+func setupState(t *testing.T, store *state.Store[state.SystemState], fn func(*state.SystemState)) {
+	t.Helper()
+	require.NoError(t, store.Lock())
+	defer func() { _ = store.Unlock() }()
+	st := state.NewSystemState()
+	fn(st)
+	require.NoError(t, store.Save(st))
+}
+
 func (s *systemEngineTestSetup) getEvents() []Event {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -304,28 +316,26 @@ func TestSystemEngine_Apply_NoChanges(t *testing.T) {
 	s := newSystemEngineTestSetup(t)
 
 	// Pre-populate state
-	require.NoError(t, s.store.Lock())
-	st := state.NewSystemState()
-	st.SystemInstallers["apt"] = &resource.SystemInstallerState{
-		Version:   "1.0.0",
-		UpdatedAt: time.Now(),
-	}
-	st.SystemPackageRepositories["docker"] = &resource.SystemPackageRepositoryState{
-		InstallerRef: "apt",
-		Source: resource.SourceConfig{
-			URL:    "https://example.com/docker/repo",
-			KeyURL: "https://example.com/docker/gpg",
-		},
-		UpdatedAt: time.Now(),
-	}
-	st.SystemPackages["docker-pkgs"] = &resource.SystemPackageSetState{
-		InstallerRef:  "apt",
-		RepositoryRef: "docker",
-		Packages:      []string{"docker-ce", "containerd.io"},
-		UpdatedAt:     time.Now(),
-	}
-	require.NoError(t, s.store.Save(st))
-	require.NoError(t, s.store.Unlock())
+	setupState(t, s.store, func(st *state.SystemState) {
+		st.SystemInstallers["apt"] = &resource.SystemInstallerState{
+			Version:   "1.0.0",
+			UpdatedAt: time.Now(),
+		}
+		st.SystemPackageRepositories["docker"] = &resource.SystemPackageRepositoryState{
+			InstallerRef: "apt",
+			Source: resource.SourceConfig{
+				URL:    "https://example.com/docker/repo",
+				KeyURL: "https://example.com/docker/gpg",
+			},
+			UpdatedAt: time.Now(),
+		}
+		st.SystemPackages["docker-pkgs"] = &resource.SystemPackageSetState{
+			InstallerRef:  "apt",
+			RepositoryRef: "docker",
+			Packages:      []string{"docker-ce", "containerd.io"},
+			UpdatedAt:     time.Now(),
+		}
+	})
 
 	resources := []resource.Resource{
 		testSystemInstaller("apt"),
@@ -353,25 +363,23 @@ func TestSystemEngine_Apply_Removals(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pre-populate state with resources that will be removed
-	require.NoError(t, store.Lock())
-	st := state.NewSystemState()
-	st.SystemInstallers["apt"] = &resource.SystemInstallerState{
-		Version:   "1.0.0",
-		UpdatedAt: time.Now(),
-	}
-	st.SystemPackageRepositories["docker"] = &resource.SystemPackageRepositoryState{
-		InstallerRef: "apt",
-		Source:       resource.SourceConfig{URL: "https://example.com/docker/repo"},
-		UpdatedAt:    time.Now(),
-	}
-	st.SystemPackages["docker-pkgs"] = &resource.SystemPackageSetState{
-		InstallerRef:  "apt",
-		RepositoryRef: "docker",
-		Packages:      []string{"docker-ce"},
-		UpdatedAt:     time.Now(),
-	}
-	require.NoError(t, store.Save(st))
-	require.NoError(t, store.Unlock())
+	setupState(t, store, func(st *state.SystemState) {
+		st.SystemInstallers["apt"] = &resource.SystemInstallerState{
+			Version:   "1.0.0",
+			UpdatedAt: time.Now(),
+		}
+		st.SystemPackageRepositories["docker"] = &resource.SystemPackageRepositoryState{
+			InstallerRef: "apt",
+			Source:       resource.SourceConfig{URL: "https://example.com/docker/repo"},
+			UpdatedAt:    time.Now(),
+		}
+		st.SystemPackages["docker-pkgs"] = &resource.SystemPackageSetState{
+			InstallerRef:  "apt",
+			RepositoryRef: "docker",
+			Packages:      []string{"docker-ce"},
+			UpdatedAt:     time.Now(),
+		}
+	})
 
 	installerMock := &mockSysInstallerInstaller{
 		installFn: defaultInstallerInstallFn,
@@ -419,7 +427,7 @@ func TestSystemEngine_Apply_Removals(t *testing.T) {
 	// Verify state is cleared
 	require.NoError(t, store.Lock())
 	defer func() { _ = store.Unlock() }()
-	st, err = store.Load()
+	st, err := store.Load()
 	require.NoError(t, err)
 	assert.Empty(t, st.SystemInstallers)
 	assert.Empty(t, st.SystemPackageRepositories)
@@ -505,22 +513,20 @@ func TestSystemEngine_Apply_UpgradeRepo(t *testing.T) {
 	s := newSystemEngineTestSetup(t)
 
 	// Pre-populate state with old URL
-	require.NoError(t, s.store.Lock())
-	st := state.NewSystemState()
-	st.SystemInstallers["apt"] = &resource.SystemInstallerState{
-		Version:   "1.0.0",
-		UpdatedAt: time.Now(),
-	}
-	st.SystemPackageRepositories["docker"] = &resource.SystemPackageRepositoryState{
-		InstallerRef: "apt",
-		Source: resource.SourceConfig{
-			URL:    "https://old.example.com/docker/repo",
-			KeyURL: "https://example.com/docker/gpg",
-		},
-		UpdatedAt: time.Now(),
-	}
-	require.NoError(t, s.store.Save(st))
-	require.NoError(t, s.store.Unlock())
+	setupState(t, s.store, func(st *state.SystemState) {
+		st.SystemInstallers["apt"] = &resource.SystemInstallerState{
+			Version:   "1.0.0",
+			UpdatedAt: time.Now(),
+		}
+		st.SystemPackageRepositories["docker"] = &resource.SystemPackageRepositoryState{
+			InstallerRef: "apt",
+			Source: resource.SourceConfig{
+				URL:    "https://old.example.com/docker/repo",
+				KeyURL: "https://example.com/docker/gpg",
+			},
+			UpdatedAt: time.Now(),
+		}
+	})
 
 	resources := []resource.Resource{
 		testSystemInstaller("apt"),
@@ -651,28 +657,26 @@ func TestSystemEngine_PlanAll_NoChanges(t *testing.T) {
 	s := newSystemEngineTestSetup(t)
 
 	// Pre-populate state matching spec
-	require.NoError(t, s.store.Lock())
-	st := state.NewSystemState()
-	st.SystemInstallers["apt"] = &resource.SystemInstallerState{
-		Version:   "1.0.0",
-		UpdatedAt: time.Now(),
-	}
-	st.SystemPackageRepositories["docker"] = &resource.SystemPackageRepositoryState{
-		InstallerRef: "apt",
-		Source: resource.SourceConfig{
-			URL:    "https://example.com/docker/repo",
-			KeyURL: "https://example.com/docker/gpg",
-		},
-		UpdatedAt: time.Now(),
-	}
-	st.SystemPackages["docker-pkgs"] = &resource.SystemPackageSetState{
-		InstallerRef:  "apt",
-		RepositoryRef: "docker",
-		Packages:      []string{"docker-ce"},
-		UpdatedAt:     time.Now(),
-	}
-	require.NoError(t, s.store.Save(st))
-	require.NoError(t, s.store.Unlock())
+	setupState(t, s.store, func(st *state.SystemState) {
+		st.SystemInstallers["apt"] = &resource.SystemInstallerState{
+			Version:   "1.0.0",
+			UpdatedAt: time.Now(),
+		}
+		st.SystemPackageRepositories["docker"] = &resource.SystemPackageRepositoryState{
+			InstallerRef: "apt",
+			Source: resource.SourceConfig{
+				URL:    "https://example.com/docker/repo",
+				KeyURL: "https://example.com/docker/gpg",
+			},
+			UpdatedAt: time.Now(),
+		}
+		st.SystemPackages["docker-pkgs"] = &resource.SystemPackageSetState{
+			InstallerRef:  "apt",
+			RepositoryRef: "docker",
+			Packages:      []string{"docker-ce"},
+			UpdatedAt:     time.Now(),
+		}
+	})
 
 	resources := []resource.Resource{
 		testSystemInstaller("apt"),
@@ -693,19 +697,17 @@ func TestSystemEngine_PlanAll_InstallerRemovalDependencyError(t *testing.T) {
 	s := newSystemEngineTestSetup(t)
 
 	// Pre-populate state: installer "apt" exists, repo "docker" depends on it
-	require.NoError(t, s.store.Lock())
-	st := state.NewSystemState()
-	st.SystemInstallers["apt"] = &resource.SystemInstallerState{
-		Version:   "1.0.0",
-		UpdatedAt: time.Now(),
-	}
-	st.SystemPackageRepositories["docker"] = &resource.SystemPackageRepositoryState{
-		InstallerRef: "apt",
-		Source:       resource.SourceConfig{URL: "https://example.com/docker/repo"},
-		UpdatedAt:    time.Now(),
-	}
-	require.NoError(t, s.store.Save(st))
-	require.NoError(t, s.store.Unlock())
+	setupState(t, s.store, func(st *state.SystemState) {
+		st.SystemInstallers["apt"] = &resource.SystemInstallerState{
+			Version:   "1.0.0",
+			UpdatedAt: time.Now(),
+		}
+		st.SystemPackageRepositories["docker"] = &resource.SystemPackageRepositoryState{
+			InstallerRef: "apt",
+			Source:       resource.SourceConfig{URL: "https://example.com/docker/repo"},
+			UpdatedAt:    time.Now(),
+		}
+	})
 
 	// Spec keeps repo "docker" but removes installer "apt" → dependency error
 	resources := []resource.Resource{
@@ -722,25 +724,23 @@ func TestSystemEngine_PlanAll_RepoRemovalDependencyError(t *testing.T) {
 	s := newSystemEngineTestSetup(t)
 
 	// Pre-populate state: repo "docker" exists, package set depends on it
-	require.NoError(t, s.store.Lock())
-	st := state.NewSystemState()
-	st.SystemInstallers["apt"] = &resource.SystemInstallerState{
-		Version:   "1.0.0",
-		UpdatedAt: time.Now(),
-	}
-	st.SystemPackageRepositories["docker"] = &resource.SystemPackageRepositoryState{
-		InstallerRef: "apt",
-		Source:       resource.SourceConfig{URL: "https://example.com/docker/repo"},
-		UpdatedAt:    time.Now(),
-	}
-	st.SystemPackages["docker-pkgs"] = &resource.SystemPackageSetState{
-		InstallerRef:  "apt",
-		RepositoryRef: "docker",
-		Packages:      []string{"docker-ce"},
-		UpdatedAt:     time.Now(),
-	}
-	require.NoError(t, s.store.Save(st))
-	require.NoError(t, s.store.Unlock())
+	setupState(t, s.store, func(st *state.SystemState) {
+		st.SystemInstallers["apt"] = &resource.SystemInstallerState{
+			Version:   "1.0.0",
+			UpdatedAt: time.Now(),
+		}
+		st.SystemPackageRepositories["docker"] = &resource.SystemPackageRepositoryState{
+			InstallerRef: "apt",
+			Source:       resource.SourceConfig{URL: "https://example.com/docker/repo"},
+			UpdatedAt:    time.Now(),
+		}
+		st.SystemPackages["docker-pkgs"] = &resource.SystemPackageSetState{
+			InstallerRef:  "apt",
+			RepositoryRef: "docker",
+			Packages:      []string{"docker-ce"},
+			UpdatedAt:     time.Now(),
+		}
+	})
 
 	// Spec keeps installer and packages but removes repo → dependency error
 	resources := []resource.Resource{
@@ -760,15 +760,13 @@ func TestSystemEngine_Apply_RemoveError(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pre-populate state with a single package set
-	require.NoError(t, store.Lock())
-	st := state.NewSystemState()
-	st.SystemPackages["failing-pkg"] = &resource.SystemPackageSetState{
-		InstallerRef: "apt",
-		Packages:     []string{"a"},
-		UpdatedAt:    time.Now(),
-	}
-	require.NoError(t, store.Save(st))
-	require.NoError(t, store.Unlock())
+	setupState(t, store, func(st *state.SystemState) {
+		st.SystemPackages["failing-pkg"] = &resource.SystemPackageSetState{
+			InstallerRef: "apt",
+			Packages:     []string{"a"},
+			UpdatedAt:    time.Now(),
+		}
+	})
 
 	packageMock := &mockSysPackageInstaller{
 		installFn: defaultPackageInstallFn,
@@ -793,7 +791,7 @@ func TestSystemEngine_Apply_RemoveError(t *testing.T) {
 	// State should still contain the failed resource
 	require.NoError(t, store.Lock())
 	defer func() { _ = store.Unlock() }()
-	st, err = store.Load()
+	st, err := store.Load()
 	require.NoError(t, err)
 	assert.NotNil(t, st.SystemPackages["failing-pkg"], "failed removal should leave state intact")
 }
@@ -808,20 +806,18 @@ func TestSystemEngine_Apply_RemoveErrorFlushesSuccessful(t *testing.T) {
 	// and one repo (removal will fail).
 	// Removal order is packages → repos → installers, so packages should
 	// be removed and flushed before the repo removal fails.
-	require.NoError(t, store.Lock())
-	st := state.NewSystemState()
-	st.SystemPackages["good-pkg"] = &resource.SystemPackageSetState{
-		InstallerRef: "apt",
-		Packages:     []string{"a"},
-		UpdatedAt:    time.Now(),
-	}
-	st.SystemPackageRepositories["bad-repo"] = &resource.SystemPackageRepositoryState{
-		InstallerRef: "apt",
-		Source:       resource.SourceConfig{URL: "https://example.com"},
-		UpdatedAt:    time.Now(),
-	}
-	require.NoError(t, store.Save(st))
-	require.NoError(t, store.Unlock())
+	setupState(t, store, func(st *state.SystemState) {
+		st.SystemPackages["good-pkg"] = &resource.SystemPackageSetState{
+			InstallerRef: "apt",
+			Packages:     []string{"a"},
+			UpdatedAt:    time.Now(),
+		}
+		st.SystemPackageRepositories["bad-repo"] = &resource.SystemPackageRepositoryState{
+			InstallerRef: "apt",
+			Source:       resource.SourceConfig{URL: "https://example.com"},
+			UpdatedAt:    time.Now(),
+		}
+	})
 
 	repoMock := &mockSysRepoInstaller{
 		installFn: defaultRepoInstallFn,
@@ -846,7 +842,7 @@ func TestSystemEngine_Apply_RemoveErrorFlushesSuccessful(t *testing.T) {
 	// Verify: successful package removal was flushed despite the repo error
 	require.NoError(t, store.Lock())
 	defer func() { _ = store.Unlock() }()
-	st, err = store.Load()
+	st, err := store.Load()
 	require.NoError(t, err)
 	assert.Nil(t, st.SystemPackages["good-pkg"], "successful removal should be persisted even when later batch fails")
 	assert.NotNil(t, st.SystemPackageRepositories["bad-repo"], "failed removal should leave state intact")


### PR DESCRIPTION
Add SystemEngine that orchestrates Install/Upgrade/Remove lifecycle for
system-privilege resources (SystemInstaller, SystemPackageRepository,
SystemPackageSet) using DAG-based layer execution.

Key design decisions:
- Separate struct from Engine (operates on SystemState, not UserState)
- Sequential layer execution (system resources are few, share DB locks)
- PrivilegeHandler required (all system operations need sudo)
- Generic reconcileAndExecute[R,S] eliminates per-kind boilerplate
- eventEmitter interface enables executeRemovals reuse across engines
- Reverse-order removal with per-kind dependency validation

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
