### PR TITLE
feat(cmd): integrate SystemEngine into apply and plan commands (#167)

### DIFF
--- a/cmd/tomei/apply.go
+++ b/cmd/tomei/apply.go
@@ -67,13 +67,14 @@ For user-level resources (Runtime, Tool, ToolSet):
 For privileged resources (tools with privileged: true):
   tomei apply --system .
 
-Privileged tools (e.g., Homebrew) declare that their install/upgrade/
-reinstall/remove commands require a cached sudo timestamp while they run.
-Without --system, privileged operations are skipped with a warning.
+For system resources (SystemInstaller, SystemPackageRepository, SystemPackageSet):
+  tomei apply --system .
+
 With --system, tomei prompts for sudo credentials once and keeps the
-timestamp refreshed; the tool's commands still run as the invoking user,
-and "sudo ..." invocations inside them can use the cached ticket without
-re-prompting, subject to the host's sudoers policy.`,
+timestamp refreshed. Privileged tool commands and system package operations
+run as the invoking user, using the cached sudo ticket without re-prompting
+(subject to sudoers policy). Without --system, privileged and system
+resources are skipped with a warning.`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: runApply,
 }
@@ -92,14 +93,14 @@ func runApply(cmd *cobra.Command, args []string) error {
 	}
 
 	if systemMode {
-		cmd.Printf("Applying resources (including privileged) from %v\n", args)
+		cmd.Printf("Applying resources (including privileged and system) from %v\n", args)
 	} else {
 		cmd.Printf("Applying user-level resources from %v\n", args)
 	}
-	return runUserApply(cmd.Context(), args, cmd.OutOrStdout(), &applyCfg, systemMode)
+	return executeApply(cmd.Context(), args, cmd.OutOrStdout(), &applyCfg, systemMode)
 }
 
-func runUserApply(ctx context.Context, paths []string, w io.Writer, cfg *applyConfig, system bool) error {
+func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyConfig, system bool) error {
 	// Load resources from paths (manifests)
 	loader := config.NewLoader(nil, cfg.verifierOpts()...)
 	resources, err := loader.LoadPaths(paths)
@@ -113,23 +114,40 @@ func runUserApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 		return fmt.Errorf("failed to expand sets: %w", err)
 	}
 
-	// System-privilege resource kinds (SystemInstaller, SystemPackage*) are not
-	// yet implemented by the engine and would otherwise be silently ignored.
-	// Fail fast with a clear error so users know these manifests have no effect.
-	if err := rejectUnsupportedSystemKinds(resources); err != nil {
-		return err
+	// Split resources into user-kind and system-kind
+	userResources, systemResources := resource.FilterSystemKinds(resources)
+
+	// Handle system resources: skip or prepare for execution
+	var sysEng *engine.SystemEngine
+	var supportedSystemResources []resource.Resource
+	if !system && len(systemResources) > 0 {
+		for _, r := range systemResources {
+			slog.Info("skipping system resource (use --system)", "kind", r.Kind(), "name", r.Name())
+		}
+		fmt.Fprintf(w, "%d system resource(s) skipped. Use 'tomei apply --system' to manage.\n\n", len(systemResources))
+	}
+	if system && len(systemResources) > 0 {
+		// Filter to resources with concrete installer implementations
+		supported, skipped := filterSupportedSystemResources(systemResources)
+		supportedSystemResources = supported
+		if len(skipped) > 0 {
+			for _, r := range skipped {
+				slog.Info("skipping system resource (not yet implemented)", "kind", r.Kind(), "name", r.Name())
+			}
+			fmt.Fprintf(w, "%d system resource(s) skipped (not yet implemented: repository/package management).\n\n", len(skipped))
+		}
 	}
 
 	// Filter out privileged resources when --system is not set
 	if !system {
-		normal, privileged := resource.FilterPrivileged(resources)
+		normal, privileged := resource.FilterPrivileged(userResources)
 		if len(privileged) > 0 {
 			for _, r := range privileged {
 				slog.Info("skipping privileged resource (use --system)", "kind", r.Kind(), "name", r.Name())
 			}
 			fmt.Fprintf(w, "%d privileged resource(s) skipped. Use 'tomei apply --system' to install.\n\n", len(privileged))
 		}
-		resources = normal
+		userResources = normal
 	}
 
 	// Load config from fixed path (~/.config/tomei/config.cue)
@@ -188,6 +206,7 @@ func runUserApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 		UpdateTools:    cfg.updateTools || cfg.updateAll,
 		UpdateRuntimes: cfg.updateRuntimes || cfg.updateAll,
 	}
+	// Show plan with all resources (system + user) for complete picture
 	hasChanges, err := planForResources(w, resources, cfg.noColor, updCfg, system)
 	if err != nil {
 		return fmt.Errorf("failed to plan: %w", err)
@@ -245,6 +264,16 @@ func runUserApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 		return nil
 	})
 
+	// Create SystemEngine when --system is set. Even with zero system resources
+	// in the manifest, state may contain entries that need removal.
+	if system {
+		se, err := createSystemEngine(pathConfig.SystemDataDir())
+		if err != nil {
+			return fmt.Errorf("failed to create system engine: %w", err)
+		}
+		sysEng = se
+	}
+
 	// Acquire sudo credentials when --system is set (before TUI to allow interactive prompt).
 	// We always acquire when --system is given, not only when the manifest contains
 	// privileged tools, because privileged tools may exist only in state (removal case).
@@ -259,15 +288,18 @@ func runUserApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 			}
 		}()
 		eng.SetPrivilegeHandler(handler)
+		if sysEng != nil {
+			sysEng.SetPrivilegeHandler(handler)
+		}
 	}
 
 	// Choose TUI or ProgressManager based on TTY
 	isTTY := isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
 	var applyErr error
 	if isTTY && !cfg.quiet {
-		applyErr = runApplyWithTUI(ctx, eng, resources, results, logStore, w, cfg)
+		applyErr = runApplyWithTUI(ctx, eng, userResources, sysEng, supportedSystemResources, results, logStore, w, cfg)
 	} else {
-		applyErr = runApplyWithProgressManager(ctx, eng, resources, results, logStore, w, cfg)
+		applyErr = runApplyWithProgressManager(ctx, eng, userResources, sysEng, supportedSystemResources, results, logStore, w, cfg)
 	}
 
 	// Report privileged action skips after apply completes.
@@ -285,7 +317,9 @@ func runUserApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 func runApplyWithTUI(
 	ctx context.Context,
 	eng *engine.Engine,
-	resources []resource.Resource,
+	userResources []resource.Resource,
+	sysEng *engine.SystemEngine,
+	systemResources []resource.Resource,
 	results *ui.ApplyResults,
 	logStore *tomeilog.Store,
 	w io.Writer,
@@ -305,18 +339,32 @@ func runApplyWithTUI(
 	reporter := ui.NewThrottledReporter(p)
 
 	// Set event handler: forward to reporter + log store
-	eng.SetEventHandler(func(event engine.Event) {
+	eventHandler := func(event engine.Event) {
 		reporter.HandleEvent(event)
 		if logStore != nil {
 			handleLogEvent(logStore, event)
 		}
-	})
+	}
+	eng.SetEventHandler(eventHandler)
+	if sysEng != nil {
+		sysEng.SetEventHandler(eventHandler)
+	}
 
-	// Run engine in background goroutine; signal completion via channel
+	// Run engines in background goroutine; signal completion via channel.
+	// SystemEngine runs first (sequential), then Engine for user resources.
 	engineDone := make(chan struct{})
 	go func() {
 		defer close(engineDone)
-		applyErr := eng.Apply(ctx, resources)
+		if sysEng != nil {
+			if err := sysEng.Apply(ctx, systemResources); err != nil {
+				if ctx.Err() != nil {
+					reporter.Done(ctx.Err())
+					return
+				}
+				slog.Error("system resource apply failed, continuing with user resources", "error", err)
+			}
+		}
+		applyErr := eng.Apply(ctx, userResources)
 		reporter.Done(applyErr)
 	}()
 
@@ -361,7 +409,9 @@ func runApplyWithTUI(
 func runApplyWithProgressManager(
 	ctx context.Context,
 	eng *engine.Engine,
-	resources []resource.Resource,
+	userResources []resource.Resource,
+	sysEng *engine.SystemEngine,
+	systemResources []resource.Resource,
 	results *ui.ApplyResults,
 	logStore *tomeilog.Store,
 	w io.Writer,
@@ -376,20 +426,31 @@ func runApplyWithProgressManager(
 	defer pm.Wait()
 
 	// Set event handler for progress display and log capture
-	if !cfg.quiet {
-		eng.SetEventHandler(func(event engine.Event) {
+	eventHandler := func(event engine.Event) {
+		if !cfg.quiet {
 			pm.HandleEvent(event, results)
-			if logStore != nil {
-				handleLogEvent(logStore, event)
-			}
-		})
-	} else if logStore != nil {
-		eng.SetEventHandler(func(event engine.Event) {
+		}
+		if logStore != nil {
 			handleLogEvent(logStore, event)
-		})
+		}
+	}
+	eng.SetEventHandler(eventHandler)
+	if sysEng != nil {
+		sysEng.SetEventHandler(eventHandler)
 	}
 
-	applyErr := eng.Apply(ctx, resources)
+	// Run system engine first, then user engine
+	if sysEng != nil {
+		if err := sysEng.Apply(ctx, systemResources); err != nil {
+			if ctx.Err() != nil {
+				return finishApply(w, ctx.Err(), results, logStore, cfg)
+			}
+			slog.Error("system resource apply failed, continuing with user resources", "error", err)
+			fmt.Fprintf(w, "Warning: system resource apply failed: %v\n\n", err)
+		}
+	}
+
+	applyErr := eng.Apply(ctx, userResources)
 	return finishApply(w, applyErr, results, logStore, cfg)
 }
 
@@ -517,20 +578,4 @@ func (h *sudoHandler) Release() error {
 		err = exec.CommandContext(releaseCtx, "sudo", "-k").Run()
 	})
 	return err
-}
-
-// rejectUnsupportedSystemKinds returns an error if the resources include any
-// system-privilege kind. The engine does not yet execute SystemInstaller or
-// SystemPackage* resources, so we fail fast rather than silently ignoring them.
-func rejectUnsupportedSystemKinds(resources []resource.Resource) error {
-	var names []string
-	for _, r := range resources {
-		if resource.IsSystemKind(r.Kind()) {
-			names = append(names, fmt.Sprintf("%s/%s", r.Kind(), r.Name()))
-		}
-	}
-	if len(names) > 0 {
-		return fmt.Errorf("system-privilege resources are not yet supported: %s", strings.Join(names, ", "))
-	}
-	return nil
 }

--- a/cmd/tomei/plan.go
+++ b/cmd/tomei/plan.go
@@ -168,7 +168,8 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 	for _, res := range resources {
 		nodeID := graph.NewNodeID(res.Kind(), res.Name())
 
-		// System resources are handled separately via PlanAll
+		// System resources are added separately via addSystemResourceInfo using
+		// the read-only store and reconcilers, so skip them in this per-resource loop.
 		if resource.IsSystemKind(res.Kind()) {
 			continue
 		}
@@ -467,7 +468,8 @@ func addSystemResourceInfo(info map[graph.NodeID]graph.ResourceInfo, resources [
 	// plan is a read-only command and should not create directories.
 	systemDir := pathConfig.SystemDataDir()
 	if _, err := os.Stat(systemDir); os.IsNotExist(err) {
-		// No system state yet (first run) — mark all as install
+		// No system state yet (first run) — use install fallback for supported
+		// system installers and skip unsupported system resource kinds.
 		markAllSystemAsInstall(info, resources)
 		return
 	}

--- a/cmd/tomei/plan.go
+++ b/cmd/tomei/plan.go
@@ -16,6 +16,7 @@ import (
 	"github.com/terassyi/tomei/internal/github"
 	"github.com/terassyi/tomei/internal/graph"
 	"github.com/terassyi/tomei/internal/installer/engine"
+	"github.com/terassyi/tomei/internal/installer/reconciler"
 	"github.com/terassyi/tomei/internal/path"
 	"github.com/terassyi/tomei/internal/registry/aqua"
 	"github.com/terassyi/tomei/internal/resource"
@@ -98,11 +99,6 @@ func runPlan(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to expand sets: %w", err)
 	}
 
-	// Reject unsupported system-privilege resource kinds (see apply.go for rationale).
-	if err := rejectUnsupportedSystemKinds(resources); err != nil {
-		return err
-	}
-
 	updateCfg := engine.UpdateConfig{
 		SyncMode:       planCfg.syncRegistry,
 		UpdateTools:    planCfg.updateTools || planCfg.updateAll,
@@ -136,10 +132,12 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 
 	// Load config and state
 	var userState *state.UserState
+	var pathConfig *path.Paths
 	cfg, err := config.LoadConfig(config.DefaultConfigDir)
 	if err == nil {
-		pathConfig, err := path.NewFromConfig(cfg)
+		pc, err := path.NewFromConfig(cfg)
 		if err == nil {
+			pathConfig = pc
 			store, err := state.NewStore[state.UserState](pathConfig.UserDataDir())
 			if err == nil {
 				loaded, err := store.LoadReadOnly()
@@ -161,6 +159,12 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 
 	for _, res := range resources {
 		nodeID := graph.NewNodeID(res.Kind(), res.Name())
+
+		// System resources are handled separately via PlanAll
+		if resource.IsSystemKind(res.Kind()) {
+			continue
+		}
+
 		resInfo := graph.ResourceInfo{
 			Kind:   res.Kind(),
 			Name:   res.Name(),
@@ -214,6 +218,23 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 		}
 
 		info[nodeID] = resInfo
+	}
+
+	// Handle system resources
+	if system && pathConfig != nil {
+		addSystemResourceInfo(info, resources, pathConfig)
+	} else {
+		// Without --system, mark all system resources as skip
+		for _, res := range resources {
+			if resource.IsSystemKind(res.Kind()) {
+				nodeID := graph.NewNodeID(res.Kind(), res.Name())
+				info[nodeID] = graph.ResourceInfo{
+					Kind:   res.Kind(),
+					Name:   res.Name(),
+					Action: resource.ActionSkip,
+				}
+			}
+		}
 	}
 
 	// Detect removals: resources in state but not in manifests
@@ -428,6 +449,104 @@ func collectSkipInfos(resourceInfo map[graph.NodeID]graph.ResourceInfo) []graph.
 		return cmp.Compare(a.Name, b.Name)
 	})
 	return infos
+}
+
+// noopInstaller is a generic no-op installer used by PlanAll for plan-only
+// operations where the installer is never actually called.
+type noopInstaller[R resource.Resource, S resource.State] struct{}
+
+func (*noopInstaller[R, S]) Install(_ context.Context, _ R, _ string) (S, error) {
+	var zero S
+	return zero, nil
+}
+
+func (*noopInstaller[R, S]) Remove(_ context.Context, _ S, _ string) error {
+	return nil
+}
+
+// addSystemResourceInfo uses SystemEngine.PlanAll to compute accurate actions
+// for system resources and merges them into the info map.
+func addSystemResourceInfo(info map[graph.NodeID]graph.ResourceInfo, resources []resource.Resource, pathConfig *path.Paths) {
+	// Check if system state directory exists before creating a store.
+	// plan is a read-only command and should not create directories.
+	systemDir := pathConfig.SystemDataDir()
+	if _, err := os.Stat(systemDir); os.IsNotExist(err) {
+		// No system state yet (first run) — mark all as install
+		markAllSystemAsInstall(info, resources)
+		return
+	}
+
+	store, err := state.NewStore[state.SystemState](systemDir)
+	if err != nil {
+		markAllSystemAsInstall(info, resources)
+		return
+	}
+
+	// PlanAll uses reconcilers only; installers are never called, so noop is safe.
+	sysEng := engine.NewSystemEngine(
+		&noopInstaller[*resource.SystemInstaller, *resource.SystemInstallerState]{},
+		&noopInstaller[*resource.SystemPackageRepository, *resource.SystemPackageRepositoryState]{},
+		&noopInstaller[*resource.SystemPackageSet, *resource.SystemPackageSetState]{},
+		store,
+	)
+
+	ctx := context.Background()
+	installerActions, repoActions, pkgActions, err := sysEng.PlanAll(ctx, resources)
+	if err != nil {
+		slog.Warn("failed to plan system resources", "error", err)
+		markAllSystemAsInstall(info, resources)
+		return
+	}
+
+	convertActions[*resource.SystemInstaller, *resource.SystemInstallerState](info, resource.KindSystemInstaller, installerActions)
+	convertActions[*resource.SystemPackageRepository, *resource.SystemPackageRepositoryState](info, resource.KindSystemPackageRepository, repoActions)
+	convertActions[*resource.SystemPackageSet, *resource.SystemPackageSetState](info, resource.KindSystemPackageSet, pkgActions)
+
+	// Mark repo/package resources as skip when they would require actions,
+	// since concrete installers are not yet implemented.
+	for nodeID, ri := range info {
+		if ri.Kind == resource.KindSystemPackageRepository || ri.Kind == resource.KindSystemPackageSet {
+			if ri.Action != resource.ActionNone {
+				ri.Action = resource.ActionSkip
+				info[nodeID] = ri
+			}
+		}
+	}
+}
+
+// markAllSystemAsInstall marks all system resources as ActionInstall (first-run fallback).
+func markAllSystemAsInstall(info map[graph.NodeID]graph.ResourceInfo, resources []resource.Resource) {
+	for _, res := range resources {
+		if resource.IsSystemKind(res.Kind()) {
+			nodeID := graph.NewNodeID(res.Kind(), res.Name())
+			action := resource.ActionInstall
+			// repo/package not yet implemented — skip
+			if res.Kind() != resource.KindSystemInstaller {
+				action = resource.ActionSkip
+			}
+			info[nodeID] = graph.ResourceInfo{
+				Kind:   res.Kind(),
+				Name:   res.Name(),
+				Action: action,
+			}
+		}
+	}
+}
+
+// convertActions converts reconciler actions to graph.ResourceInfo entries.
+func convertActions[R resource.Resource, S resource.State](
+	info map[graph.NodeID]graph.ResourceInfo,
+	kind resource.Kind,
+	actions []reconciler.Action[R, S],
+) {
+	for _, action := range actions {
+		nodeID := graph.NewNodeID(kind, action.Name)
+		info[nodeID] = graph.ResourceInfo{
+			Kind:   kind,
+			Name:   action.Name,
+			Action: action.Type,
+		}
+	}
 }
 
 // syncRegistryForPlan creates a store and syncs the aqua registry.

--- a/cmd/tomei/plan.go
+++ b/cmd/tomei/plan.go
@@ -148,6 +148,14 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 		}
 	}
 
+	// Fall back to default paths when config is unavailable, so system
+	// resource plans can still compute SystemDataDir accurately.
+	if pathConfig == nil {
+		if pc, err := path.New(); err == nil {
+			pathConfig = pc
+		}
+	}
+
 	if userState == nil {
 		fmt.Fprintln(os.Stderr, "Warning: tomei is not initialized. Run 'tomei init' for accurate state comparison.")
 	}
@@ -451,21 +459,9 @@ func collectSkipInfos(resourceInfo map[graph.NodeID]graph.ResourceInfo) []graph.
 	return infos
 }
 
-// noopInstaller is a generic no-op installer used by PlanAll for plan-only
-// operations where the installer is never actually called.
-type noopInstaller[R resource.Resource, S resource.State] struct{}
-
-func (*noopInstaller[R, S]) Install(_ context.Context, _ R, _ string) (S, error) {
-	var zero S
-	return zero, nil
-}
-
-func (*noopInstaller[R, S]) Remove(_ context.Context, _ S, _ string) error {
-	return nil
-}
-
-// addSystemResourceInfo uses SystemEngine.PlanAll to compute accurate actions
-// for system resources and merges them into the info map.
+// addSystemResourceInfo computes accurate actions for system resources
+// using reconcilers and LoadReadOnly (no lock, no filesystem side effects)
+// and merges them into the info map.
 func addSystemResourceInfo(info map[graph.NodeID]graph.ResourceInfo, resources []resource.Resource, pathConfig *path.Paths) {
 	// Check if system state directory exists before creating a store.
 	// plan is a read-only command and should not create directories.
@@ -482,21 +478,34 @@ func addSystemResourceInfo(info map[graph.NodeID]graph.ResourceInfo, resources [
 		return
 	}
 
-	// PlanAll uses reconcilers only; installers are never called, so noop is safe.
-	sysEng := engine.NewSystemEngine(
-		&noopInstaller[*resource.SystemInstaller, *resource.SystemInstallerState]{},
-		&noopInstaller[*resource.SystemPackageRepository, *resource.SystemPackageRepositoryState]{},
-		&noopInstaller[*resource.SystemPackageSet, *resource.SystemPackageSetState]{},
-		store,
-	)
-
-	ctx := context.Background()
-	installerActions, repoActions, pkgActions, err := sysEng.PlanAll(ctx, resources)
+	// Use LoadReadOnly to avoid acquiring the state lock.
+	// plan should have no filesystem side effects.
+	st, err := store.LoadReadOnly()
 	if err != nil {
-		slog.Warn("failed to plan system resources", "error", err)
+		slog.Warn("failed to load system state for plan", "error", err)
 		markAllSystemAsInstall(info, resources)
 		return
 	}
+
+	// Extract system resources by kind
+	var installers []*resource.SystemInstaller
+	var repos []*resource.SystemPackageRepository
+	var packages []*resource.SystemPackageSet
+	for _, res := range resources {
+		switch r := res.(type) {
+		case *resource.SystemInstaller:
+			installers = append(installers, r)
+		case *resource.SystemPackageRepository:
+			repos = append(repos, r)
+		case *resource.SystemPackageSet:
+			packages = append(packages, r)
+		}
+	}
+
+	// Reconcile each resource type directly (reconcilers are stateless)
+	installerActions := reconciler.NewSystemInstallerReconciler().Reconcile(installers, st.SystemInstallers)
+	repoActions := reconciler.NewSystemPackageRepositoryReconciler().Reconcile(repos, st.SystemPackageRepositories)
+	pkgActions := reconciler.NewSystemPackageSetReconciler().Reconcile(packages, st.SystemPackages)
 
 	convertActions[*resource.SystemInstaller, *resource.SystemInstallerState](info, resource.KindSystemInstaller, installerActions)
 	convertActions[*resource.SystemPackageRepository, *resource.SystemPackageRepositoryState](info, resource.KindSystemPackageRepository, repoActions)

--- a/cmd/tomei/root.go
+++ b/cmd/tomei/root.go
@@ -120,7 +120,7 @@ Commands are separated by privilege level:
 
 func init() {
 	// Global flags
-	rootCmd.PersistentFlags().BoolVar(&systemMode, "system", false, "Enable privileged tool operations; tomei caches a sudo timestamp so tool commands can invoke 'sudo' internally using it (subject to sudoers policy)")
+	rootCmd.PersistentFlags().BoolVar(&systemMode, "system", false, "Enable system package management and privileged operations. System state is stored per-user (~/.local/share/tomei/system/). In multi-user environments, each user maintains an independent view of system package state. This tool is designed for personal dev environment setup and does not detect out-of-band system changes")
 	rootCmd.PersistentFlags().Var(globalLogLevel, "log-level", "Log level (debug, info, warn, error)")
 	_ = rootCmd.RegisterFlagCompletionFunc("log-level", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"debug", "info", "warn", "error"}, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/tomei/system_engine.go
+++ b/cmd/tomei/system_engine.go
@@ -24,8 +24,11 @@ func (a *validatorInstallerAdapter) Install(ctx context.Context, res *resource.S
 	return a.validator.Validate(ctx, res)
 }
 
-func (a *validatorInstallerAdapter) Remove(_ context.Context, _ *resource.SystemInstallerState, name string) error {
-	return fmt.Errorf("removing system package manager %q is not supported: managed by the OS", name)
+func (a *validatorInstallerAdapter) Remove(_ context.Context, _ *resource.SystemInstallerState, _ string) error {
+	// System package managers are OS-managed and cannot actually be removed.
+	// Returning nil allows the executor to delete the stale state entry when
+	// a SystemInstaller is dropped from the manifest.
+	return nil
 }
 
 // skipRepoInstaller is a placeholder for SystemPackageRepository operations.

--- a/cmd/tomei/system_engine.go
+++ b/cmd/tomei/system_engine.go
@@ -22,6 +22,9 @@ type validatorInstallerAdapter struct {
 }
 
 func (a *validatorInstallerAdapter) Install(ctx context.Context, res *resource.SystemInstaller, _ string) (*resource.SystemInstallerState, error) {
+	if a.validator == nil {
+		return nil, fmt.Errorf("system package manager validation unavailable: distro detection failed or unsupported platform")
+	}
 	return a.validator.Validate(ctx, res)
 }
 
@@ -81,20 +84,25 @@ func createSystemEngine(systemDataDir string) (*engine.SystemEngine, error) {
 		return nil, fmt.Errorf("failed to create system state store: %w", err)
 	}
 
+	// Distro detection and validator creation are best-effort.
+	// When unavailable (e.g., macOS, minimal containers), the engine can
+	// still run removals (state cleanup) — only Install actions will fail.
+	var validator *system.Validator
 	distro, err := system.DetectDistro()
 	if err != nil {
-		return nil, fmt.Errorf("failed to detect Linux distribution: %w", err)
-	}
-	slog.Debug("detected distribution", "id", distro.ID, "id_like", distro.IDLike)
-
-	runner := command.NewExecutor("")
-	versionFuncs := map[system.PackageManager]system.VersionFunc{
-		system.PackageManagerAPT: apt.VersionFunc(runner),
-	}
-
-	validator, err := system.NewValidator(distro, versionFuncs)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create system validator: %w", err)
+		slog.Warn("system distro detection unavailable; system installer validation will be skipped", "error", err)
+	} else {
+		slog.Debug("detected distribution", "id", distro.ID, "id_like", distro.IDLike)
+		runner := command.NewExecutor("")
+		versionFuncs := map[system.PackageManager]system.VersionFunc{
+			system.PackageManagerAPT: apt.VersionFunc(runner),
+		}
+		v, err := system.NewValidator(distro, versionFuncs)
+		if err != nil {
+			slog.Warn("failed to create system validator; system installer validation will be skipped", "error", err)
+		} else {
+			validator = v
+		}
 	}
 
 	eng := engine.NewSystemEngine(

--- a/cmd/tomei/system_engine.go
+++ b/cmd/tomei/system_engine.go
@@ -15,7 +15,8 @@ import (
 
 // validatorInstallerAdapter wraps system.Validator as executor.Installer
 // for SystemInstaller resources. Install validates the package manager;
-// Remove always returns an error because OS package managers cannot be removed.
+// Remove is a no-op that allows stale state entries to be cleaned up;
+// OS package managers themselves are not removed.
 type validatorInstallerAdapter struct {
 	validator *system.Validator
 }

--- a/cmd/tomei/system_engine.go
+++ b/cmd/tomei/system_engine.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/terassyi/tomei/internal/installer/apt"
+	"github.com/terassyi/tomei/internal/installer/command"
+	"github.com/terassyi/tomei/internal/installer/engine"
+	"github.com/terassyi/tomei/internal/resource"
+	"github.com/terassyi/tomei/internal/state"
+	"github.com/terassyi/tomei/internal/system"
+)
+
+// validatorInstallerAdapter wraps system.Validator as executor.Installer
+// for SystemInstaller resources. Install validates the package manager;
+// Remove always returns an error because OS package managers cannot be removed.
+type validatorInstallerAdapter struct {
+	validator *system.Validator
+}
+
+func (a *validatorInstallerAdapter) Install(ctx context.Context, res *resource.SystemInstaller, _ string) (*resource.SystemInstallerState, error) {
+	return a.validator.Validate(ctx, res)
+}
+
+func (a *validatorInstallerAdapter) Remove(_ context.Context, _ *resource.SystemInstallerState, name string) error {
+	return fmt.Errorf("removing system package manager %q is not supported: managed by the OS", name)
+}
+
+// skipRepoInstaller is a placeholder for SystemPackageRepository operations.
+// Concrete implementations (e.g., APT add-apt-repository) are tracked as a future issue.
+type skipRepoInstaller struct{}
+
+func (*skipRepoInstaller) Install(_ context.Context, _ *resource.SystemPackageRepository, name string) (*resource.SystemPackageRepositoryState, error) {
+	return nil, fmt.Errorf("system package repository %q: repository management is not yet implemented", name)
+}
+
+func (*skipRepoInstaller) Remove(_ context.Context, _ *resource.SystemPackageRepositoryState, name string) error {
+	return fmt.Errorf("system package repository %q: repository management is not yet implemented", name)
+}
+
+// skipPackageInstaller is a placeholder for SystemPackageSet operations.
+// Concrete implementations (e.g., APT apt-get install) are tracked as a future issue.
+type skipPackageInstaller struct{}
+
+func (*skipPackageInstaller) Install(_ context.Context, _ *resource.SystemPackageSet, name string) (*resource.SystemPackageSetState, error) {
+	return nil, fmt.Errorf("system package set %q: package management is not yet implemented", name)
+}
+
+func (*skipPackageInstaller) Remove(_ context.Context, _ *resource.SystemPackageSetState, name string) error {
+	return fmt.Errorf("system package set %q: package management is not yet implemented", name)
+}
+
+// filterSupportedSystemResources returns resources that have concrete installer
+// implementations (currently only SystemInstaller). Unsupported resources
+// (SystemPackageRepository, SystemPackageSet) are returned separately so the
+// caller can warn and skip them.
+func filterSupportedSystemResources(resources []resource.Resource) (supported, skipped []resource.Resource) {
+	for _, res := range resources {
+		switch res.Kind() {
+		case resource.KindSystemInstaller:
+			supported = append(supported, res)
+		default:
+			skipped = append(skipped, res)
+		}
+	}
+	return supported, skipped
+}
+
+// createSystemEngine builds a SystemEngine with the available concrete
+// installers for the detected distribution. It auto-creates the system
+// state directory if it does not exist.
+func createSystemEngine(systemDataDir string) (*engine.SystemEngine, error) {
+	store, err := state.NewStore[state.SystemState](systemDataDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create system state store: %w", err)
+	}
+
+	distro, err := system.DetectDistro()
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect Linux distribution: %w", err)
+	}
+	slog.Debug("detected distribution", "id", distro.ID, "id_like", distro.IDLike)
+
+	runner := command.NewExecutor("")
+	versionFuncs := map[system.PackageManager]system.VersionFunc{
+		system.PackageManagerAPT: apt.VersionFunc(runner),
+	}
+
+	validator, err := system.NewValidator(distro, versionFuncs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create system validator: %w", err)
+	}
+
+	eng := engine.NewSystemEngine(
+		&validatorInstallerAdapter{validator: validator},
+		&skipRepoInstaller{},
+		&skipPackageInstaller{},
+		store,
+	)
+	return eng, nil
+}

--- a/cmd/tomei/system_engine_test.go
+++ b/cmd/tomei/system_engine_test.go
@@ -12,10 +12,10 @@ import (
 func TestValidatorInstallerAdapter_Remove(t *testing.T) {
 	t.Parallel()
 	adapter := &validatorInstallerAdapter{validator: nil}
+	// Remove is a no-op: system package managers are OS-managed, so
+	// "removing" just cleans the state entry.
 	err := adapter.Remove(context.Background(), nil, "apt")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not supported")
-	assert.Contains(t, err.Error(), "apt")
+	require.NoError(t, err)
 }
 
 func TestSkipRepoInstaller(t *testing.T) {

--- a/cmd/tomei/system_engine_test.go
+++ b/cmd/tomei/system_engine_test.go
@@ -18,6 +18,16 @@ func TestValidatorInstallerAdapter_Remove(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestValidatorInstallerAdapter_Install_NilValidator(t *testing.T) {
+	t.Parallel()
+	// When distro detection fails, validator is nil.
+	// Install should return a clear error instead of panicking.
+	adapter := &validatorInstallerAdapter{validator: nil}
+	_, err := adapter.Install(context.Background(), nil, "apt")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "distro detection failed")
+}
+
 func TestSkipRepoInstaller(t *testing.T) {
 	t.Parallel()
 	installer := &skipRepoInstaller{}

--- a/cmd/tomei/system_engine_test.go
+++ b/cmd/tomei/system_engine_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/terassyi/tomei/internal/resource"
+)
+
+func TestValidatorInstallerAdapter_Remove(t *testing.T) {
+	t.Parallel()
+	adapter := &validatorInstallerAdapter{validator: nil}
+	err := adapter.Remove(context.Background(), nil, "apt")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not supported")
+	assert.Contains(t, err.Error(), "apt")
+}
+
+func TestSkipRepoInstaller(t *testing.T) {
+	t.Parallel()
+	installer := &skipRepoInstaller{}
+
+	t.Run("Install", func(t *testing.T) {
+		t.Parallel()
+		_, err := installer.Install(context.Background(), nil, "docker-repo")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not yet implemented")
+		assert.Contains(t, err.Error(), "docker-repo")
+	})
+
+	t.Run("Remove", func(t *testing.T) {
+		t.Parallel()
+		err := installer.Remove(context.Background(), nil, "docker-repo")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not yet implemented")
+	})
+}
+
+func TestSkipPackageInstaller(t *testing.T) {
+	t.Parallel()
+	installer := &skipPackageInstaller{}
+
+	t.Run("Install", func(t *testing.T) {
+		t.Parallel()
+		_, err := installer.Install(context.Background(), nil, "dev-tools")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not yet implemented")
+		assert.Contains(t, err.Error(), "dev-tools")
+	})
+
+	t.Run("Remove", func(t *testing.T) {
+		t.Parallel()
+		err := installer.Remove(context.Background(), nil, "dev-tools")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not yet implemented")
+	})
+}
+
+func TestFilterSupportedSystemResources(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+		supported, skipped := filterSupportedSystemResources(nil)
+		assert.Empty(t, supported)
+		assert.Empty(t, skipped)
+	})
+
+	t.Run("installer only", func(t *testing.T) {
+		t.Parallel()
+		resources := []resource.Resource{
+			&resource.SystemInstaller{BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "apt"}}},
+		}
+		supported, skipped := filterSupportedSystemResources(resources)
+		assert.Len(t, supported, 1)
+		assert.Empty(t, skipped)
+	})
+
+	t.Run("mixed", func(t *testing.T) {
+		t.Parallel()
+		resources := []resource.Resource{
+			&resource.SystemInstaller{BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "apt"}}},
+			&resource.SystemPackageRepository{BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "docker-repo"}}},
+			&resource.SystemPackageSet{BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "dev-tools"}}},
+		}
+		supported, skipped := filterSupportedSystemResources(resources)
+		assert.Len(t, supported, 1)
+		assert.Equal(t, "apt", supported[0].Name())
+		assert.Len(t, skipped, 2)
+	})
+}

--- a/internal/installer/engine/system_engine.go
+++ b/internal/installer/engine/system_engine.go
@@ -196,11 +196,7 @@ func (e *SystemEngine) Apply(ctx context.Context, resources []resource.Resource)
 			}
 
 			if err := e.executeSystemNode(ctx, node, resourceMap, &totalActions); err != nil {
-				// Flush what we have before returning
-				if flushErr := e.stateCache.Flush(); flushErr != nil {
-					slog.Warn("failed to flush state after error", "error", flushErr)
-				}
-				return err
+				return flushAndReturn(err)
 			}
 		}
 
@@ -292,6 +288,7 @@ func reconcileAndExecute[R resource.Resource, S resource.State](
 		Kind:   kind,
 		Name:   action.Name,
 		Action: action.Type,
+		Method: "system",
 	})
 
 	if err := exec.Execute(ctx, action); err != nil {

--- a/internal/installer/engine/system_engine.go
+++ b/internal/installer/engine/system_engine.go
@@ -297,6 +297,7 @@ func reconcileAndExecute[R resource.Resource, S resource.State](
 			Kind:   kind,
 			Name:   action.Name,
 			Action: action.Type,
+			Method: "system",
 			Error:  err,
 		})
 		return fmt.Errorf("failed to execute action %s for %s %s: %w", action.Type, kind, action.Name, err)
@@ -307,6 +308,7 @@ func reconcileAndExecute[R resource.Resource, S resource.State](
 		Kind:   kind,
 		Name:   action.Name,
 		Action: action.Type,
+		Method: "system",
 	})
 
 	*totalActions++

--- a/internal/installer/engine/system_engine_test.go
+++ b/internal/installer/engine/system_engine_test.go
@@ -506,6 +506,11 @@ func TestSystemEngine_Apply_Events(t *testing.T) {
 	// Verify kinds are correct
 	assert.Equal(t, resource.KindSystemInstaller, starts[0].Kind)
 	assert.Equal(t, resource.KindSystemPackageRepository, starts[1].Kind)
+
+	// Verify method is set to "system" for all start events
+	for _, e := range starts {
+		assert.Equal(t, "system", e.Method, "system engine events should have Method=\"system\"")
+	}
 }
 
 func TestSystemEngine_Apply_UpgradeRepo(t *testing.T) {

--- a/internal/installer/engine/system_engine_test.go
+++ b/internal/installer/engine/system_engine_test.go
@@ -507,9 +507,12 @@ func TestSystemEngine_Apply_Events(t *testing.T) {
 	assert.Equal(t, resource.KindSystemInstaller, starts[0].Kind)
 	assert.Equal(t, resource.KindSystemPackageRepository, starts[1].Kind)
 
-	// Verify method is set to "system" for all start events
+	// Verify method is set to "system" for all emitted success-path events
 	for _, e := range starts {
-		assert.Equal(t, "system", e.Method, "system engine events should have Method=\"system\"")
+		assert.Equal(t, "system", e.Method, "system engine start events should have Method=\"system\"")
+	}
+	for _, e := range completes {
+		assert.Equal(t, "system", e.Method, "system engine complete events should have Method=\"system\"")
 	}
 }
 

--- a/internal/path/path.go
+++ b/internal/path/path.go
@@ -8,11 +8,6 @@ import (
 	"github.com/terassyi/tomei/internal/config"
 )
 
-// Default path constants
-const (
-	DefaultSystemDataDir = "/var/lib/tomei"
-)
-
 // Default path suffixes (relative to home directory)
 const (
 	defaultUserDataSuffix  = ".local/share/tomei"
@@ -64,7 +59,7 @@ func New(opts ...Option) (*Paths, error) {
 		userDataDir:   filepath.Join(home, defaultUserDataSuffix),
 		userBinDir:    filepath.Join(home, defaultUserBinSuffix),
 		userCacheDir:  filepath.Join(home, defaultUserCacheSuffix),
-		systemDataDir: DefaultSystemDataDir,
+		systemDataDir: filepath.Join(home, defaultUserDataSuffix, "system"),
 	}
 
 	for _, opt := range opts {
@@ -167,7 +162,7 @@ func NewFromConfig(cfg *config.Config) (*Paths, error) {
 		userBinDir:    binDir,
 		userCacheDir:  filepath.Join(home, defaultUserCacheSuffix),
 		envDir:        envDir,
-		systemDataDir: DefaultSystemDataDir,
+		systemDataDir: filepath.Join(dataDir, "system"),
 	}, nil
 }
 

--- a/internal/path/path_test.go
+++ b/internal/path/path_test.go
@@ -28,21 +28,21 @@ func TestNew(t *testing.T) {
 			opts:            nil,
 			wantUserDataDir: filepath.Join(home, ".local/share/tomei"),
 			wantUserBinDir:  filepath.Join(home, ".local/bin"),
-			wantSystemDir:   DefaultSystemDataDir,
+			wantSystemDir:   filepath.Join(home, ".local/share/tomei/system"),
 		},
 		{
 			name:            "with custom user data dir",
 			opts:            []Option{WithUserDataDir("/custom/data")},
 			wantUserDataDir: "/custom/data",
 			wantUserBinDir:  filepath.Join(home, ".local/bin"),
-			wantSystemDir:   DefaultSystemDataDir,
+			wantSystemDir:   filepath.Join(home, ".local/share/tomei/system"),
 		},
 		{
 			name:            "with custom user bin dir",
 			opts:            []Option{WithUserBinDir("/custom/bin")},
 			wantUserDataDir: filepath.Join(home, ".local/share/tomei"),
 			wantUserBinDir:  "/custom/bin",
-			wantSystemDir:   DefaultSystemDataDir,
+			wantSystemDir:   filepath.Join(home, ".local/share/tomei/system"),
 		},
 		{
 			name:            "with custom system data dir",
@@ -296,6 +296,7 @@ func TestNewFromConfig(t *testing.T) {
 		cfg             *config.Config
 		wantUserDataDir string
 		wantUserBinDir  string
+		wantSystemDir   string
 	}{
 		{
 			name: "default config",
@@ -305,6 +306,7 @@ func TestNewFromConfig(t *testing.T) {
 			},
 			wantUserDataDir: filepath.Join(home, ".local/share/tomei"),
 			wantUserBinDir:  filepath.Join(home, ".local/bin"),
+			wantSystemDir:   filepath.Join(home, ".local/share/tomei/system"),
 		},
 		{
 			name: "custom config with tilde",
@@ -314,6 +316,7 @@ func TestNewFromConfig(t *testing.T) {
 			},
 			wantUserDataDir: filepath.Join(home, "my-data"),
 			wantUserBinDir:  filepath.Join(home, "my-bin"),
+			wantSystemDir:   filepath.Join(home, "my-data/system"),
 		},
 		{
 			name: "absolute paths",
@@ -323,6 +326,7 @@ func TestNewFromConfig(t *testing.T) {
 			},
 			wantUserDataDir: "/opt/tomei/data",
 			wantUserBinDir:  "/opt/tomei/bin",
+			wantSystemDir:   "/opt/tomei/data/system",
 		},
 	}
 
@@ -335,6 +339,7 @@ func TestNewFromConfig(t *testing.T) {
 
 			assert.Equal(t, tt.wantUserDataDir, p.UserDataDir())
 			assert.Equal(t, tt.wantUserBinDir, p.UserBinDir())
+			assert.Equal(t, tt.wantSystemDir, p.SystemDataDir())
 		})
 	}
 }

--- a/internal/resource/expand.go
+++ b/internal/resource/expand.go
@@ -85,6 +85,19 @@ func IsPrivileged(res Resource) bool {
 	return false
 }
 
+// FilterSystemKinds partitions resources into user-kind and system-kind groups.
+// User-kind resources are returned first, system-kind second.
+func FilterSystemKinds(resources []Resource) (user, system []Resource) {
+	for _, res := range resources {
+		if IsSystemKind(res.Kind()) {
+			system = append(system, res)
+		} else {
+			user = append(user, res)
+		}
+	}
+	return user, system
+}
+
 // FilterPrivileged partitions resources into non-privileged and privileged groups.
 // Non-privileged resources are returned first, privileged second.
 func FilterPrivileged(resources []Resource) (normal, privileged []Resource) {

--- a/internal/resource/expand_test.go
+++ b/internal/resource/expand_test.go
@@ -618,6 +618,57 @@ func TestFilterPrivileged(t *testing.T) {
 	assert.Equal(t, "go", normal[1].Name())
 }
 
+func TestFilterSystemKinds(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+		user, system := FilterSystemKinds(nil)
+		assert.Empty(t, user)
+		assert.Empty(t, system)
+	})
+
+	t.Run("user only", func(t *testing.T) {
+		t.Parallel()
+		resources := []Resource{
+			&Tool{BaseResource: BaseResource{Metadata: Metadata{Name: "rg"}}},
+			&Runtime{BaseResource: BaseResource{Metadata: Metadata{Name: "go"}}},
+		}
+		user, system := FilterSystemKinds(resources)
+		assert.Len(t, user, 2)
+		assert.Empty(t, system)
+	})
+
+	t.Run("system only", func(t *testing.T) {
+		t.Parallel()
+		resources := []Resource{
+			&SystemInstaller{BaseResource: BaseResource{Metadata: Metadata{Name: "apt"}}},
+			&SystemPackageRepository{BaseResource: BaseResource{Metadata: Metadata{Name: "docker-repo"}}},
+			&SystemPackageSet{BaseResource: BaseResource{Metadata: Metadata{Name: "dev-tools"}}},
+		}
+		user, system := FilterSystemKinds(resources)
+		assert.Empty(t, user)
+		assert.Len(t, system, 3)
+	})
+
+	t.Run("mixed", func(t *testing.T) {
+		t.Parallel()
+		resources := []Resource{
+			&Tool{BaseResource: BaseResource{Metadata: Metadata{Name: "rg"}}},
+			&SystemInstaller{BaseResource: BaseResource{Metadata: Metadata{Name: "apt"}}},
+			&Runtime{BaseResource: BaseResource{Metadata: Metadata{Name: "go"}}},
+			&SystemPackageSet{BaseResource: BaseResource{Metadata: Metadata{Name: "dev-tools"}}},
+		}
+		user, system := FilterSystemKinds(resources)
+		assert.Len(t, user, 2)
+		assert.Equal(t, "rg", user[0].Name())
+		assert.Equal(t, "go", user[1].Name())
+		assert.Len(t, system, 2)
+		assert.Equal(t, "apt", system[0].Name())
+		assert.Equal(t, "dev-tools", system[1].Name())
+	})
+}
+
 func TestHasPrivileged(t *testing.T) {
 	t.Parallel()
 

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -40,9 +40,17 @@ func NewUserStore() (*Store[UserState], error) {
 }
 
 // NewSystemStore creates a Store for system state.
-// Default path: /var/lib/tomei/state.json
+// Default path: ~/.local/share/tomei/system/state.json
+//
+// Prefer using NewStore[SystemState](pathConfig.SystemDataDir()) in cmd code
+// where path configuration is available.
 func NewSystemStore() (*Store[SystemState], error) {
-	return NewStore[SystemState]("/var/lib/tomei")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get home directory: %w", err)
+	}
+	dir := filepath.Join(home, ".local", "share", "tomei", "system")
+	return NewStore[SystemState](dir)
 }
 
 // NewStore creates a new Store with the given directory.


### PR DESCRIPTION
Wire SystemEngine into the CLI, removing the rejectUnsupportedSystemKinds
guard. System resources (SystemInstaller, SystemPackageRepository,
SystemPackageSet) are now recognized by both apply and plan commands.

Key changes:
- Split resources into user-kind and system-kind via FilterSystemKinds
- With --system: create SystemEngine, run Apply before user Engine;
  system failure warns but does not block user resource processing
- Without --system: system resources shown as skip with warning
- Plan uses SystemEngine.PlanAll for accurate action computation
- System state stored per-user at ~/.local/share/tomei/system/
- Event Method field set to "system" to prevent UI download pattern
- Repo/package installers stubbed (concrete APT impl is future work)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
