### PR TITLE
docs: document system package management (#168)

### DIFF
--- a/docs/cue-schema.md
+++ b/docs/cue-schema.md
@@ -279,8 +279,10 @@ spec: {
 
 System-level package manager. Requires `--system` to be applied. Only `apt` is currently wired into the engine; declaring other package managers can fail at apply time in several ways depending on the host:
 
+- error contains `unknown package manager "<x>"` — `metadata.name` isn't one of the known identifiers (`apt`, `dnf`, `zypper`, `pacman`, `apk`)
 - error contains `package manager "<x>" is not supported on this system` (with appended distro context such as `(ID=..., ID_LIKE=...)`) — the host's distro does not match
 - error contains `no version function registered for package manager "<x>"` — the package manager is not yet wired up in tomei
+- error contains `failed to get version for "<x>"` — the version probe itself failed (e.g., the package manager binary is missing or returned an unexpected output)
 - error contains `system package manager validation unavailable: distro detection failed or unsupported platform` — running on a host where distro detection isn't available (e.g., macOS, minimal containers)
 
 `metadata.name` must match a known package manager identifier (`apt`, `dnf`, `zypper`, `pacman`, `apk`); identifiers other than `apt` are not currently supported by the engine.
@@ -313,7 +315,7 @@ The CUE schema requires `spec.pattern`, `spec.privileged`, and `spec.commands` (
 | `spec.commands.check` | object | recommended | `{command: string, verb: string}` — used by future package operations |
 | `spec.commands.update` | string | no | Optional update command |
 
-`verb` is a string field defined on each command entry but is not currently consumed anywhere in the engine. It is intended as a human-readable label for future log/progress-UI integration. Unlike [CommandSet](#commandset), system commands take no Go template variables at declaration time — once installers are implemented, the engine will append package names per [SystemPackageSet](#systempackageset).
+`verb` is a string field defined on each command entry but is not currently consumed anywhere in the engine. It is intended as a human-readable label for future log/progress-UI integration. The `spec.commands.*` declarations are likewise not consumed by the engine at apply time today; once concrete installers are implemented, the engine is expected to append package names per [SystemPackageSet](#systempackageset), and any Go template variable conventions for these commands will be documented as part of that implementation.
 
 ### SystemPackageRepository
 

--- a/docs/cue-schema.md
+++ b/docs/cue-schema.md
@@ -293,9 +293,9 @@ spec: {
     pattern:    "delegation"
     privileged: true
     commands: {
-        install: {command: "apt-get install -y", verb: "install"}
-        remove:  {command: "apt-get remove -y",  verb: "remove"}
-        check:   {command: "dpkg -s",            verb: "check"}
+        install: {command: "sudo apt-get install -y", verb: "install"}
+        remove:  {command: "sudo apt-get remove -y",  verb: "remove"}
+        check:   {command: "dpkg -s",                 verb: "check"}
     }
 }
 ```
@@ -313,7 +313,7 @@ The CUE schema requires `spec.pattern`, `spec.privileged`, and `spec.commands` (
 | `spec.commands.check` | object | recommended | `{command: string, verb: string}` — used by future package operations |
 | `spec.commands.update` | string | no | Optional update command |
 
-When present, `verb` is a human-readable label used in logs and progress UI. Unlike [CommandSet](#commandset), system commands take no Go template variables at declaration time — once installers are implemented, the engine will append package names per [SystemPackageSet](#systempackageset).
+`verb` is a string field defined on each command entry but is not currently consumed anywhere in the engine. It is intended as a human-readable label for future log/progress-UI integration. Unlike [CommandSet](#commandset), system commands take no Go template variables at declaration time — once installers are implemented, the engine will append package names per [SystemPackageSet](#systempackageset).
 
 ### SystemPackageRepository
 

--- a/docs/cue-schema.md
+++ b/docs/cue-schema.md
@@ -277,9 +277,13 @@ spec: {
 
 ### SystemInstaller
 
-System-level package manager. Requires `--system` to be applied. Only `apt` is currently supported by the engine; declaring other package managers will fail at apply time with "no version function registered".
+System-level package manager. Requires `--system` to be applied. Only `apt` is currently wired into the engine; declaring other package managers can fail at apply time in several ways depending on the host:
 
-`metadata.name` must match a known package manager identifier (`apt`, `dnf`, `zypper`, `pacman`, `apk`).
+- `package manager <x> is not supported on this system` — the host's distro does not match
+- `no version function registered for package manager <x>` — the package manager is not yet wired up in tomei
+- `system package manager validation unavailable: distro detection failed or unsupported platform` — running on a host where distro detection isn't available (e.g., macOS, minimal containers)
+
+`metadata.name` must match a known package manager identifier (`apt`, `dnf`, `zypper`, `pacman`, `apk`); identifiers other than `apt` are not currently supported by the engine.
 
 ```cue
 apiVersion: "tomei.terassyi.net/v1beta1"
@@ -298,18 +302,18 @@ spec: {
 
 #### Fields
 
-The CUE schema defines `spec.commands` as an open struct. The fields below are what the loader expects; declaring them is required for the resource to apply successfully.
+The CUE schema defines `spec.commands` as an open struct. Today, only `spec.pattern` is enforced by the loader, and the engine validates `SystemInstaller` resources by checking that the named package manager exists on the host (see error list above) — the `commands.*` entries below are not consumed at apply time. They are documented here as the conventional shape for `SystemPackageRepository` / `SystemPackageSet` reconciliation, which will start consuming them once the concrete installers land.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `spec.pattern` | string | yes | Installer pattern. Currently only `"delegation"` is meaningful |
 | `spec.privileged` | bool | yes | Whether package operations require elevated privileges |
-| `spec.commands.install` | object | yes | `{command: string, verb: string}` — command for installing packages |
-| `spec.commands.remove` | object | yes | `{command: string, verb: string}` — command for removing packages |
-| `spec.commands.check` | object | yes | `{command: string, verb: string}` — command for checking package state |
+| `spec.commands.install` | object | recommended | `{command: string, verb: string}` — used by future package operations |
+| `spec.commands.remove` | object | recommended | `{command: string, verb: string}` — used by future package operations |
+| `spec.commands.check` | object | recommended | `{command: string, verb: string}` — used by future package operations |
 | `spec.commands.update` | string | no | Optional update command |
 
-`verb` is a human-readable label used in logs and progress UI. Unlike [CommandSet](#commandset), system commands are appended with package names by the engine and don't take Go template variables at declaration time.
+When present, `verb` is a human-readable label used in logs and progress UI. Unlike [CommandSet](#commandset), system commands take no Go template variables at declaration time — once installers are implemented, the engine will append package names per [SystemPackageSet](#systempackageset).
 
 ### SystemPackageRepository
 

--- a/docs/cue-schema.md
+++ b/docs/cue-schema.md
@@ -275,6 +275,119 @@ spec: {
 | `spec.source.url` | HTTPS URL | git only | Repository URL |
 | `spec.source.commands` | [CommandSet](#commandset) | delegation only | Repository management commands |
 
+### SystemInstaller
+
+System-level package manager. Requires `--system` to be applied. Only `apt` is currently supported by the engine; declaring other package managers will fail at apply time with "no version function registered".
+
+`metadata.name` must match a known package manager identifier (`apt`, `dnf`, `zypper`, `pacman`, `apk`).
+
+```cue
+apiVersion: "tomei.terassyi.net/v1beta1"
+kind:       "SystemInstaller"
+metadata: name: "apt"
+spec: {
+    pattern:    "delegation"
+    privileged: true
+    commands: {
+        install: {command: "apt-get install -y", verb: "install"}
+        remove:  {command: "apt-get remove -y",  verb: "remove"}
+        check:   {command: "dpkg -s",            verb: "check"}
+    }
+}
+```
+
+#### Fields
+
+The CUE schema defines `spec.commands` as an open struct. The fields below are what the loader expects; declaring them is required for the resource to apply successfully.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `spec.pattern` | string | yes | Installer pattern. Currently only `"delegation"` is meaningful |
+| `spec.privileged` | bool | yes | Whether package operations require elevated privileges |
+| `spec.commands.install` | object | yes | `{command: string, verb: string}` — command for installing packages |
+| `spec.commands.remove` | object | yes | `{command: string, verb: string}` — command for removing packages |
+| `spec.commands.check` | object | yes | `{command: string, verb: string}` — command for checking package state |
+| `spec.commands.update` | string | no | Optional update command |
+
+`verb` is a human-readable label used in logs and progress UI. Unlike [CommandSet](#commandset), system commands are appended with package names by the engine and don't take Go template variables at declaration time.
+
+### SystemPackageRepository
+
+Third-party APT repository (e.g., Docker, Kubernetes). The CUE schema accepts the resource and the reconciler computes plan actions, but the concrete installer is **not yet implemented** — declared repositories are shown as `skip` in plan and skipped at apply time with a warning.
+
+```cue
+apiVersion: "tomei.terassyi.net/v1beta1"
+kind:       "SystemPackageRepository"
+metadata: name: "docker"
+spec: {
+    installerRef: "apt"
+    source: {
+        url:     "https://download.docker.com/linux/ubuntu"
+        keyUrl:  "https://download.docker.com/linux/ubuntu/gpg"
+        keyHash: "sha256:1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570"
+        options: {
+            arch:        "amd64"
+            "signed-by": "/etc/apt/keyrings/docker.asc"
+        }
+    }
+}
+```
+
+#### Fields
+
+The CUE schema defines `spec.source` as an open struct constrained only by `url: #HTTPSURL`. The fields below are what the loader expects.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `spec.installerRef` | string | yes | Reference to a [SystemInstaller](#systeminstaller) |
+| `spec.source.url` | HTTPS URL | yes | Repository URL |
+| `spec.source.keyUrl` | string | no | GPG key URL |
+| `spec.source.keyHash` | string | no | SHA-256 checksum of the GPG key (e.g., `sha256:...`) |
+| `spec.source.options` | `{[string]: string}` | no | Installer-specific options. For APT, common keys include `arch` and `signed-by` |
+
+The exact `options` schema may evolve once the concrete installer lands.
+
+### SystemPackageSet
+
+Set of system packages installed via a [SystemInstaller](#systeminstaller). The CUE schema accepts the resource and the reconciler computes plan actions, but the concrete installer is **not yet implemented** — declared package sets are shown as `skip` in plan and skipped at apply time with a warning.
+
+```cue
+// Distribution-provided packages — no repositoryRef
+apiVersion: "tomei.terassyi.net/v1beta1"
+kind:       "SystemPackageSet"
+metadata: name: "build-essential"
+spec: {
+    installerRef: "apt"
+    packages: [
+        "build-essential",
+        "pkg-config",
+        "libssl-dev",
+    ]
+}
+
+// Packages from a third-party repository
+apiVersion: "tomei.terassyi.net/v1beta1"
+kind:       "SystemPackageSet"
+metadata: name: "docker"
+spec: {
+    installerRef:  "apt"
+    repositoryRef: "docker"   // matches the SystemPackageRepository above
+    packages: [
+        "docker-ce",
+        "docker-ce-cli",
+        "containerd.io",
+    ]
+}
+```
+
+#### Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `spec.installerRef` | string | yes | Reference to a [SystemInstaller](#systeminstaller) |
+| `spec.repositoryRef` | string | no | Reference to a [SystemPackageRepository](#systempackagerepository) — adds a DAG edge so the repository is registered before packages are installed |
+| `spec.packages` | `[...string]` | yes | Package names to install (must be non-empty) |
+
 ## Common Types
 
 ### DownloadSource

--- a/docs/cue-schema.md
+++ b/docs/cue-schema.md
@@ -279,9 +279,9 @@ spec: {
 
 System-level package manager. Requires `--system` to be applied. Only `apt` is currently wired into the engine; declaring other package managers can fail at apply time in several ways depending on the host:
 
-- `package manager <x> is not supported on this system` — the host's distro does not match
-- `no version function registered for package manager <x>` — the package manager is not yet wired up in tomei
-- `system package manager validation unavailable: distro detection failed or unsupported platform` — running on a host where distro detection isn't available (e.g., macOS, minimal containers)
+- error contains `package manager "<x>" is not supported on this system` (with appended distro context such as `(ID=..., ID_LIKE=...)`) — the host's distro does not match
+- error contains `no version function registered for package manager "<x>"` — the package manager is not yet wired up in tomei
+- error contains `system package manager validation unavailable: distro detection failed or unsupported platform` — running on a host where distro detection isn't available (e.g., macOS, minimal containers)
 
 `metadata.name` must match a known package manager identifier (`apt`, `dnf`, `zypper`, `pacman`, `apk`); identifiers other than `apt` are not currently supported by the engine.
 
@@ -302,7 +302,7 @@ spec: {
 
 #### Fields
 
-The CUE schema defines `spec.commands` as an open struct. Today, only `spec.pattern` is enforced by the loader, and the engine validates `SystemInstaller` resources by checking that the named package manager exists on the host (see error list above) — the `commands.*` entries below are not consumed at apply time. They are documented here as the conventional shape for `SystemPackageRepository` / `SystemPackageSet` reconciliation, which will start consuming them once the concrete installers land.
+The CUE schema requires `spec.pattern`, `spec.privileged`, and `spec.commands` (with `commands` as an open struct). Beyond that, current Go-side validation only checks `spec.pattern`, and the engine validates `SystemInstaller` resources by checking that the named package manager exists on the host (see error list above). The `commands.*` entries below are not consumed by the engine at apply time; they are documented here as the conventional shape for `SystemPackageRepository` / `SystemPackageSet` reconciliation, which will start consuming them once the concrete installers land.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|

--- a/docs/design.md
+++ b/docs/design.md
@@ -223,7 +223,7 @@ System resource state lives at `~/.local/share/tomei/system/state.json`. Each us
 
 This is a deliberate trade-off for the tool's target use case (single-developer dev environment setup). It is **not** suitable for coordinated multi-user system administration:
 
-- **No cross-user coordination.** State files are independent. If user A installs `vim` via tomei and later drops it from their manifest, tomei runs `apt-get remove vim` — affecting user B who also relied on the package. Idempotent installs (`apt-get install`) are safe to overlap; removals are not.
+- **No cross-user coordination.** State files are independent. Once `SystemPackageSet` reconciliation is implemented (see Roadmap below), dropping a package from user A's manifest would cause tomei to run a system-wide removal (e.g., `apt-get remove vim`) — affecting user B who also relied on the package. Idempotent installs (`apt-get install`) are safe to overlap; removals are not.
 - **No drift detection.** Reconciliation compares the declared spec against tomei's own state file. Out-of-band changes (manual `apt install`, distro upgrades, packages installed by other tools) are invisible.
 
 For shared servers, use a configuration management tool (Ansible, Chef, Puppet) instead.

--- a/docs/design.md
+++ b/docs/design.md
@@ -65,11 +65,13 @@ User privilege (tomei apply):
 ├── Installer            User-level installer definition (aqua, brew, binstall)
 └── InstallerRepository  Third-party tool metadata repository
 
-System privilege (sudo tomei apply --system):
+System privilege (tomei apply --system):
 ├── SystemInstaller          Package manager definition (apt)
 ├── SystemPackageRepository  Third-party apt repository
 └── SystemPackageSet         Set of system packages
 ```
+
+`tomei` itself is invoked as a regular user; privileged commands are delegated to `sudo`. Do not run `sudo tomei apply` — running the whole tool as root would write user state files (under `~/.local/share/tomei/`) as root and break subsequent unprivileged invocations.
 
 Each resource has `apiVersion`, `kind`, `metadata`, and `spec`. A Tool specifies exactly one of `runtimeRef`, `installerRef`, or `commands`. The full field reference is in [CUE Schema Reference](cue-schema.md).
 
@@ -139,10 +141,13 @@ Mode:  headless (server, CI, container, SSH), desktop (GUI)
 └── *.cue                  # User manifests
 
 ~/.local/share/tomei/      # Data (configurable via config.cue)
-├── state.json             # Current state
+├── state.json             # Current state (user resources)
 ├── state.lock             # flock file
 ├── runtimes/<name>/<ver>/ # Installed runtimes
-└── tools/<name>/<ver>/    # Installed tools
+├── tools/<name>/<ver>/    # Installed tools
+└── system/
+    ├── state.json         # Current state (system resources)
+    └── state.lock         # flock file
 
 ~/.local/bin/              # Symlinks (configurable via config.cue)
 
@@ -199,24 +204,66 @@ Completed:
 - CUE `@if()` boolean platform tags: `@if(darwin)`, `@if(arm64)`, `@if(headless)` for file-level branching
 - Disabled resource filtering: `enabled: false` resources excluded from ExpandSets and shown as "skip" in `tomei plan`
 - Aqua template variable `AssetWithoutExt` for `files[].src` path references
+- System package management: SystemInstaller validation (APT) via per-user state, sudo delegation, distro detection (Debian/Ubuntu family)
 
-## 10. Roadmap
+## 10. System Package Management
 
-### System privilege (deferred)
+### Execution model
 
-System-level package management via `sudo tomei apply --system`:
+`tomei` runs as the invoking user and delegates privileged work to `sudo` per command. The user is prompted for the sudo password once and the cached credential is reused for the rest of the run.
 
-- **SystemInstaller**: Package manager definitions (apt as builtin)
-- **SystemPackageRepository**: Third-party APT repositories with GPG key management
-- **SystemPackageSet**: Sets of system packages
+```
+Right:  tomei apply --system     # tomei runs as user, escalates per command
+Wrong:  sudo tomei apply --system # would write user state files as root
+```
 
-The CUE schema and resource types are already defined. Implementation requires privilege escalation handling and APT-specific installer logic.
+### Per-user state
+
+System resource state lives at `~/.local/share/tomei/system/state.json`. Each user maintains an independent view of system package state.
+
+This is a deliberate trade-off for the tool's target use case (single-developer dev environment setup). It is **not** suitable for coordinated multi-user system administration:
+
+- **No cross-user coordination.** State files are independent. If user A installs `vim` via tomei and later drops it from their manifest, tomei runs `apt-get remove vim` — affecting user B who also relied on the package. Idempotent installs (`apt-get install`) are safe to overlap; removals are not.
+- **No drift detection.** Reconciliation compares the declared spec against tomei's own state file. Out-of-band changes (manual `apt install`, distro upgrades, packages installed by other tools) are invisible.
+
+For shared servers, use a configuration management tool (Ansible, Chef, Puppet) instead.
+
+### Dependency graph
+
+Following the convention from §3, arrows point from a resource to the dependents it enables:
+
+```
+SystemInstaller → SystemPackageRepository → SystemPackageSet
+                ↘ SystemPackageSet
+```
+
+- `SystemPackageRepository.spec.installerRef` and `SystemPackageSet.spec.installerRef` reference a `SystemInstaller`
+- `SystemPackageSet.spec.repositoryRef` (optional) references a `SystemPackageRepository`
+
+### Implementation status
+
+| Resource | Status |
+|----------|--------|
+| `SystemInstaller` (`apt`) | Validates that `apt-get` exists on the host and captures its version |
+| `SystemInstaller` (other) | Schema accepts `dnf`/`zypper`/`pacman`/`apk`, but the engine only wires up `apt` — apply will fail with "no version function registered" |
+| `SystemPackageRepository` | Concrete installer not yet implemented (planned: `add-apt-repository`, GPG key management). Recognized by plan/apply but skipped at runtime |
+| `SystemPackageSet` | Concrete installer not yet implemented (planned: `apt-get install`). Recognized by plan/apply but skipped at runtime |
+
+`tomei plan --system` and `tomei apply --system` recognize all three kinds. Resources without a concrete installer are shown as `skip` in plan and skipped at apply time with a warning, so that declaring them does not produce a false success.
+
+`SystemInstaller` removal does not uninstall the OS package manager — it only clears the state entry.
+
+## 11. Roadmap
+
+### System package installers
+
+Concrete installer implementations for `SystemPackageRepository` (`add-apt-repository`, `apt-key` / `/etc/apt/keyrings`) and `SystemPackageSet` (`apt-get install` / `apt-get remove`) are tracked in [#162](https://github.com/terassyi/tomei/issues/162).
 
 ### Private repository access
 
 Authenticated downloads from private GitHub repositories. Public repository rate limiting is already addressed via `GITHUB_TOKEN` / `GH_TOKEN`.
 
-## 11. Design Considerations
+## 12. Design Considerations
 
 ### Authentication & tokens
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -71,7 +71,7 @@ System privilege (tomei apply --system):
 └── SystemPackageSet         Set of system packages
 ```
 
-`tomei` itself is invoked as a regular user; privileged commands are delegated to `sudo`. Do not run `sudo tomei apply` — running the whole tool as root would write user state files (under `~/.local/share/tomei/`) as root and break subsequent unprivileged invocations.
+`tomei` itself runs as the invoking user. Manifests must use `sudo` explicitly for steps that require elevation; tomei does not wrap commands. With `--system`, tomei pre-acquires the sudo timestamp (`sudo -v`) and keeps it refreshed so those explicit `sudo` calls typically don't re-prompt. Do not run `sudo tomei apply` — running the whole tool as root may operate on root's home directory or create root-owned files under the configured Tomei data directory (by default `~/.local/share/tomei/`), causing permission issues for subsequent unprivileged invocations.
 
 Each resource has `apiVersion`, `kind`, `metadata`, and `spec`. A Tool specifies exactly one of `runtimeRef`, `installerRef`, or `commands`. The full field reference is in [CUE Schema Reference](cue-schema.md).
 
@@ -210,16 +210,16 @@ Completed:
 
 ### Execution model
 
-`tomei` runs as the invoking user and delegates privileged work to `sudo` per command. The user is prompted for the sudo password once and the cached credential is reused for the rest of the run.
+`tomei` runs as the invoking user. Manifests written for `--system` mode must use `sudo` explicitly on commands that need elevation; tomei does not wrap commands itself. With `--system`, tomei pre-acquires the sudo timestamp (`sudo -v`) and keeps it refreshed in the background, so subsequent explicit `sudo …` calls in manifests typically do not re-prompt for a password.
 
 ```
-Right:  tomei apply --system     # tomei runs as user, escalates per command
-Wrong:  sudo tomei apply --system # would write user state files as root
+Right:  tomei apply --system     # tomei runs as user; manifests use sudo where needed
+Wrong:  sudo tomei apply --system # may create root-owned files under the Tomei data directory
 ```
 
 ### Per-user state
 
-System resource state lives at `~/.local/share/tomei/system/state.json`. Each user maintains an independent view of system package state.
+System resource state lives under `<dataDir>/system/state.json` (by default, `~/.local/share/tomei/system/state.json`). Each user maintains an independent view of system package state.
 
 This is a deliberate trade-off for the tool's target use case (single-developer dev environment setup). It is **not** suitable for coordinated multi-user system administration:
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -245,7 +245,7 @@ SystemInstaller → SystemPackageRepository → SystemPackageSet
 | Resource | Status |
 |----------|--------|
 | `SystemInstaller` (`apt`) | Validates that `apt-get` exists on the host and captures its version |
-| `SystemInstaller` (other) | Schema accepts `dnf`/`zypper`/`pacman`/`apk`, but the engine only wires up `apt` — apply will fail with "no version function registered" |
+| `SystemInstaller` (other) | Schema accepts `dnf`/`zypper`/`pacman`/`apk`, but only `apt` is currently wired. Other package managers fail validation either with "package manager is not supported on this system" (distro mismatch) or "no version function registered" (supported by distro detection but not yet wired in the engine) |
 | `SystemPackageRepository` | Concrete installer not yet implemented (planned: `add-apt-repository`, GPG key management). Recognized by plan/apply but skipped at runtime |
 | `SystemPackageSet` | Concrete installer not yet implemented (planned: `apt-get install`). Recognized by plan/apply but skipped at runtime |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -291,13 +291,15 @@ spec: {
 }
 ```
 
-Without `--system`, system resources and privileged tools are listed as skipped:
+Without `--system`, system resources and privileged tools are skipped at apply time:
 
 ```text
-$ tomei plan .
+$ tomei apply .
 2 system resource(s) skipped. Use 'tomei apply --system' to manage.
 1 privileged resource(s) skipped. Use 'tomei apply --system' to install.
 ```
+
+`tomei plan .` (without `--system`) shows the same resources marked `skip` in the graph and summary, without the count lines above.
 
 Behavior notes:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -284,9 +284,9 @@ spec: {
     pattern:    "delegation"
     privileged: true
     commands: {
-        install: {command: "apt-get install -y", verb: "install"}
-        remove:  {command: "apt-get remove -y",  verb: "remove"}
-        check:   {command: "dpkg -s",            verb: "check"}
+        install: {command: "sudo apt-get install -y", verb: "install"}
+        remove:  {command: "sudo apt-get remove -y",  verb: "remove"}
+        check:   {command: "dpkg -s",                 verb: "check"}
     }
 }
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -256,7 +256,7 @@ See [CUE Schema Reference — ToolCommandSet](cue-schema.md#toolcommandset) for 
 
 ### System Package Management (`--system`)
 
-`--system` enables system-level package management and privileged tool operations. tomei still runs as the invoking user — privileged commands are delegated to `sudo` per command.
+`--system` enables system-level package management and privileged tool operations. tomei itself still runs as the invoking user; manifests must use `sudo` explicitly on commands that need elevation. With `--system`, tomei pre-acquires the sudo timestamp (`sudo -v`) and keeps it refreshed so those explicit `sudo …` calls typically do not re-prompt for a password.
 
 ```bash
 # Show what would change for system resources
@@ -305,9 +305,9 @@ Behavior notes:
 
 - **State location.** System state is stored at `~/.local/share/tomei/system/state.json`, per user. The system state directory is auto-created on first apply, but `tomei apply` still requires `tomei init` to have been run first because the user state file (`~/.local/share/tomei/state.json`) is checked unconditionally before any apply.
 - **Multi-user limitation.** Each user maintains an independent view of system package state. tomei does not coordinate between users on the same host and does not detect out-of-band changes (e.g., manual `apt install` or distro upgrades). For shared servers, use a configuration management tool instead.
-- **Sudo behavior.** tomei prompts for the sudo password once per run and reuses the cached credential. With passwordless sudo (e.g., `NOPASSWD` in `/etc/sudoers`, common in CI), no prompt is shown. Do not run `sudo tomei apply --system` — it would write user state files as root.
+- **Sudo behavior.** tomei prompts for the sudo password once per run and reuses the cached credential. With passwordless sudo (e.g., `NOPASSWD` in `/etc/sudoers`, common in CI), no prompt is shown. Do not run `sudo tomei apply --system` — it may create or write state files as root, leaving permission issues later or operating on root's home directory instead of the invoking user's.
 - **Removing a `SystemInstaller`.** Drops only the state entry — the underlying OS package manager is not uninstalled.
-- **Unsupported platforms.** On non-Linux hosts (e.g., macOS) or distros without a registered package manager, distro detection falls back gracefully: removals (state cleanup) still work, but `Install` actions fail with a clear "distro detection failed" error.
+- **Unsupported platforms.** On non-Linux hosts (e.g., macOS) or distros without a registered package manager, distro detection falls back gracefully: removals (state cleanup) still work, but `Install` actions fail with `system package manager validation unavailable: distro detection failed or unsupported platform`.
 
 ### Version Resolvers
 
@@ -573,7 +573,7 @@ tomei version [flags]
 
 | Flag | Description |
 |------|-------------|
-| `--system` | Enable system package management and privileged tool operations. Used with `apply` and `plan`. tomei runs as the invoking user and delegates privileged commands to `sudo` — do not run `sudo tomei`. System state is stored per-user under `~/.local/share/tomei/system/`; in multi-user environments each user maintains an independent view, and out-of-band system changes are not detected. |
+| `--system` | Enable system package management and privileged tool operations. Used with `apply` and `plan`. tomei itself runs as the invoking user; manifests use `sudo` explicitly for elevation, and tomei keeps the sudo timestamp refreshed so re-prompts are rare. Do not run `sudo tomei`. System state is stored per-user under `<dataDir>/system/` (by default `~/.local/share/tomei/system/`); in multi-user environments each user maintains an independent view, and out-of-band system changes are not detected. |
 
 ## Environment Variables
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -254,6 +254,59 @@ Commands-pattern tools run in the first execution layer alongside download-patte
 
 See [CUE Schema Reference — ToolCommandSet](cue-schema.md#toolcommandset) for field details.
 
+### System Package Management (`--system`)
+
+`--system` enables system-level package management and privileged tool operations. tomei still runs as the invoking user — privileged commands are delegated to `sudo` per command.
+
+```bash
+# Show what would change for system resources
+tomei plan --system .
+
+# Apply (user is prompted for sudo password once)
+tomei apply --system .
+```
+
+System resources:
+
+| Kind | Purpose |
+|------|---------|
+| `SystemInstaller` | Declares a host package manager (currently `apt` only). Validates the package manager is available and captures its version. |
+| `SystemPackageRepository` | Third-party APT repository (e.g., Docker, Kubernetes). Concrete installer is **not yet implemented** — declared resources are shown as `skip`. |
+| `SystemPackageSet` | Set of system packages to install. Concrete installer is **not yet implemented** — declared resources are shown as `skip`. |
+
+Example manifest (no preset ships for `apt` — declare it inline):
+
+```cue
+apiVersion: "tomei.terassyi.net/v1beta1"
+kind:       "SystemInstaller"
+metadata: name: "apt"
+spec: {
+    pattern:    "delegation"
+    privileged: true
+    commands: {
+        install: {command: "apt-get install -y", verb: "install"}
+        remove:  {command: "apt-get remove -y",  verb: "remove"}
+        check:   {command: "dpkg -s",            verb: "check"}
+    }
+}
+```
+
+Without `--system`, system resources and privileged tools are listed as skipped:
+
+```text
+$ tomei plan .
+2 system resource(s) skipped. Use 'tomei apply --system' to manage.
+1 privileged resource(s) skipped. Use 'tomei apply --system' to install.
+```
+
+Behavior notes:
+
+- **State location.** System state is stored at `~/.local/share/tomei/system/state.json`, per user. The directory is auto-created on first apply; `tomei init` is not required for system resources.
+- **Multi-user limitation.** Each user maintains an independent view of system package state. tomei does not coordinate between users on the same host and does not detect out-of-band changes (e.g., manual `apt install` or distro upgrades). For shared servers, use a configuration management tool instead.
+- **Sudo behavior.** tomei prompts for the sudo password once per run and reuses the cached credential. With passwordless sudo (e.g., `NOPASSWD` in `/etc/sudoers`, common in CI), no prompt is shown. Do not run `sudo tomei apply --system` — it would write user state files as root.
+- **Removing a `SystemInstaller`.** Drops only the state entry — the underlying OS package manager is not uninstalled.
+- **Unsupported platforms.** On non-Linux hosts (e.g., macOS) or distros without a registered package manager, distro detection falls back gracefully: removals (state cleanup) still work, but `Install` actions fail with a clear "distro detection failed" error.
+
 ### Version Resolvers
 
 Runtime presets and commands-pattern tools can declare a `resolveVersion` field that automatically resolves the actual version at install time. Two built-in resolver syntaxes are available, plus a shell command fallback.
@@ -518,7 +571,7 @@ tomei version [flags]
 
 | Flag | Description |
 |------|-------------|
-| `--system` | Apply system-level resources (requires root). Used with `apply` and `plan`. |
+| `--system` | Enable system package management and privileged tool operations. Used with `apply` and `plan`. tomei runs as the invoking user and delegates privileged commands to `sudo` — do not run `sudo tomei`. System state is stored per-user under `~/.local/share/tomei/system/`; in multi-user environments each user maintains an independent view, and out-of-band system changes are not detected. |
 
 ## Environment Variables
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -303,7 +303,7 @@ $ tomei apply .
 
 Behavior notes:
 
-- **State location.** System state is stored at `~/.local/share/tomei/system/state.json`, per user. The directory is auto-created on first apply; `tomei init` is not required for system resources.
+- **State location.** System state is stored at `~/.local/share/tomei/system/state.json`, per user. The system state directory is auto-created on first apply, but `tomei apply` still requires `tomei init` to have been run first because the user state file (`~/.local/share/tomei/state.json`) is checked unconditionally before any apply.
 - **Multi-user limitation.** Each user maintains an independent view of system package state. tomei does not coordinate between users on the same host and does not detect out-of-band changes (e.g., manual `apt install` or distro upgrades). For shared servers, use a configuration management tool instead.
 - **Sudo behavior.** tomei prompts for the sudo password once per run and reuses the cached credential. With passwordless sudo (e.g., `NOPASSWD` in `/etc/sudoers`, common in CI), no prompt is shown. Do not run `sudo tomei apply --system` — it would write user state files as root.
 - **Removing a `SystemInstaller`.** Drops only the state entry — the underlying OS package manager is not uninstalled.


### PR DESCRIPTION
Update design.md, usage.md, and cue-schema.md to reflect the system
package management implementation shipped in #166/#167/#183.

- design.md: new "System Package Management" section covering
  the user-mode + sudo execution model, per-user state location, the
  multi-user limitation (state files don't coordinate; removals can
  affect other users), the dependency graph, and the implementation
  status of each system kind.
- usage.md: System Package Management subsection under tomei apply
  with example manifest, skip behavior without --system, sudo /
  passwordless / CI notes, and unsupported-platform fallback. Global
  --system flag description rewritten.
- cue-schema.md: SystemInstaller, SystemPackageRepository, and
  SystemPackageSet resource sections with field tables. Schema.cue
  open-struct nature is called out so readers don't expect type
  enforcement on commands/source shapes.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
