### PR TITLE
refactor(resource): remove unused Verb field from CommandSpec

### DIFF
--- a/docs/cue-schema.md
+++ b/docs/cue-schema.md
@@ -295,9 +295,9 @@ spec: {
     pattern:    "delegation"
     privileged: true
     commands: {
-        install: {command: "sudo apt-get install -y", verb: "install"}
-        remove:  {command: "sudo apt-get remove -y",  verb: "remove"}
-        check:   {command: "dpkg -s",                 verb: "check"}
+        install: {command: "sudo apt-get install -y"}
+        remove:  {command: "sudo apt-get remove -y"}
+        check:   {command: "dpkg -s"}
     }
 }
 ```
@@ -310,12 +310,12 @@ The CUE schema requires `spec.pattern`, `spec.privileged`, and `spec.commands` (
 |-------|------|----------|-------------|
 | `spec.pattern` | string | yes | Installer pattern. Currently only `"delegation"` is meaningful |
 | `spec.privileged` | bool | yes | Whether package operations require elevated privileges |
-| `spec.commands.install` | object | recommended | `{command: string, verb: string}` — used by future package operations |
-| `spec.commands.remove` | object | recommended | `{command: string, verb: string}` — used by future package operations |
-| `spec.commands.check` | object | recommended | `{command: string, verb: string}` — used by future package operations |
+| `spec.commands.install` | object | recommended | `{command: string}` — used by future package operations |
+| `spec.commands.remove` | object | recommended | `{command: string}` — used by future package operations |
+| `spec.commands.check` | object | recommended | `{command: string}` — used by future package operations |
 | `spec.commands.update` | string | no | Optional update command |
 
-`verb` is a string field defined on each command entry but is not currently consumed anywhere in the engine. It is intended as a human-readable label for future log/progress-UI integration. The `spec.commands.*` declarations are likewise not consumed by the engine at apply time today; once concrete installers are implemented, the engine is expected to append package names per [SystemPackageSet](#systempackageset), and any Go template variable conventions for these commands will be documented as part of that implementation.
+The `spec.commands.*` declarations are not consumed by the engine at apply time today; once concrete installers are implemented, the engine is expected to append package names per [SystemPackageSet](#systempackageset), and any Go template variable conventions for these commands will be documented as part of that implementation.
 
 ### SystemPackageRepository
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -284,9 +284,9 @@ spec: {
     pattern:    "delegation"
     privileged: true
     commands: {
-        install: {command: "sudo apt-get install -y", verb: "install"}
-        remove:  {command: "sudo apt-get remove -y",  verb: "remove"}
-        check:   {command: "dpkg -s",                 verb: "check"}
+        install: {command: "sudo apt-get install -y"}
+        remove:  {command: "sudo apt-get remove -y"}
+        check:   {command: "dpkg -s"}
     }
 }
 ```

--- a/internal/installer/engine/system_engine_test.go
+++ b/internal/installer/engine/system_engine_test.go
@@ -103,9 +103,9 @@ func testSystemInstaller(name string) *resource.SystemInstaller {
 			Pattern:    "delegation",
 			Privileged: true,
 			Commands: resource.SystemInstallerCommandsSpec{
-				Install: resource.CommandSpec{Command: name, Verb: "install"},
-				Remove:  resource.CommandSpec{Command: name, Verb: "remove"},
-				Check:   resource.CommandSpec{Command: "dpkg", Verb: "-s"},
+				Install: resource.CommandSpec{Command: name},
+				Remove:  resource.CommandSpec{Command: name},
+				Check:   resource.CommandSpec{Command: "dpkg"},
 			},
 		},
 	}

--- a/internal/installer/engine/system_engine_test.go
+++ b/internal/installer/engine/system_engine_test.go
@@ -103,9 +103,9 @@ func testSystemInstaller(name string) *resource.SystemInstaller {
 			Pattern:    "delegation",
 			Privileged: true,
 			Commands: resource.SystemInstallerCommandsSpec{
-				Install: resource.CommandSpec{Command: name},
-				Remove:  resource.CommandSpec{Command: name},
-				Check:   resource.CommandSpec{Command: "dpkg"},
+				Install: resource.CommandSpec{Command: name + " install -y"},
+				Remove:  resource.CommandSpec{Command: name + " remove -y"},
+				Check:   resource.CommandSpec{Command: "dpkg -s"},
 			},
 		},
 	}

--- a/internal/resource/system_installer.go
+++ b/internal/resource/system_installer.go
@@ -46,10 +46,9 @@ type SystemInstallerCommandsSpec struct {
 	Update  string      `json:"update,omitempty"`
 }
 
-// CommandSpec defines a command with its verb.
+// CommandSpec defines a command.
 type CommandSpec struct {
 	Command string `json:"command"`
-	Verb    string `json:"verb"`
 }
 
 // SystemInstallerState represents the state of a system installer.


### PR DESCRIPTION
The Verb field on CommandSpec is defined but never read anywhere in the
engine. Drop it from the struct, test fixtures, and the SystemInstaller
documentation/examples to remove the dead code and the misleading shape
in the docs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
