### PR TITLE
feat(resource): implement SystemPackage.Expand() (#187)

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -591,6 +591,8 @@ func (l *Loader) parseResource(value cue.Value) (resource.Resource, error) {
 		return decodeResource[*resource.SystemInstaller](value)
 	case resource.KindSystemPackageRepository:
 		return decodeResource[*resource.SystemPackageRepository](value)
+	case resource.KindSystemPackage:
+		return decodeResource[*resource.SystemPackage](value)
 	case resource.KindSystemPackageSet:
 		return decodeResource[*resource.SystemPackageSet](value)
 	default:

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -223,6 +223,55 @@ spec: {
 	}
 }
 
+func TestLoader_LoadFile_SystemPackage(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cueFile := filepath.Join(dir, "syspkg.cue")
+
+	content := `
+apiVersion: "tomei.terassyi.net/v1beta1"
+kind: "SystemPackage"
+metadata: name: "docker"
+spec: {
+    installerRef: "apt"
+    repositoryRef: "docker-repo"
+    package: "docker-ce"
+}
+`
+	if err := os.WriteFile(cueFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	loader := NewLoader(nil)
+	resources, err := loader.LoadFile(cueFile)
+	if err != nil {
+		t.Fatalf("failed to load file: %v", err)
+	}
+
+	res := resources[0]
+	if res.Kind() != resource.KindSystemPackage {
+		t.Errorf("expected kind SystemPackage, got %s", res.Kind())
+	}
+
+	pkg, ok := res.(*resource.SystemPackage)
+	if !ok {
+		t.Fatalf("expected *resource.SystemPackage, got %T", res)
+	}
+	if pkg.Name() != "docker" {
+		t.Errorf("expected name docker, got %s", pkg.Name())
+	}
+	if pkg.SystemPackageSpec.InstallerRef != "apt" {
+		t.Errorf("expected installerRef apt, got %s", pkg.SystemPackageSpec.InstallerRef)
+	}
+	if pkg.SystemPackageSpec.RepositoryRef != "docker-repo" {
+		t.Errorf("expected repositoryRef docker-repo, got %s", pkg.SystemPackageSpec.RepositoryRef)
+	}
+	if pkg.SystemPackageSpec.Package != "docker-ce" {
+		t.Errorf("expected package docker-ce, got %s", pkg.SystemPackageSpec.Package)
+	}
+}
+
 func TestLoader_LoadFile_WithLabels(t *testing.T) {
 	t.Parallel()
 

--- a/internal/resource/expand_test.go
+++ b/internal/resource/expand_test.go
@@ -552,6 +552,81 @@ func TestToolImplementsEnableable(t *testing.T) {
 	var _ Enableable = (*Tool)(nil)
 }
 
+func TestExpandSets_SystemPackage_Basic(t *testing.T) {
+	t.Parallel()
+	sp := &SystemPackage{
+		BaseResource: BaseResource{Metadata: Metadata{Name: "git"}},
+		SystemPackageSpec: &SystemPackageSpec{
+			InstallerRef: "apt",
+			Package:      "git",
+		},
+	}
+
+	got, err := ExpandSets([]Resource{sp})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	set, ok := got[0].(*SystemPackageSet)
+	require.True(t, ok, "expected *SystemPackageSet, got %T", got[0])
+	assert.Equal(t, "git", set.Name())
+	assert.Equal(t, "apt", set.SystemPackageSetSpec.InstallerRef)
+	assert.Equal(t, []string{"git"}, set.SystemPackageSetSpec.Packages)
+
+	// SystemPackage must not remain in the output.
+	for _, r := range got {
+		_, ok := r.(*SystemPackage)
+		assert.False(t, ok, "SystemPackage should be replaced by expansion")
+	}
+}
+
+func TestExpandSets_SystemPackage_NameConflict(t *testing.T) {
+	t.Parallel()
+	resources := []Resource{
+		&SystemPackage{
+			BaseResource:      BaseResource{Metadata: Metadata{Name: "curl"}},
+			SystemPackageSpec: &SystemPackageSpec{InstallerRef: "apt", Package: "curl"},
+		},
+		&SystemPackage{
+			BaseResource:      BaseResource{Metadata: Metadata{Name: "curl"}},
+			SystemPackageSpec: &SystemPackageSpec{InstallerRef: "apt", Package: "curl-minimal"},
+		},
+	}
+
+	_, err := ExpandSets(resources)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "name conflict")
+}
+
+// TestExpandSets_SystemPackage_SamePackageDifferentName validates the
+// Name/Package decoupling: two SystemPackages installing the same OS package
+// but with distinct resource identities expand without conflict.
+func TestExpandSets_SystemPackage_SamePackageDifferentName(t *testing.T) {
+	t.Parallel()
+	resources := []Resource{
+		&SystemPackage{
+			BaseResource:      BaseResource{Metadata: Metadata{Name: "curl-main"}},
+			SystemPackageSpec: &SystemPackageSpec{InstallerRef: "apt", Package: "curl"},
+		},
+		&SystemPackage{
+			BaseResource:      BaseResource{Metadata: Metadata{Name: "curl-backup"}},
+			SystemPackageSpec: &SystemPackageSpec{InstallerRef: "apt", Package: "curl"},
+		},
+	}
+
+	got, err := ExpandSets(resources)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	names := []string{got[0].Name(), got[1].Name()}
+	assert.ElementsMatch(t, []string{"curl-main", "curl-backup"}, names)
+
+	for _, r := range got {
+		set, ok := r.(*SystemPackageSet)
+		require.True(t, ok)
+		assert.Equal(t, []string{"curl"}, set.SystemPackageSetSpec.Packages)
+	}
+}
+
 func TestIsPrivileged(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/resource/system_package.go
+++ b/internal/resource/system_package.go
@@ -151,3 +151,25 @@ func (*SystemPackage) Kind() Kind { return KindSystemPackage }
 
 // Spec returns the spec as Spec interface.
 func (s *SystemPackage) Spec() Spec { return s.SystemPackageSpec }
+
+// Expand expands a SystemPackage into a single-element SystemPackageSet.
+// Sugar semantics: the engine never sees SystemPackage, only SystemPackageSet.
+func (s *SystemPackage) Expand() ([]Resource, error) {
+	if s.SystemPackageSpec == nil {
+		return nil, fmt.Errorf("SystemPackage %q has nil spec", s.Name())
+	}
+	return []Resource{
+		&SystemPackageSet{
+			BaseResource: BaseResource{
+				APIVersion:   GroupVersion,
+				ResourceKind: KindSystemPackageSet,
+				Metadata:     Metadata{Name: s.Name()},
+			},
+			SystemPackageSetSpec: &SystemPackageSetSpec{
+				InstallerRef:  s.SystemPackageSpec.InstallerRef,
+				RepositoryRef: s.SystemPackageSpec.RepositoryRef,
+				Packages:      []string{s.SystemPackageSpec.Package},
+			},
+		},
+	}, nil
+}

--- a/internal/resource/system_package.go
+++ b/internal/resource/system_package.go
@@ -64,6 +64,11 @@ func (s *SystemPackageSetSpec) Validate() error {
 	if len(s.Packages) == 0 {
 		return fmt.Errorf("at least one package is required")
 	}
+	for i, p := range s.Packages {
+		if p == "" {
+			return fmt.Errorf("packages[%d] must not be empty", i)
+		}
+	}
 	return nil
 }
 

--- a/internal/resource/system_package_test.go
+++ b/internal/resource/system_package_test.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"slices"
 	"strings"
 	"testing"
 )
@@ -87,6 +88,139 @@ func TestSystemPackageSpec_Dependencies(t *testing.T) {
 				if got[i] != tt.want[i] {
 					t.Errorf("Dependencies()[%d] = %v, want %v", i, got[i], tt.want[i])
 				}
+			}
+		})
+	}
+}
+
+// TestSystemPackageImplementsExpandable is a compile-time assertion that
+// *SystemPackage satisfies the Expandable interface.
+func TestSystemPackageImplementsExpandable(t *testing.T) {
+	var _ Expandable = (*SystemPackage)(nil)
+}
+
+func TestSystemPackage_Expand_Basic(t *testing.T) {
+	t.Parallel()
+	sp := &SystemPackage{
+		BaseResource:      BaseResource{Metadata: Metadata{Name: "git"}},
+		SystemPackageSpec: &SystemPackageSpec{InstallerRef: "apt", Package: "git"},
+	}
+
+	got, err := sp.Expand()
+	if err != nil {
+		t.Fatalf("Expand() unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Expand() returned %d resources, want 1", len(got))
+	}
+	set, ok := got[0].(*SystemPackageSet)
+	if !ok {
+		t.Fatalf("Expand()[0] type = %T, want *SystemPackageSet", got[0])
+	}
+	if set.APIVersion != GroupVersion {
+		t.Errorf("expanded APIVersion = %q, want %q", set.APIVersion, GroupVersion)
+	}
+	if set.Kind() != KindSystemPackageSet {
+		t.Errorf("expanded Kind = %s, want %s", set.Kind(), KindSystemPackageSet)
+	}
+	if set.SystemPackageSetSpec.InstallerRef != "apt" {
+		t.Errorf("expanded InstallerRef = %q, want %q", set.SystemPackageSetSpec.InstallerRef, "apt")
+	}
+	if set.SystemPackageSetSpec.RepositoryRef != "" {
+		t.Errorf("expanded RepositoryRef = %q, want empty", set.SystemPackageSetSpec.RepositoryRef)
+	}
+}
+
+func TestSystemPackage_Expand_WithRepository(t *testing.T) {
+	t.Parallel()
+	sp := &SystemPackage{
+		BaseResource: BaseResource{Metadata: Metadata{Name: "docker-ce"}},
+		SystemPackageSpec: &SystemPackageSpec{
+			InstallerRef:  "apt",
+			RepositoryRef: "docker-repo",
+			Package:       "docker-ce",
+		},
+	}
+
+	got, err := sp.Expand()
+	if err != nil {
+		t.Fatalf("Expand() unexpected error: %v", err)
+	}
+	set := got[0].(*SystemPackageSet)
+	if set.SystemPackageSetSpec.RepositoryRef != "docker-repo" {
+		t.Errorf("expanded RepositoryRef = %q, want %q", set.SystemPackageSetSpec.RepositoryRef, "docker-repo")
+	}
+}
+
+// TestSystemPackage_Expand_PackageDiffersFromName is the load-bearing test
+// for the Name/Package decoupling decision: Packages[0] must come from
+// spec.Package, NOT sp.Name(). Real-world: name="docker", package="docker-ce".
+func TestSystemPackage_Expand_PackageDiffersFromName(t *testing.T) {
+	t.Parallel()
+	sp := &SystemPackage{
+		BaseResource: BaseResource{Metadata: Metadata{Name: "docker"}},
+		SystemPackageSpec: &SystemPackageSpec{
+			InstallerRef: "apt",
+			Package:      "docker-ce",
+		},
+	}
+
+	got, err := sp.Expand()
+	if err != nil {
+		t.Fatalf("Expand() unexpected error: %v", err)
+	}
+	set := got[0].(*SystemPackageSet)
+	if set.Name() != "docker" {
+		t.Errorf("expanded Name = %q, want %q (resource identity)", set.Name(), "docker")
+	}
+	if got, want := set.SystemPackageSetSpec.Packages, []string{"docker-ce"}; !slices.Equal(got, want) {
+		t.Errorf("expanded Packages = %v, want %v (must use spec.Package, not sp.Name())", got, want)
+	}
+}
+
+func TestSystemPackage_Expand_NilSpec(t *testing.T) {
+	t.Parallel()
+	sp := &SystemPackage{
+		BaseResource: BaseResource{Metadata: Metadata{Name: "git"}},
+	}
+
+	_, err := sp.Expand()
+	if err == nil {
+		t.Fatal("Expand() with nil spec: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "nil spec") {
+		t.Errorf("Expand() error = %q, want containing %q", err.Error(), "nil spec")
+	}
+}
+
+// TestSystemPackage_Expand_Verbatim is a regression fence for the
+// "no normalization, no validation" contract on Package strings.
+// If a future change adds rejection or rewriting in Expand(), these
+// cases break and document what real-world (and hostile) inputs are
+// silently passed through to the installer adapter.
+func TestSystemPackage_Expand_Verbatim(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"apt version pin": "nodejs=18.*",
+		"apt multiarch":   "libc6:i386",
+		"newline":         "git\nrm -rf /", // hostile: must NOT be normalized here
+		"leading dash":    "--reinstall",   // hostile: flag-injection style; argv hardening lives in #190
+		"nul byte":        "git\x00rm",     // hostile: should round-trip; rejection (if any) belongs at installer boundary
+	}
+	for name, pkg := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			sp := &SystemPackage{
+				BaseResource:      BaseResource{Metadata: Metadata{Name: "x"}},
+				SystemPackageSpec: &SystemPackageSpec{InstallerRef: "apt", Package: pkg},
+			}
+			got, err := sp.Expand()
+			if err != nil {
+				t.Fatalf("Expand(%q) error: %v", pkg, err)
+			}
+			set := got[0].(*SystemPackageSet)
+			if got, want := set.SystemPackageSetSpec.Packages, []string{pkg}; !slices.Equal(got, want) {
+				t.Errorf("Packages = %q, want %q (verbatim)", got, want)
 			}
 		})
 	}

--- a/internal/resource/system_package_test.go
+++ b/internal/resource/system_package_test.go
@@ -6,6 +6,59 @@ import (
 	"testing"
 )
 
+func TestSystemPackageSetSpec_Validate(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		spec    SystemPackageSetSpec
+		wantErr string
+	}{
+		{
+			name:    "empty installerRef",
+			spec:    SystemPackageSetSpec{Packages: []string{"git"}},
+			wantErr: "installerRef is required",
+		},
+		{
+			name:    "empty packages slice",
+			spec:    SystemPackageSetSpec{InstallerRef: "apt"},
+			wantErr: "at least one package is required",
+		},
+		{
+			name:    "empty package string",
+			spec:    SystemPackageSetSpec{InstallerRef: "apt", Packages: []string{""}},
+			wantErr: "packages[0] must not be empty",
+		},
+		{
+			name:    "empty package among valid ones",
+			spec:    SystemPackageSetSpec{InstallerRef: "apt", Packages: []string{"git", "", "curl"}},
+			wantErr: "packages[1] must not be empty",
+		},
+		{
+			name:    "valid",
+			spec:    SystemPackageSetSpec{InstallerRef: "apt", Packages: []string{"git"}},
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.spec.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("Validate() unexpected error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("Validate() expected error containing %q, got nil", tt.wantErr)
+				} else if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("Validate() error = %q, want containing %q", err.Error(), tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
 func TestSystemPackageSpec_Validate(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -220,7 +273,7 @@ func TestSystemPackage_Expand_Verbatim(t *testing.T) {
 			}
 			set := got[0].(*SystemPackageSet)
 			if got, want := set.SystemPackageSetSpec.Packages, []string{pkg}; !slices.Equal(got, want) {
-				t.Errorf("Packages = %q, want %q (verbatim)", got, want)
+				t.Errorf("Packages = %v, want %v (verbatim)", got, want)
 			}
 		})
 	}


### PR DESCRIPTION
Adds Expand() so a SystemPackage manifest is rewritten to a 1-element
SystemPackageSet before reaching the engine. The engine, reconciler,
and plan code paths never see SystemPackage directly.

Packages[0] is sourced from spec.Package (not metadata.name) to keep
resource identity decoupled from the OS-level package string — e.g.
name=docker / package=docker-ce, version pins (nodejs=18.*), multiarch
(libc6:i386). The expansion is verbatim with no validation or
normalization; that contract is locked in by hostile-input regression
tests (newline, leading-dash, NUL). Per-installer package-name
validation and argv-mode exec are tracked as follow-ups for #190.

Also adds a KindSystemPackage case to the config loader so manifests
with kind: SystemPackage deserialize. The CUE schema is tracked
separately under #188.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
