### PR TITLE
docs: add SystemPackage section and E2E for validate/plan (#189)

### DIFF
--- a/docs/cue-schema.md
+++ b/docs/cue-schema.md
@@ -353,9 +353,51 @@ The CUE schema defines `spec.source` as an open struct constrained only by `url:
 
 The exact `options` schema may evolve once the concrete installer lands.
 
+### SystemPackage
+
+Single-package shorthand for [SystemPackageSet](#systempackageset). A `SystemPackage` manifest is rewritten into a one-element `SystemPackageSet` at load time — `tomei plan` and `tomei apply` output show `SystemPackageSet/<name>`, never `SystemPackage/<name>`.
+
+Use `SystemPackage` when you want to declare an OS package as its own resource (one resource per package, with its own `metadata.name` and dependency edges). Use [SystemPackageSet](#systempackageset) for batched declarations.
+
+> **Note:** Like `SystemPackageSet`, the concrete installer is **not yet implemented** — declared `SystemPackage` resources expand to `SystemPackageSet` and are shown as `skip` in plan, then skipped at apply time with a warning.
+
+```cue
+git: {
+    apiVersion: "tomei.terassyi.net/v1beta1"
+    kind:       "SystemPackage"
+    metadata: name: "git"
+    spec: {
+        installerRef: "apt"
+        package:      "git"
+    }
+}
+
+// docker uses an upstream apt repository.
+docker: {
+    apiVersion: "tomei.terassyi.net/v1beta1"
+    kind:       "SystemPackage"
+    metadata: name: "docker"
+    spec: {
+        installerRef:  "apt"
+        repositoryRef: "docker"
+        package:       "docker-ce"
+    }
+}
+```
+
+#### Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `spec.installerRef` | string | yes | Reference to a [SystemInstaller](#systeminstaller) |
+| `spec.repositoryRef` | string | no | Reference to a [SystemPackageRepository](#systempackagerepository) — adds a DAG edge so the repository is registered before the package is installed |
+| `spec.package` | string | yes | Package name passed to the installer. Per-installer grammar (version pins like `nodejs=18.*`, multiarch suffixes like `libc6:i386`, group prefixes like `@core`) is accepted verbatim |
+
+`metadata.name` is a tomei resource identifier and is independent from `spec.package` — e.g., `name: "docker"` with `package: "docker-ce"`.
+
 ### SystemPackageSet
 
-Set of system packages installed via a [SystemInstaller](#systeminstaller). The CUE schema accepts the resource and the reconciler computes plan actions, but the concrete installer is **not yet implemented** — declared package sets are shown as `skip` in plan and skipped at apply time with a warning.
+Set of system packages installed via a [SystemInstaller](#systeminstaller). The CUE schema accepts the resource and the reconciler computes plan actions, but the concrete installer is **not yet implemented** — declared package sets (and their shorthand [SystemPackage](#systempackage)) are shown as `skip` in plan and skipped at apply time with a warning.
 
 ```cue
 // Distribution-provided packages — no repositoryRef

--- a/docs/cue-schema.md
+++ b/docs/cue-schema.md
@@ -391,7 +391,7 @@ docker: {
 |-------|------|----------|-------------|
 | `spec.installerRef` | string | yes | Reference to a [SystemInstaller](#systeminstaller) |
 | `spec.repositoryRef` | string | no | Reference to a [SystemPackageRepository](#systempackagerepository) — adds a DAG edge so the repository is registered before the package is installed |
-| `spec.package` | string | yes | Package name passed to the installer. Per-installer grammar (version pins like `nodejs=18.*`, multiarch suffixes like `libc6:i386`, group prefixes like `@core`) is accepted verbatim |
+| `spec.package` | string | yes | Package name passed to the installer. Must be a non-whitespace token (`^\S+$` — no spaces, tabs, or newlines). Per-installer grammar (version pins like `nodejs=18.*`, multiarch suffixes like `libc6:i386`, group prefixes like `@core`) is accepted verbatim within that constraint |
 
 `metadata.name` is a tomei resource identifier and is independent from `spec.package` — e.g., `name: "docker"` with `package: "docker-ce"`.
 
@@ -434,7 +434,7 @@ spec: {
 |-------|------|----------|-------------|
 | `spec.installerRef` | string | yes | Reference to a [SystemInstaller](#systeminstaller) |
 | `spec.repositoryRef` | string | no | Reference to a [SystemPackageRepository](#systempackagerepository) — adds a DAG edge so the repository is registered before packages are installed |
-| `spec.packages` | `[...string]` | yes | Package names to install (must be non-empty) |
+| `spec.packages` | `[...string]` | yes | Package names to install. Each element must be a non-whitespace token (`^\S+$`); the list itself must be non-empty |
 
 ## Common Types
 

--- a/docs/cue-schema.md
+++ b/docs/cue-schema.md
@@ -319,7 +319,7 @@ The `spec.commands.*` declarations are not consumed by the engine at apply time 
 
 ### SystemPackageRepository
 
-Third-party APT repository (e.g., Docker, Kubernetes). The CUE schema accepts the resource and the reconciler computes plan actions, but the concrete installer is **not yet implemented** — declared repositories are shown as `skip` in plan and skipped at apply time with a warning.
+Third-party APT repository (e.g., Docker, Kubernetes). The CUE schema accepts the resource and the reconciler computes plan actions, but the concrete installer is **not yet implemented** — declared repositories are shown as `skip` in plan when changes would be required, and skipped at apply time with a warning.
 
 ```cue
 apiVersion: "tomei.terassyi.net/v1beta1"
@@ -359,7 +359,7 @@ Single-package shorthand for [SystemPackageSet](#systempackageset). A `SystemPac
 
 Use `SystemPackage` when you want to declare an OS package as its own resource (one resource per package, with its own `metadata.name` and dependency edges). Use [SystemPackageSet](#systempackageset) for batched declarations.
 
-> **Note:** Like `SystemPackageSet`, the concrete installer is **not yet implemented** — declared `SystemPackage` resources expand to `SystemPackageSet` and are shown as `skip` in plan, then skipped at apply time with a warning.
+> **Note:** Like `SystemPackageSet`, the concrete installer is **not yet implemented** — declared `SystemPackage` resources expand to `SystemPackageSet` and are shown as `skip` in plan when changes would be required, then skipped at apply time with a warning.
 
 ```cue
 git: {
@@ -397,7 +397,7 @@ docker: {
 
 ### SystemPackageSet
 
-Set of system packages installed via a [SystemInstaller](#systeminstaller). The CUE schema accepts the resource and the reconciler computes plan actions, but the concrete installer is **not yet implemented** — declared package sets (and their shorthand [SystemPackage](#systempackage)) are shown as `skip` in plan and skipped at apply time with a warning.
+Set of system packages installed via a [SystemInstaller](#systeminstaller). The CUE schema accepts the resource and the reconciler computes plan actions, but the concrete installer is **not yet implemented** — declared package sets (and their shorthand [SystemPackage](#systempackage)) are shown as `skip` in plan when changes would be required, and skipped at apply time with a warning.
 
 ```cue
 // Distribution-provided packages — no repositoryRef

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -272,6 +272,7 @@ System resources:
 |------|---------|
 | `SystemInstaller` | Declares a host package manager (currently `apt` only). Validates the package manager is available and captures its version. |
 | `SystemPackageRepository` | Third-party APT repository (e.g., Docker, Kubernetes). Concrete installer is **not yet implemented** — declared resources are shown as `skip`. |
+| `SystemPackage` | Single-package shorthand for `SystemPackageSet`. Expands to a one-element set at load time; same skip behavior. |
 | `SystemPackageSet` | Set of system packages to install. Concrete installer is **not yet implemented** — declared resources are shown as `skip`. |
 
 Example manifest (no preset ships for `apt` — declare it inline):
@@ -290,6 +291,20 @@ spec: {
     }
 }
 ```
+
+For a single package, use `SystemPackage` (shorthand that expands to a one-element `SystemPackageSet`):
+
+```cue
+apiVersion: "tomei.terassyi.net/v1beta1"
+kind:       "SystemPackage"
+metadata: name: "git"
+spec: {
+    installerRef: "apt"
+    package:      "git"
+}
+```
+
+Both `SystemPackage` and `SystemPackageSet` require `--system` at apply time. See [CUE Schema → SystemPackage](./cue-schema.md#systempackage) for field details.
 
 Without `--system`, system resources and privileged tools are skipped at apply time:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -271,9 +271,9 @@ System resources:
 | Kind | Purpose |
 |------|---------|
 | `SystemInstaller` | Declares a host package manager (currently `apt` only). Validates the package manager is available and captures its version. |
-| `SystemPackageRepository` | Third-party APT repository (e.g., Docker, Kubernetes). Concrete installer is **not yet implemented** — declared resources are shown as `skip`. |
+| `SystemPackageRepository` | Third-party APT repository (e.g., Docker, Kubernetes). Concrete installer is **not yet implemented** — declared resources are shown as `skip` in plan when changes would be required. |
 | `SystemPackage` | Single-package shorthand for `SystemPackageSet`. Expands to a one-element set at load time; same skip behavior. |
-| `SystemPackageSet` | Set of system packages to install. Concrete installer is **not yet implemented** — declared resources are shown as `skip`. |
+| `SystemPackageSet` | Set of system packages to install. Concrete installer is **not yet implemented** — declared resources are shown as `skip` in plan when changes would be required. |
 
 Example manifest (no preset ships for `apt` — declare it inline):
 

--- a/e2e/config/system-package-test/cue.mod/module.cue
+++ b/e2e/config/system-package-test/cue.mod/module.cue
@@ -1,0 +1,2 @@
+module: "tomei.local@v0"
+language: version: "v0.9.0"

--- a/e2e/config/system-package-test/manifest.cue
+++ b/e2e/config/system-package-test/manifest.cue
@@ -1,0 +1,36 @@
+package tomei
+
+apt: {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "SystemInstaller"
+	metadata: name: "apt"
+	spec: {
+		pattern:    "delegation"
+		privileged: true
+		commands: {
+			install: {command: "sudo apt-get install -y"}
+			remove:  {command: "sudo apt-get remove -y"}
+			check:   {command: "dpkg -s"}
+		}
+	}
+}
+
+tree: {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "SystemPackage"
+	metadata: name: "tree"
+	spec: {
+		installerRef: "apt"
+		package:      "tree"
+	}
+}
+
+cliTools: {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "SystemPackageSet"
+	metadata: name: "cli-tools"
+	spec: {
+		installerRef: "apt"
+		packages: ["jq", "curl"]
+	}
+}

--- a/e2e/containers/ubuntu/Dockerfile
+++ b/e2e/containers/ubuntu/Dockerfile
@@ -70,5 +70,8 @@ COPY --chown=testuser:testuser config/binary-name-test/ /home/testuser/binary-na
 # Copy privileged-test manifests
 COPY --chown=testuser:testuser config/privileged-test/ /home/testuser/privileged-test/
 
+# Copy system-package-test manifests
+COPY --chown=testuser:testuser config/system-package-test/ /home/testuser/system-package-test/
+
 # Default command
 CMD ["tomei", "version"]

--- a/e2e/executor.go
+++ b/e2e/executor.go
@@ -270,6 +270,11 @@ func (e *nativeExecutor) copyTestConfigs() error {
 		return fmt.Errorf("failed to copy privileged-test: %w", err)
 	}
 
+	// Copy system-package-test configs
+	if err := copyDir(filepath.Join(configDir, "system-package-test"), filepath.Join(e.testHome, "system-package-test")); err != nil {
+		return fmt.Errorf("failed to copy system-package-test: %w", err)
+	}
+
 	return nil
 }
 

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -53,4 +53,5 @@ var _ = Describe("tomei E2E", Ordered, func() {
 	Context("Commands Pattern", commandsPatternTests)
 	Context("BinaryName", binaryNameTests)
 	Context("Privileged", privilegedTests)
+	Context("SystemPackage and SystemPackageSet", systemPackageTests)
 })

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -14,10 +14,11 @@ func systemPackageTests() {
 		out, err := testExec.Exec("tomei", "validate", cfgPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(out).To(ContainSubstring("SystemInstaller/apt"))
-		// SystemPackage は ExpandSets で展開され、出力は SystemPackageSet 名となる。
 		Expect(out).To(ContainSubstring("SystemPackageSet/tree"))
 		Expect(out).To(ContainSubstring("SystemPackageSet/cli-tools"))
-		// desugar 契約: pre-expand の SystemPackage 名は出力に現れない。
+		// Desugar contract: pre-expand SystemPackage names must not surface
+		// in user-visible output. ExpandSets at validate.go:51 rewrites
+		// SystemPackage into SystemPackageSet before printing.
 		Expect(out).NotTo(ContainSubstring("SystemPackage/tree"))
 		Expect(out).To(ContainSubstring("Validation successful"))
 	})

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -17,8 +17,8 @@ func systemPackageTests() {
 		Expect(out).To(ContainSubstring("SystemPackageSet/tree"))
 		Expect(out).To(ContainSubstring("SystemPackageSet/cli-tools"))
 		// Desugar contract: pre-expand SystemPackage names must not surface
-		// in user-visible output. ExpandSets at validate.go:51 rewrites
-		// SystemPackage into SystemPackageSet before printing.
+		// in user-visible output. ExpandSets rewrites SystemPackage into
+		// SystemPackageSet before any kind/name printing.
 		Expect(out).NotTo(ContainSubstring("SystemPackage/tree"))
 		Expect(out).To(ContainSubstring("Validation successful"))
 	})

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -24,9 +24,8 @@ func systemPackageTests() {
 	})
 
 	It("plan without --system shows system resources (skipped)", func() {
-		// Action label (skip/install) is intentionally not asserted: today
-		// SystemPackageSet shows "skip" via plan.go's skip-stub branch and will
-		// become "install" once #199 wires the concrete APT installer.
+		// Without --system, system resources are forced to ActionSkip
+		// regardless of installer wiring. Action label is not asserted.
 		out, err := testExec.Exec("tomei", "plan", cfgPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(out).To(ContainSubstring("SystemPackageSet/tree"))
@@ -34,6 +33,10 @@ func systemPackageTests() {
 	})
 
 	It("plan --system shows expanded SystemPackageSet entries", func() {
+		// With --system, SystemPackageSet currently shows "skip" because
+		// the concrete APT installer is not yet wired (skipPackageInstaller
+		// stub). Once #199 lands, the action label becomes "install"; the
+		// loose ContainSubstring assertions stay green across the transition.
 		out, err := testExec.Exec("tomei", "plan", "--system", cfgPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(out).To(ContainSubstring("SystemInstaller/apt"))

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -1,0 +1,42 @@
+//go:build e2e
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func systemPackageTests() {
+	const cfgPath = "~/system-package-test/"
+
+	It("validates SystemPackage and SystemPackageSet manifests", func() {
+		out, err := testExec.Exec("tomei", "validate", cfgPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(ContainSubstring("SystemInstaller/apt"))
+		// SystemPackage は ExpandSets で展開され、出力は SystemPackageSet 名となる。
+		Expect(out).To(ContainSubstring("SystemPackageSet/tree"))
+		Expect(out).To(ContainSubstring("SystemPackageSet/cli-tools"))
+		// desugar 契約: pre-expand の SystemPackage 名は出力に現れない。
+		Expect(out).NotTo(ContainSubstring("SystemPackage/tree"))
+		Expect(out).To(ContainSubstring("Validation successful"))
+	})
+
+	It("plan without --system shows system resources (skipped)", func() {
+		// Action label (skip/install) is intentionally not asserted: today
+		// SystemPackageSet shows "skip" via plan.go's skip-stub branch and will
+		// become "install" once #199 wires the concrete APT installer.
+		out, err := testExec.Exec("tomei", "plan", cfgPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(ContainSubstring("SystemPackageSet/tree"))
+		Expect(out).To(ContainSubstring("SystemPackageSet/cli-tools"))
+	})
+
+	It("plan --system shows expanded SystemPackageSet entries", func() {
+		out, err := testExec.Exec("tomei", "plan", "--system", cfgPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(ContainSubstring("SystemInstaller/apt"))
+		Expect(out).To(ContainSubstring("SystemPackageSet/tree"))
+		Expect(out).To(ContainSubstring("SystemPackageSet/cli-tools"))
+	})
+}


### PR DESCRIPTION
## Summary

Closes #189.

- Add **SystemPackage** section to `docs/cue-schema.md` (before `SystemPackageSet`, mirroring Tool/ToolSet ordering).
- Add SystemPackage row + example to `docs/usage.md`'s System Package Management section.
- Add `e2e/config/system-package-test/` fixture covering both `SystemPackage` (sugar) and `SystemPackageSet` (set) forms with one shared `SystemInstaller`.
- Add `e2e/system_package_test.go` with three Its under `Context(\"SystemPackage and SystemPackageSet\")` asserting validate / plan / plan --system print the post-expand `SystemPackageSet/<name>`.
- Wire the fixture in BOTH `e2e/executor.go` (native mode) AND `e2e/containers/ubuntu/Dockerfile` (container mode) — every fixture needs both.

This is **regression-pinning, not feature-driven TDD**: the production code merged in #201 / #203 / #204; this PR closes the verification gap so CI catches regressions on the validate + plan path going forward.

`design.md` is intentionally not updated — SystemPackage is a loader-time shorthand and is not a node in the engine DAG, so its absence from the architecture diagram is correct.

Action labels (skip/install) are intentionally NOT asserted so the tests stay green across the skip→install transition once #199 wires the concrete APT installer. The validate test does include a `NotTo(ContainSubstring(\"SystemPackage/tree\"))` to lock the desugar contract end-to-end.

## Test plan

- [x] \`make build\` passes
- [x] \`bin/tomei validate e2e/config/system-package-test/\` succeeds locally (3 resources)
- [x] \`bin/tomei plan e2e/config/system-package-test/\` shows `SystemPackageSet/tree`, `SystemPackageSet/cli-tools`, `SystemInstaller/apt`
- [x] \`make test-e2e\` — full 215-spec suite passes including 3 new Its under \`Context(\"SystemPackage and SystemPackageSet\")\`
- [x] \`make lint\` — golangci-lint clean (cue fmt --check expected to fail locally without \`cue\` CLI; CI handles)
- [x] \`make test\` — no unit-test regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)