### PR TITLE
feat(apt): add GetInstall helper (#190)

### DIFF
--- a/cmd/tomei/system_engine.go
+++ b/cmd/tomei/system_engine.go
@@ -95,7 +95,7 @@ func createSystemEngine(systemDataDir string) (*engine.SystemEngine, error) {
 		slog.Debug("detected distribution", "id", distro.ID, "id_like", distro.IDLike)
 		runner := command.NewExecutor("")
 		versionFuncs := map[system.PackageManager]system.VersionFunc{
-			system.PackageManagerAPT: apt.VersionFunc(runner),
+			system.PackageManagerAPT: apt.New(runner).VersionFunc(),
 		}
 		v, err := system.NewValidator(distro, versionFuncs)
 		if err != nil {

--- a/internal/installer/apt/apt.go
+++ b/internal/installer/apt/apt.go
@@ -16,16 +16,43 @@ type CommandRunner interface {
 	ExecuteCapture(ctx context.Context, cmds []string, vars command.Vars, env map[string]string) (string, error)
 }
 
+// Client groups apt-get / dpkg helpers used by the SystemInstaller validator
+// and (in #195/#198) the SystemPackageRepository / SystemPackageSet installers.
+// All methods share a single CommandRunner.
+type Client struct {
+	runner CommandRunner
+}
+
+// New returns a Client bound to the given runner.
+func New(runner CommandRunner) *Client {
+	return &Client{runner: runner}
+}
+
 // VersionFunc returns a system.VersionFunc that runs "apt-get --version"
 // and extracts the version string.
-func VersionFunc(runner CommandRunner) system.VersionFunc {
+func (c *Client) VersionFunc() system.VersionFunc {
 	return func(ctx context.Context) (string, error) {
-		output, err := runner.ExecuteCapture(ctx, []string{"apt-get --version"}, command.Vars{}, nil)
+		output, err := c.runner.ExecuteCapture(ctx, []string{"apt-get --version"}, command.Vars{}, nil)
 		if err != nil {
 			return "", fmt.Errorf("failed to run apt-get --version: %w", err)
 		}
 		return parseAptVersion(output)
 	}
+}
+
+// GetInstall installs the given packages via "sudo -n apt-get install -y".
+// Wiring into the SystemPackageSet installer happens in #198.
+// Returns an error if packages is empty (defense-in-depth; schema validation
+// at the resource layer should reject this earlier).
+func (c *Client) GetInstall(ctx context.Context, packages []string) error {
+	if len(packages) == 0 {
+		return fmt.Errorf("GetInstall: at least one package is required")
+	}
+	cmd := "sudo -n apt-get install -y " + strings.Join(packages, " ")
+	if _, err := c.runner.ExecuteCapture(ctx, []string{cmd}, command.Vars{}, nil); err != nil {
+		return fmt.Errorf("apt-get install %v: %w", packages, err)
+	}
+	return nil
 }
 
 // parseAptVersion extracts the version string from apt-get --version output.
@@ -38,19 +65,4 @@ func parseAptVersion(output string) (string, error) {
 		return "", fmt.Errorf("unexpected apt-get --version output: %q", output)
 	}
 	return fields[1], nil
-}
-
-// GetInstall installs the given packages via "sudo -n apt-get install -y".
-// Pure helper — wiring into the SystemPackageSet installer happens in #198.
-// Returns an error if packages is empty (defense-in-depth; schema validation
-// at the resource layer should reject this earlier).
-func GetInstall(ctx context.Context, runner CommandRunner, packages []string) error {
-	if len(packages) == 0 {
-		return fmt.Errorf("GetInstall: at least one package is required")
-	}
-	cmd := "sudo -n apt-get install -y " + strings.Join(packages, " ")
-	if _, err := runner.ExecuteCapture(ctx, []string{cmd}, command.Vars{}, nil); err != nil {
-		return fmt.Errorf("apt-get install %v: %w", packages, err)
-	}
-	return nil
 }

--- a/internal/installer/apt/apt.go
+++ b/internal/installer/apt/apt.go
@@ -18,14 +18,14 @@ type CommandRunner interface {
 	ExecuteWithOutput(ctx context.Context, cmds []string, vars command.Vars, env map[string]string, callback command.OutputCallback) error
 }
 
-// errEmptyPackages is returned by GetInstall when called with no packages.
+// errEmptyPackages is returned by Install when called with no packages.
 var errEmptyPackages = errors.New("apt: install requires at least one package")
 
 // disallowedInPackageName covers whitespace, shell metacharacters, and
 // shell-expansion characters (globs, tilde, comment) that would either
 // split a package name across argv slots, allow injection through the
 // sh -c command form, or be expanded by the shell against the cwd. The
-// schema layer also rejects whitespace; GetInstall guards independently
+// schema layer also rejects whitespace; Install guards independently
 // as defense-in-depth for non-CUE callers. As a side effect, apt's regex
 // package syntax (e.g. "linux-image-*") is also rejected — argv-form
 // executor migration is tracked separately and would close this entire
@@ -61,7 +61,7 @@ func (c *Client) VersionFunc() system.VersionFunc {
 	}
 }
 
-// GetInstall installs the given packages by running, under the configured
+// Install installs the given packages by running, under the configured
 // runner: "sudo -n apt-get install -y -o DPkg::Lock::Timeout=60 -- <packages>"
 // with DEBIAN_FRONTEND=noninteractive in the environment. stdout/stderr are
 // drained; the install action is silent on success.
@@ -72,7 +72,7 @@ func (c *Client) VersionFunc() system.VersionFunc {
 //
 // Callers are responsible for ensuring a recent "apt-get update" has run
 // when stale package indexes would cause 404s.
-func (c *Client) GetInstall(ctx context.Context, packages []string) error {
+func (c *Client) Install(ctx context.Context, packages []string) error {
 	if len(packages) == 0 {
 		return errEmptyPackages
 	}

--- a/internal/installer/apt/apt.go
+++ b/internal/installer/apt/apt.go
@@ -35,10 +35,12 @@ var errEmptyPackages = errors.New("apt: install requires at least one package")
 // surface.
 const disallowedInPackageName = " \t\n\r;|&`$<>(){}*?[]~#\\\"'"
 
-// aptEnv is the environment for every apt-get invocation. DEBIAN_FRONTEND is
-// load-bearing: without it, packages with debconf prompts (tzdata,
-// keyboard-configuration, etc.) hang indefinitely under "apt-get -y".
-var aptEnv = map[string]string{"DEBIAN_FRONTEND": "noninteractive"}
+// debianFrontendNoninteractive is prepended to the apt-get install command
+// via `env`, not passed via the runner's env map. sudo strips most parent
+// env vars by default (env_reset in /etc/sudoers), so a plain `env` map on
+// the runner side would not reach apt-get; running `sudo env VAR=value
+// apt-get …` is sudoers-independent and works on minimal CI images.
+const debianFrontendNoninteractive = "env DEBIAN_FRONTEND=noninteractive"
 
 // Client wraps a CommandRunner with apt-get / dpkg integration. It is the
 // shared entry point: callers obtain adapters for specific system resources
@@ -57,7 +59,7 @@ func New(runner CommandRunner) *Client {
 // and extracts the version string. Used by the SystemInstaller validator.
 func (c *Client) VersionFunc() system.VersionFunc {
 	return func(ctx context.Context) (string, error) {
-		output, err := c.runner.ExecuteCapture(ctx, []string{"apt-get --version"}, command.Vars{}, aptEnv)
+		output, err := c.runner.ExecuteCapture(ctx, []string{"apt-get --version"}, command.Vars{}, nil)
 		if err != nil {
 			return "", fmt.Errorf("failed to run apt-get --version: %w", err)
 		}
@@ -130,10 +132,12 @@ func (p *PackageSetInstaller) runInstall(ctx context.Context, packages []string)
 			return fmt.Errorf("apt: package %q contains disallowed characters", pkg)
 		}
 	}
-	cmd := "sudo -n apt-get install -y -o DPkg::Lock::Timeout=60 -- " + strings.Join(packages, " ")
+	cmd := "sudo -n " + debianFrontendNoninteractive +
+		" apt-get install -y -o DPkg::Lock::Timeout=60 -- " +
+		strings.Join(packages, " ")
 	// nil callback drains stdout/stderr to io.Discard rather than buffering
 	// in memory; apt-get install output can be large.
-	if err := p.client.runner.ExecuteWithOutput(ctx, []string{cmd}, command.Vars{}, aptEnv, nil); err != nil {
+	if err := p.client.runner.ExecuteWithOutput(ctx, []string{cmd}, command.Vars{}, nil, nil); err != nil {
 		return fmt.Errorf("apt: install %q: %w", packages, err)
 	}
 	return nil

--- a/internal/installer/apt/apt.go
+++ b/internal/installer/apt/apt.go
@@ -21,11 +21,13 @@ type CommandRunner interface {
 // errEmptyPackages is returned by GetInstall when called with no packages.
 var errEmptyPackages = errors.New("apt: install requires at least one package")
 
-// shellMetachars are characters that, if present in a package name, would
-// allow shell injection via the sh -c command form. The schema layer rejects
-// whitespace; this layer rejects the remaining shell metacharacters as
-// defense-in-depth until the executor moves to argv form.
-const shellMetachars = ";|&`$<>(){}\\\"'"
+// disallowedInPackageName covers whitespace and shell metacharacters that
+// would either split a package name across argv slots or allow injection
+// through the sh -c command form. The schema layer also rejects whitespace,
+// but GetInstall guards independently as defense-in-depth for non-CUE
+// callers (e.g., programmatic construction). Argv-form executor migration
+// is tracked separately and would close this entire surface.
+const disallowedInPackageName = " \t\n\r;|&`$<>(){}\\\"'"
 
 // aptEnv is the environment for every apt-get invocation. DEBIAN_FRONTEND is
 // load-bearing: without it, packages with debconf prompts (tzdata,
@@ -56,10 +58,14 @@ func (c *Client) VersionFunc() system.VersionFunc {
 	}
 }
 
-// GetInstall installs the given packages via "sudo -n apt-get install -y".
+// GetInstall installs the given packages by running, under the configured
+// runner: "sudo -n apt-get install -y -o DPkg::Lock::Timeout=60 -- <packages>"
+// with DEBIAN_FRONTEND=noninteractive in the environment. stdout/stderr are
+// drained; the install action is silent on success.
+//
 // Returns errEmptyPackages if packages is empty. Each package name is
-// rejected if it contains shell metacharacters, since the executor uses
-// sh -c (full argv-form is tracked separately).
+// rejected if it contains whitespace or shell metacharacters, since the
+// executor uses sh -c (full argv-form is tracked separately).
 //
 // Callers are responsible for ensuring a recent "apt-get update" has run
 // when stale package indexes would cause 404s.
@@ -68,7 +74,7 @@ func (c *Client) GetInstall(ctx context.Context, packages []string) error {
 		return errEmptyPackages
 	}
 	for _, p := range packages {
-		if strings.ContainsAny(p, shellMetachars) {
+		if strings.ContainsAny(p, disallowedInPackageName) {
 			return fmt.Errorf("apt: package %q contains disallowed characters", p)
 		}
 	}

--- a/internal/installer/apt/apt.go
+++ b/internal/installer/apt/apt.go
@@ -77,6 +77,9 @@ func (c *Client) GetInstall(ctx context.Context, packages []string) error {
 		return errEmptyPackages
 	}
 	for _, p := range packages {
+		if p == "" {
+			return errors.New("apt: empty package name in install list")
+		}
 		if strings.ContainsAny(p, disallowedInPackageName) {
 			return fmt.Errorf("apt: package %q contains disallowed characters", p)
 		}

--- a/internal/installer/apt/apt.go
+++ b/internal/installer/apt/apt.go
@@ -3,6 +3,7 @@ package apt
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -16,9 +17,23 @@ type CommandRunner interface {
 	ExecuteCapture(ctx context.Context, cmds []string, vars command.Vars, env map[string]string) (string, error)
 }
 
-// Client groups apt-get / dpkg helpers used by the SystemInstaller validator
-// and (in #195/#198) the SystemPackageRepository / SystemPackageSet installers.
-// All methods share a single CommandRunner.
+// errEmptyPackages is returned by GetInstall when called with no packages.
+var errEmptyPackages = errors.New("apt: install requires at least one package")
+
+// shellMetachars are characters that, if present in a package name, would
+// allow shell injection via the sh -c command form. The schema layer rejects
+// whitespace; this layer rejects the remaining shell metacharacters as
+// defense-in-depth until the executor moves to argv form.
+const shellMetachars = ";|&`$<>(){}\\\"'"
+
+// aptEnv is the environment for every apt-get invocation. DEBIAN_FRONTEND is
+// load-bearing: without it, packages with debconf prompts (tzdata,
+// keyboard-configuration, etc.) hang indefinitely under "apt-get -y".
+var aptEnv = map[string]string{"DEBIAN_FRONTEND": "noninteractive"}
+
+// Client groups apt-get / dpkg helpers behind a single CommandRunner.
+// Used by the SystemInstaller validator and the SystemPackageRepository /
+// SystemPackageSet installers.
 type Client struct {
 	runner CommandRunner
 }
@@ -32,7 +47,7 @@ func New(runner CommandRunner) *Client {
 // and extracts the version string.
 func (c *Client) VersionFunc() system.VersionFunc {
 	return func(ctx context.Context) (string, error) {
-		output, err := c.runner.ExecuteCapture(ctx, []string{"apt-get --version"}, command.Vars{}, nil)
+		output, err := c.runner.ExecuteCapture(ctx, []string{"apt-get --version"}, command.Vars{}, aptEnv)
 		if err != nil {
 			return "", fmt.Errorf("failed to run apt-get --version: %w", err)
 		}
@@ -41,16 +56,24 @@ func (c *Client) VersionFunc() system.VersionFunc {
 }
 
 // GetInstall installs the given packages via "sudo -n apt-get install -y".
-// Wiring into the SystemPackageSet installer happens in #198.
-// Returns an error if packages is empty (defense-in-depth; schema validation
-// at the resource layer should reject this earlier).
+// Returns errEmptyPackages if packages is empty. Each package name is
+// rejected if it contains shell metacharacters, since the executor uses
+// sh -c (full argv-form is tracked separately).
+//
+// Callers are responsible for ensuring a recent "apt-get update" has run
+// when stale package indexes would cause 404s.
 func (c *Client) GetInstall(ctx context.Context, packages []string) error {
 	if len(packages) == 0 {
-		return fmt.Errorf("GetInstall: at least one package is required")
+		return errEmptyPackages
 	}
-	cmd := "sudo -n apt-get install -y " + strings.Join(packages, " ")
-	if _, err := c.runner.ExecuteCapture(ctx, []string{cmd}, command.Vars{}, nil); err != nil {
-		return fmt.Errorf("apt-get install %v: %w", packages, err)
+	for _, p := range packages {
+		if strings.ContainsAny(p, shellMetachars) {
+			return fmt.Errorf("apt: package %q contains disallowed characters", p)
+		}
+	}
+	cmd := "sudo -n apt-get install -y -o DPkg::Lock::Timeout=60 -- " + strings.Join(packages, " ")
+	if _, err := c.runner.ExecuteCapture(ctx, []string{cmd}, command.Vars{}, aptEnv); err != nil {
+		return fmt.Errorf("apt: install %q: %w", packages, err)
 	}
 	return nil
 }

--- a/internal/installer/apt/apt.go
+++ b/internal/installer/apt/apt.go
@@ -90,10 +90,9 @@ var _ executor.Installer[*resource.SystemPackageSet, *resource.SystemPackageSetS
 //
 // The shell command executed is:
 //
-//	sudo -n apt-get install -y -o DPkg::Lock::Timeout=60 -- <packages>
+//	sudo -n env DEBIAN_FRONTEND=noninteractive apt-get install -y -o DPkg::Lock::Timeout=60 -- <packages>
 //
-// with DEBIAN_FRONTEND=noninteractive in the environment. stdout/stderr are
-// drained line-by-line rather than buffered.
+// stdout/stderr are drained line-by-line rather than buffered.
 //
 // Callers are responsible for ensuring a recent "apt-get update" has run
 // when stale package indexes would cause 404s.
@@ -116,10 +115,11 @@ func (p *PackageSetInstaller) Remove(_ context.Context, _ *resource.SystemPackag
 	return fmt.Errorf("apt: package set %q: remove not yet implemented", name)
 }
 
-// runInstall executes "sudo -n apt-get install -y -o DPkg::Lock::Timeout=60 --
-// <packages>" with DEBIAN_FRONTEND=noninteractive. Returns errEmptyPackages
-// if packages is empty. Each name is rejected if it is empty or contains
-// whitespace / shell metacharacters / shell-expansion characters.
+// runInstall executes "sudo -n env DEBIAN_FRONTEND=noninteractive apt-get
+// install -y -o DPkg::Lock::Timeout=60 -- <packages>". Returns
+// errEmptyPackages if packages is empty. Each name is rejected if it is
+// empty or contains whitespace / shell metacharacters / shell-expansion
+// characters.
 func (p *PackageSetInstaller) runInstall(ctx context.Context, packages []string) error {
 	if len(packages) == 0 {
 		return errEmptyPackages

--- a/internal/installer/apt/apt.go
+++ b/internal/installer/apt/apt.go
@@ -6,8 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/terassyi/tomei/internal/installer/command"
+	"github.com/terassyi/tomei/internal/installer/executor"
+	"github.com/terassyi/tomei/internal/resource"
 	"github.com/terassyi/tomei/internal/system"
 )
 
@@ -18,14 +21,14 @@ type CommandRunner interface {
 	ExecuteWithOutput(ctx context.Context, cmds []string, vars command.Vars, env map[string]string, callback command.OutputCallback) error
 }
 
-// errEmptyPackages is returned by Install when called with no packages.
+// errEmptyPackages is returned when the package list is empty.
 var errEmptyPackages = errors.New("apt: install requires at least one package")
 
 // disallowedInPackageName covers whitespace, shell metacharacters, and
 // shell-expansion characters (globs, tilde, comment) that would either
 // split a package name across argv slots, allow injection through the
 // sh -c command form, or be expanded by the shell against the cwd. The
-// schema layer also rejects whitespace; Install guards independently
+// schema layer also rejects whitespace; the apt layer guards independently
 // as defense-in-depth for non-CUE callers. As a side effect, apt's regex
 // package syntax (e.g. "linux-image-*") is also rejected — argv-form
 // executor migration is tracked separately and would close this entire
@@ -37,9 +40,10 @@ const disallowedInPackageName = " \t\n\r;|&`$<>(){}*?[]~#\\\"'"
 // keyboard-configuration, etc.) hang indefinitely under "apt-get -y".
 var aptEnv = map[string]string{"DEBIAN_FRONTEND": "noninteractive"}
 
-// Client groups apt-get / dpkg helpers behind a single CommandRunner.
-// Used by the SystemInstaller validator and the SystemPackageRepository /
-// SystemPackageSet installers.
+// Client wraps a CommandRunner with apt-get / dpkg integration. It is the
+// shared entry point: callers obtain adapters for specific system resources
+// (VersionFunc for SystemInstaller, PackageSetInstaller for SystemPackageSet)
+// from a single Client so the same runner is reused across all apt operations.
 type Client struct {
 	runner CommandRunner
 }
@@ -50,7 +54,7 @@ func New(runner CommandRunner) *Client {
 }
 
 // VersionFunc returns a system.VersionFunc that runs "apt-get --version"
-// and extracts the version string.
+// and extracts the version string. Used by the SystemInstaller validator.
 func (c *Client) VersionFunc() system.VersionFunc {
 	return func(ctx context.Context) (string, error) {
 		output, err := c.runner.ExecuteCapture(ctx, []string{"apt-get --version"}, command.Vars{}, aptEnv)
@@ -61,33 +65,75 @@ func (c *Client) VersionFunc() system.VersionFunc {
 	}
 }
 
-// Install installs the given packages by running, under the configured
-// runner: "sudo -n apt-get install -y -o DPkg::Lock::Timeout=60 -- <packages>"
-// with DEBIAN_FRONTEND=noninteractive in the environment. stdout/stderr are
-// drained; the install action is silent on success.
+// PackageSetInstaller returns the executor.Installer adapter for
+// SystemPackageSet resources backed by apt-get.
+func (c *Client) PackageSetInstaller() *PackageSetInstaller {
+	return &PackageSetInstaller{client: c}
+}
+
+// PackageSetInstaller installs and removes SystemPackageSet resources via
+// apt-get. It satisfies executor.Installer[*resource.SystemPackageSet,
+// *resource.SystemPackageSetState].
+type PackageSetInstaller struct {
+	client *Client
+}
+
+// Compile-time assertion that *PackageSetInstaller satisfies the executor
+// installer interface for SystemPackageSet.
+var _ executor.Installer[*resource.SystemPackageSet, *resource.SystemPackageSetState] = (*PackageSetInstaller)(nil)
+
+// Install runs the apt-get install for the resource's packages and returns
+// the new state. The InstalledVersions field is left empty until the
+// dpkg-query helper lands; the install action itself is complete.
 //
-// Returns errEmptyPackages if packages is empty. Each package name is
-// rejected if it contains whitespace or shell metacharacters, since the
-// executor uses sh -c (full argv-form is tracked separately).
+// The shell command executed is:
+//
+//	sudo -n apt-get install -y -o DPkg::Lock::Timeout=60 -- <packages>
+//
+// with DEBIAN_FRONTEND=noninteractive in the environment. stdout/stderr are
+// drained line-by-line rather than buffered.
 //
 // Callers are responsible for ensuring a recent "apt-get update" has run
 // when stale package indexes would cause 404s.
-func (c *Client) Install(ctx context.Context, packages []string) error {
+func (p *PackageSetInstaller) Install(ctx context.Context, res *resource.SystemPackageSet, _ string) (*resource.SystemPackageSetState, error) {
+	spec := res.SystemPackageSetSpec
+	if err := p.runInstall(ctx, spec.Packages); err != nil {
+		return nil, err
+	}
+	return &resource.SystemPackageSetState{
+		InstallerRef:      spec.InstallerRef,
+		RepositoryRef:     spec.RepositoryRef,
+		Packages:          append([]string(nil), spec.Packages...),
+		InstalledVersions: map[string]string{},
+		UpdatedAt:         time.Now(),
+	}, nil
+}
+
+// Remove is a stub until the apt-get remove helper lands.
+func (p *PackageSetInstaller) Remove(_ context.Context, _ *resource.SystemPackageSetState, name string) error {
+	return fmt.Errorf("apt: package set %q: remove not yet implemented", name)
+}
+
+// runInstall executes "sudo -n apt-get install -y -o DPkg::Lock::Timeout=60 --
+// <packages>" with DEBIAN_FRONTEND=noninteractive. Returns errEmptyPackages
+// if packages is empty. Each name is rejected if it is empty or contains
+// whitespace / shell metacharacters / shell-expansion characters.
+func (p *PackageSetInstaller) runInstall(ctx context.Context, packages []string) error {
 	if len(packages) == 0 {
 		return errEmptyPackages
 	}
-	for _, p := range packages {
-		if p == "" {
+	for _, pkg := range packages {
+		if pkg == "" {
 			return errors.New("apt: empty package name in install list")
 		}
-		if strings.ContainsAny(p, disallowedInPackageName) {
-			return fmt.Errorf("apt: package %q contains disallowed characters", p)
+		if strings.ContainsAny(pkg, disallowedInPackageName) {
+			return fmt.Errorf("apt: package %q contains disallowed characters", pkg)
 		}
 	}
 	cmd := "sudo -n apt-get install -y -o DPkg::Lock::Timeout=60 -- " + strings.Join(packages, " ")
 	// nil callback drains stdout/stderr to io.Discard rather than buffering
 	// in memory; apt-get install output can be large.
-	if err := c.runner.ExecuteWithOutput(ctx, []string{cmd}, command.Vars{}, aptEnv, nil); err != nil {
+	if err := p.client.runner.ExecuteWithOutput(ctx, []string{cmd}, command.Vars{}, aptEnv, nil); err != nil {
 		return fmt.Errorf("apt: install %q: %w", packages, err)
 	}
 	return nil

--- a/internal/installer/apt/apt.go
+++ b/internal/installer/apt/apt.go
@@ -39,3 +39,18 @@ func parseAptVersion(output string) (string, error) {
 	}
 	return fields[1], nil
 }
+
+// GetInstall installs the given packages via "sudo -n apt-get install -y".
+// Pure helper — wiring into the SystemPackageSet installer happens in #198.
+// Returns an error if packages is empty (defense-in-depth; schema validation
+// at the resource layer should reject this earlier).
+func GetInstall(ctx context.Context, runner CommandRunner, packages []string) error {
+	if len(packages) == 0 {
+		return fmt.Errorf("GetInstall: at least one package is required")
+	}
+	cmd := "sudo -n apt-get install -y " + strings.Join(packages, " ")
+	if _, err := runner.ExecuteCapture(ctx, []string{cmd}, command.Vars{}, nil); err != nil {
+		return fmt.Errorf("apt-get install %v: %w", packages, err)
+	}
+	return nil
+}

--- a/internal/installer/apt/apt.go
+++ b/internal/installer/apt/apt.go
@@ -21,13 +21,16 @@ type CommandRunner interface {
 // errEmptyPackages is returned by GetInstall when called with no packages.
 var errEmptyPackages = errors.New("apt: install requires at least one package")
 
-// disallowedInPackageName covers whitespace and shell metacharacters that
-// would either split a package name across argv slots or allow injection
-// through the sh -c command form. The schema layer also rejects whitespace,
-// but GetInstall guards independently as defense-in-depth for non-CUE
-// callers (e.g., programmatic construction). Argv-form executor migration
-// is tracked separately and would close this entire surface.
-const disallowedInPackageName = " \t\n\r;|&`$<>(){}\\\"'"
+// disallowedInPackageName covers whitespace, shell metacharacters, and
+// shell-expansion characters (globs, tilde, comment) that would either
+// split a package name across argv slots, allow injection through the
+// sh -c command form, or be expanded by the shell against the cwd. The
+// schema layer also rejects whitespace; GetInstall guards independently
+// as defense-in-depth for non-CUE callers. As a side effect, apt's regex
+// package syntax (e.g. "linux-image-*") is also rejected — argv-form
+// executor migration is tracked separately and would close this entire
+// surface.
+const disallowedInPackageName = " \t\n\r;|&`$<>(){}*?[]~#\\\"'"
 
 // aptEnv is the environment for every apt-get invocation. DEBIAN_FRONTEND is
 // load-bearing: without it, packages with debconf prompts (tzdata,

--- a/internal/installer/apt/apt.go
+++ b/internal/installer/apt/apt.go
@@ -15,6 +15,7 @@ import (
 // This is a subset of command.Executor's methods.
 type CommandRunner interface {
 	ExecuteCapture(ctx context.Context, cmds []string, vars command.Vars, env map[string]string) (string, error)
+	ExecuteWithOutput(ctx context.Context, cmds []string, vars command.Vars, env map[string]string, callback command.OutputCallback) error
 }
 
 // errEmptyPackages is returned by GetInstall when called with no packages.
@@ -72,7 +73,9 @@ func (c *Client) GetInstall(ctx context.Context, packages []string) error {
 		}
 	}
 	cmd := "sudo -n apt-get install -y -o DPkg::Lock::Timeout=60 -- " + strings.Join(packages, " ")
-	if _, err := c.runner.ExecuteCapture(ctx, []string{cmd}, command.Vars{}, aptEnv); err != nil {
+	// nil callback drains stdout/stderr to io.Discard rather than buffering
+	// in memory; apt-get install output can be large.
+	if err := c.runner.ExecuteWithOutput(ctx, []string{cmd}, command.Vars{}, aptEnv, nil); err != nil {
 		return fmt.Errorf("apt: install %q: %w", packages, err)
 	}
 	return nil

--- a/internal/installer/apt/apt_test.go
+++ b/internal/installer/apt/apt_test.go
@@ -132,12 +132,12 @@ func TestPackageSetInstaller_Install(t *testing.T) {
 		{
 			name:     "single package",
 			packages: []string{"git"},
-			wantCmd:  "sudo -n apt-get install -y -o DPkg::Lock::Timeout=60 -- git",
+			wantCmd:  "sudo -n env DEBIAN_FRONTEND=noninteractive apt-get install -y -o DPkg::Lock::Timeout=60 -- git",
 		},
 		{
 			name:     "multiple packages",
 			packages: []string{"git", "curl", "tree"},
-			wantCmd:  "sudo -n apt-get install -y -o DPkg::Lock::Timeout=60 -- git curl tree",
+			wantCmd:  "sudo -n env DEBIAN_FRONTEND=noninteractive apt-get install -y -o DPkg::Lock::Timeout=60 -- git curl tree",
 		},
 		{
 			name:     "empty packages",

--- a/internal/installer/apt/apt_test.go
+++ b/internal/installer/apt/apt_test.go
@@ -80,6 +80,11 @@ func (m *mockCommandRunner) ExecuteCapture(_ context.Context, cmds []string, _ c
 	return m.captureOutput, m.captureErr
 }
 
+func (m *mockCommandRunner) ExecuteWithOutput(_ context.Context, cmds []string, _ command.Vars, _ map[string]string, _ command.OutputCallback) error {
+	m.captureCmds = cmds
+	return m.captureErr
+}
+
 // --- VersionFunc tests ---
 
 func TestVersionFunc_Success(t *testing.T) {

--- a/internal/installer/apt/apt_test.go
+++ b/internal/installer/apt/apt_test.go
@@ -85,7 +85,7 @@ func (m *mockCommandRunner) ExecuteCapture(_ context.Context, cmds []string, _ c
 func TestVersionFunc_Success(t *testing.T) {
 	t.Parallel()
 	mock := &mockCommandRunner{captureOutput: "apt 2.7.14build2 (amd64)"}
-	vf := VersionFunc(mock)
+	vf := New(mock).VersionFunc()
 
 	version, err := vf(context.Background())
 	require.NoError(t, err)
@@ -95,7 +95,7 @@ func TestVersionFunc_Success(t *testing.T) {
 func TestVersionFunc_CommandError(t *testing.T) {
 	t.Parallel()
 	mock := &mockCommandRunner{captureErr: fmt.Errorf("exec: \"apt-get\": executable file not found in $PATH")}
-	vf := VersionFunc(mock)
+	vf := New(mock).VersionFunc()
 
 	_, err := vf(context.Background())
 	require.Error(t, err)
@@ -105,7 +105,7 @@ func TestVersionFunc_CommandError(t *testing.T) {
 func TestVersionFunc_ParseError(t *testing.T) {
 	t.Parallel()
 	mock := &mockCommandRunner{captureOutput: "apt"}
-	vf := VersionFunc(mock)
+	vf := New(mock).VersionFunc()
 
 	_, err := vf(context.Background())
 	require.Error(t, err)
@@ -149,7 +149,7 @@ func TestGetInstall(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			runner := &mockCommandRunner{captureErr: tt.runnerErr}
-			err := GetInstall(context.Background(), runner, tt.packages)
+			err := New(runner).GetInstall(context.Background(), tt.packages)
 			if tt.wantErr == "" {
 				require.NoError(t, err)
 				require.Len(t, runner.captureCmds, 1)

--- a/internal/installer/apt/apt_test.go
+++ b/internal/installer/apt/apt_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/terassyi/tomei/internal/installer/command"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
 func TestParseAptVersion(t *testing.T) {
@@ -117,9 +118,9 @@ func TestVersionFunc_ParseError(t *testing.T) {
 	assert.Contains(t, err.Error(), "unexpected apt-get --version output")
 }
 
-// --- Install tests ---
+// --- PackageSetInstaller tests ---
 
-func TestInstall(t *testing.T) {
+func TestPackageSetInstaller_Install(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name      string
@@ -189,15 +190,51 @@ func TestInstall(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			runner := &mockCommandRunner{captureErr: tt.runnerErr}
-			err := New(runner).Install(context.Background(), tt.packages)
+			res := &resource.SystemPackageSet{
+				SystemPackageSetSpec: &resource.SystemPackageSetSpec{
+					InstallerRef: "apt",
+					Packages:     tt.packages,
+				},
+			}
+			state, err := New(runner).PackageSetInstaller().Install(context.Background(), res, "cli-tools")
 			if tt.wantErr == "" {
 				require.NoError(t, err)
 				require.Len(t, runner.captureCmds, 1)
 				assert.Equal(t, tt.wantCmd, runner.captureCmds[0])
+				require.NotNil(t, state)
+				assert.Equal(t, "apt", state.InstallerRef)
+				assert.Equal(t, tt.packages, state.Packages)
+				assert.NotNil(t, state.InstalledVersions)
+				assert.False(t, state.UpdatedAt.IsZero(), "UpdatedAt should be set")
 			} else {
 				require.Error(t, err)
+				assert.Nil(t, state)
 				assert.Contains(t, err.Error(), tt.wantErr)
 			}
 		})
 	}
+}
+
+func TestPackageSetInstaller_Install_PropagatesRepositoryRef(t *testing.T) {
+	t.Parallel()
+	runner := &mockCommandRunner{}
+	res := &resource.SystemPackageSet{
+		SystemPackageSetSpec: &resource.SystemPackageSetSpec{
+			InstallerRef:  "apt",
+			RepositoryRef: "docker",
+			Packages:      []string{"docker-ce"},
+		},
+	}
+	state, err := New(runner).PackageSetInstaller().Install(context.Background(), res, "docker")
+	require.NoError(t, err)
+	assert.Equal(t, "docker", state.RepositoryRef)
+}
+
+func TestPackageSetInstaller_Remove_NotYetImplemented(t *testing.T) {
+	t.Parallel()
+	runner := &mockCommandRunner{}
+	state := &resource.SystemPackageSetState{Packages: []string{"git"}}
+	err := New(runner).PackageSetInstaller().Remove(context.Background(), state, "cli-tools")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "remove not yet implemented")
 }

--- a/internal/installer/apt/apt_test.go
+++ b/internal/installer/apt/apt_test.go
@@ -154,6 +154,16 @@ func TestGetInstall(t *testing.T) {
 			wantErr:  "contains disallowed characters",
 		},
 		{
+			name:     "package with embedded space rejected",
+			packages: []string{"git vim"},
+			wantErr:  "contains disallowed characters",
+		},
+		{
+			name:     "package with newline rejected",
+			packages: []string{"git\n"},
+			wantErr:  "contains disallowed characters",
+		},
+		{
 			name:      "runner error wraps packages context",
 			packages:  []string{"nonexistent-pkg"},
 			runnerErr: errors.New("exit status 100"),

--- a/internal/installer/apt/apt_test.go
+++ b/internal/installer/apt/apt_test.go
@@ -144,6 +144,16 @@ func TestGetInstall(t *testing.T) {
 			wantErr:  "apt: install requires at least one package",
 		},
 		{
+			name:     "empty string in packages slice",
+			packages: []string{""},
+			wantErr:  "apt: empty package name in install list",
+		},
+		{
+			name:     "empty string among valid packages",
+			packages: []string{"git", "", "tree"},
+			wantErr:  "apt: empty package name in install list",
+		},
+		{
 			name:     "package with semicolon rejected",
 			packages: []string{"git;curl evil|sh"},
 			wantErr:  "contains disallowed characters",

--- a/internal/installer/apt/apt_test.go
+++ b/internal/installer/apt/apt_test.go
@@ -117,9 +117,9 @@ func TestVersionFunc_ParseError(t *testing.T) {
 	assert.Contains(t, err.Error(), "unexpected apt-get --version output")
 }
 
-// --- GetInstall tests ---
+// --- Install tests ---
 
-func TestGetInstall(t *testing.T) {
+func TestInstall(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name      string
@@ -189,7 +189,7 @@ func TestGetInstall(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			runner := &mockCommandRunner{captureErr: tt.runnerErr}
-			err := New(runner).GetInstall(context.Background(), tt.packages)
+			err := New(runner).Install(context.Background(), tt.packages)
 			if tt.wantErr == "" {
 				require.NoError(t, err)
 				require.Len(t, runner.captureCmds, 1)

--- a/internal/installer/apt/apt_test.go
+++ b/internal/installer/apt/apt_test.go
@@ -2,6 +2,7 @@ package apt
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -67,13 +68,15 @@ func TestParseAptVersion(t *testing.T) {
 // --- mock ---
 
 type mockCommandRunner struct {
+	captureCmds   []string
 	captureOutput string
 	captureErr    error
 }
 
 var _ CommandRunner = (*mockCommandRunner)(nil)
 
-func (m *mockCommandRunner) ExecuteCapture(_ context.Context, _ []string, _ command.Vars, _ map[string]string) (string, error) {
+func (m *mockCommandRunner) ExecuteCapture(_ context.Context, cmds []string, _ command.Vars, _ map[string]string) (string, error) {
+	m.captureCmds = cmds
 	return m.captureOutput, m.captureErr
 }
 
@@ -107,4 +110,54 @@ func TestVersionFunc_ParseError(t *testing.T) {
 	_, err := vf(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unexpected apt-get --version output")
+}
+
+// --- GetInstall tests ---
+
+func TestGetInstall(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		packages  []string
+		runnerErr error
+		wantErr   string
+		wantCmd   string
+	}{
+		{
+			name:     "single package",
+			packages: []string{"git"},
+			wantCmd:  "sudo -n apt-get install -y git",
+		},
+		{
+			name:     "multiple packages",
+			packages: []string{"git", "curl", "tree"},
+			wantCmd:  "sudo -n apt-get install -y git curl tree",
+		},
+		{
+			name:     "empty packages",
+			packages: []string{},
+			wantErr:  "at least one package is required",
+		},
+		{
+			name:      "runner error wraps packages context",
+			packages:  []string{"nonexistent-pkg"},
+			runnerErr: errors.New("exit status 100"),
+			wantErr:   "apt-get install [nonexistent-pkg]",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			runner := &mockCommandRunner{captureErr: tt.runnerErr}
+			err := GetInstall(context.Background(), runner, tt.packages)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				require.Len(t, runner.captureCmds, 1)
+				assert.Equal(t, tt.wantCmd, runner.captureCmds[0])
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
 }

--- a/internal/installer/apt/apt_test.go
+++ b/internal/installer/apt/apt_test.go
@@ -164,6 +164,11 @@ func TestGetInstall(t *testing.T) {
 			wantErr:  "contains disallowed characters",
 		},
 		{
+			name:     "package with glob star rejected",
+			packages: []string{"linux-image-*"},
+			wantErr:  "contains disallowed characters",
+		},
+		{
 			name:      "runner error wraps packages context",
 			packages:  []string{"nonexistent-pkg"},
 			runnerErr: errors.New("exit status 100"),

--- a/internal/installer/apt/apt_test.go
+++ b/internal/installer/apt/apt_test.go
@@ -126,23 +126,33 @@ func TestGetInstall(t *testing.T) {
 		{
 			name:     "single package",
 			packages: []string{"git"},
-			wantCmd:  "sudo -n apt-get install -y git",
+			wantCmd:  "sudo -n apt-get install -y -o DPkg::Lock::Timeout=60 -- git",
 		},
 		{
 			name:     "multiple packages",
 			packages: []string{"git", "curl", "tree"},
-			wantCmd:  "sudo -n apt-get install -y git curl tree",
+			wantCmd:  "sudo -n apt-get install -y -o DPkg::Lock::Timeout=60 -- git curl tree",
 		},
 		{
 			name:     "empty packages",
 			packages: []string{},
-			wantErr:  "at least one package is required",
+			wantErr:  "apt: install requires at least one package",
+		},
+		{
+			name:     "package with semicolon rejected",
+			packages: []string{"git;curl evil|sh"},
+			wantErr:  "contains disallowed characters",
+		},
+		{
+			name:     "package with backtick rejected",
+			packages: []string{"git", "tree`whoami`"},
+			wantErr:  "contains disallowed characters",
 		},
 		{
 			name:      "runner error wraps packages context",
 			packages:  []string{"nonexistent-pkg"},
 			runnerErr: errors.New("exit status 100"),
-			wantErr:   "apt-get install [nonexistent-pkg]",
+			wantErr:   `apt: install ["nonexistent-pkg"]`,
 		},
 	}
 	for _, tt := range tests {

--- a/tests/apt_install_integration_test.go
+++ b/tests/apt_install_integration_test.go
@@ -38,14 +38,15 @@ func TestPackageSetInstaller_RealSystem(t *testing.T) {
 	}
 
 	const pkg = "tree"
-	// If pkg was already installed before the test (e.g. on a developer
-	// machine where it's part of their environment), skip the post-test
-	// removal so we leave the system as we found it.
-	preinstalled := exec.Command("dpkg", "-s", pkg).Run() == nil
+	// If pkg is already installed (developer environment), skip the whole
+	// test rather than just the cleanup: apt-get install could still
+	// upgrade the package, and a cleanup-skip would leave the upgrade in
+	// place. CI ubuntu-latest ships without tree, so the install path
+	// runs normally there.
+	if err := exec.Command("dpkg", "-s", pkg).Run(); err == nil {
+		t.Skipf("%s is already installed; skipping to avoid mutating the host environment", pkg)
+	}
 	t.Cleanup(func() {
-		if preinstalled {
-			return
-		}
 		// AptGetRemove is tracked separately; use raw exec for test cleanup.
 		if err := exec.Command("sudo", "-n", "apt-get", "remove", "-y", pkg).Run(); err != nil {
 			t.Logf("cleanup: apt-get remove %s: %v", pkg, err)

--- a/tests/apt_install_integration_test.go
+++ b/tests/apt_install_integration_test.go
@@ -36,7 +36,14 @@ func TestGetInstall_RealSystem(t *testing.T) {
 	}
 
 	const pkg = "tree"
+	// If pkg was already installed before the test (e.g. on a developer
+	// machine where it's part of their environment), skip the post-test
+	// removal so we leave the system as we found it.
+	preinstalled := exec.Command("dpkg", "-s", pkg).Run() == nil
 	t.Cleanup(func() {
+		if preinstalled {
+			return
+		}
 		// AptGetRemove is tracked separately; use raw exec for test cleanup.
 		if err := exec.Command("sudo", "-n", "apt-get", "remove", "-y", pkg).Run(); err != nil {
 			t.Logf("cleanup: apt-get remove %s: %v", pkg, err)

--- a/tests/apt_install_integration_test.go
+++ b/tests/apt_install_integration_test.go
@@ -16,14 +16,17 @@ import (
 	"github.com/terassyi/tomei/internal/installer/command"
 )
 
-// TestAptGetInstall_RealSystem installs `tree`, verifies via dpkg, and removes
-// in t.Cleanup. Requires Linux + apt-get + passwordless sudo (CI: ubuntu-latest).
-func TestAptGetInstall_RealSystem(t *testing.T) {
+// TestGetInstall_RealSystem installs `tree`, verifies via dpkg, and removes
+// in t.Cleanup. Requires Linux + apt-get + dpkg + passwordless sudo
+// (CI: ubuntu-latest).
+func TestGetInstall_RealSystem(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("apt-get integration test requires Linux")
 	}
-	if _, err := exec.LookPath("apt-get"); err != nil {
-		t.Skip("apt-get not found in PATH")
+	for _, bin := range []string{"apt-get", "dpkg", "sudo"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not found in PATH", bin)
+		}
 	}
 	// Mirror the precedent at cmd/tomei/apply.go (sudoHandler.Acquire) so dev
 	// machines without passwordless sudo skip with a clear message instead of

--- a/tests/apt_install_integration_test.go
+++ b/tests/apt_install_integration_test.go
@@ -33,7 +33,7 @@ func TestAptGetInstall_RealSystem(t *testing.T) {
 	})
 
 	runner := command.NewExecutor("")
-	err := apt.GetInstall(context.Background(), runner, []string{pkg})
+	err := apt.New(runner).GetInstall(context.Background(), []string{pkg})
 	require.NoError(t, err)
 
 	out, err := exec.Command("dpkg", "-l", pkg).CombinedOutput()

--- a/tests/apt_install_integration_test.go
+++ b/tests/apt_install_integration_test.go
@@ -14,12 +14,14 @@ import (
 
 	"github.com/terassyi/tomei/internal/installer/apt"
 	"github.com/terassyi/tomei/internal/installer/command"
+	"github.com/terassyi/tomei/internal/resource"
 )
 
-// TestInstall_RealSystem installs `tree`, verifies via dpkg, and removes
-// in t.Cleanup. Requires Linux + apt-get + dpkg + passwordless sudo
+// TestPackageSetInstaller_RealSystem installs `tree` via the apt
+// PackageSetInstaller, verifies presence with dpkg, and removes in
+// t.Cleanup. Requires Linux + apt-get + dpkg + passwordless sudo
 // (CI: ubuntu-latest).
-func TestInstall_RealSystem(t *testing.T) {
+func TestPackageSetInstaller_RealSystem(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("apt-get integration test requires Linux")
 	}
@@ -51,8 +53,16 @@ func TestInstall_RealSystem(t *testing.T) {
 	})
 
 	runner := command.NewExecutor("")
-	err := apt.New(runner).Install(context.Background(), []string{pkg})
+	res := &resource.SystemPackageSet{
+		SystemPackageSetSpec: &resource.SystemPackageSetSpec{
+			InstallerRef: "apt",
+			Packages:     []string{pkg},
+		},
+	}
+	state, err := apt.New(runner).PackageSetInstaller().Install(context.Background(), res, "tree-only")
 	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, []string{pkg}, state.Packages)
 
 	out, err := exec.Command("dpkg", "-l", pkg).CombinedOutput()
 	require.NoError(t, err, "dpkg -l output: %s", out)

--- a/tests/apt_install_integration_test.go
+++ b/tests/apt_install_integration_test.go
@@ -16,10 +16,10 @@ import (
 	"github.com/terassyi/tomei/internal/installer/command"
 )
 
-// TestGetInstall_RealSystem installs `tree`, verifies via dpkg, and removes
+// TestInstall_RealSystem installs `tree`, verifies via dpkg, and removes
 // in t.Cleanup. Requires Linux + apt-get + dpkg + passwordless sudo
 // (CI: ubuntu-latest).
-func TestGetInstall_RealSystem(t *testing.T) {
+func TestInstall_RealSystem(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("apt-get integration test requires Linux")
 	}
@@ -51,7 +51,7 @@ func TestGetInstall_RealSystem(t *testing.T) {
 	})
 
 	runner := command.NewExecutor("")
-	err := apt.New(runner).GetInstall(context.Background(), []string{pkg})
+	err := apt.New(runner).Install(context.Background(), []string{pkg})
 	require.NoError(t, err)
 
 	out, err := exec.Command("dpkg", "-l", pkg).CombinedOutput()

--- a/tests/apt_install_integration_test.go
+++ b/tests/apt_install_integration_test.go
@@ -25,11 +25,19 @@ func TestAptGetInstall_RealSystem(t *testing.T) {
 	if _, err := exec.LookPath("apt-get"); err != nil {
 		t.Skip("apt-get not found in PATH")
 	}
+	// Mirror the precedent at cmd/tomei/apply.go (sudoHandler.Acquire) so dev
+	// machines without passwordless sudo skip with a clear message instead of
+	// failing later with a generic exit-status error.
+	if err := exec.Command("sudo", "-n", "true").Run(); err != nil {
+		t.Skip("passwordless sudo not available")
+	}
 
 	const pkg = "tree"
 	t.Cleanup(func() {
-		// #191 (AptGetRemove) is not yet implemented; use raw exec for cleanup.
-		_ = exec.Command("sudo", "-n", "apt-get", "remove", "-y", pkg).Run()
+		// AptGetRemove is tracked separately; use raw exec for test cleanup.
+		if err := exec.Command("sudo", "-n", "apt-get", "remove", "-y", pkg).Run(); err != nil {
+			t.Logf("cleanup: apt-get remove %s: %v", pkg, err)
+		}
 	})
 
 	runner := command.NewExecutor("")

--- a/tests/apt_install_integration_test.go
+++ b/tests/apt_install_integration_test.go
@@ -53,6 +53,14 @@ func TestPackageSetInstaller_RealSystem(t *testing.T) {
 		}
 	})
 
+	// apt-get install can fail on minimal images / stale package indexes
+	// ("Unable to locate package", 404). Refresh the index first; if that
+	// fails (no network, etc.), skip rather than treat as test failure.
+	updateOut, err := exec.Command("sudo", "-n", "env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "update").CombinedOutput()
+	if err != nil {
+		t.Skipf("apt-get update failed (cannot run integration test): %v\noutput: %s", err, updateOut)
+	}
+
 	runner := command.NewExecutor("")
 	res := &resource.SystemPackageSet{
 		SystemPackageSetSpec: &resource.SystemPackageSetSpec{

--- a/tests/apt_install_integration_test.go
+++ b/tests/apt_install_integration_test.go
@@ -1,0 +1,42 @@
+//go:build integration
+
+package tests
+
+import (
+	"context"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/terassyi/tomei/internal/installer/apt"
+	"github.com/terassyi/tomei/internal/installer/command"
+)
+
+// TestAptGetInstall_RealSystem installs `tree`, verifies via dpkg, and removes
+// in t.Cleanup. Requires Linux + apt-get + passwordless sudo (CI: ubuntu-latest).
+func TestAptGetInstall_RealSystem(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("apt-get integration test requires Linux")
+	}
+	if _, err := exec.LookPath("apt-get"); err != nil {
+		t.Skip("apt-get not found in PATH")
+	}
+
+	const pkg = "tree"
+	t.Cleanup(func() {
+		// #191 (AptGetRemove) is not yet implemented; use raw exec for cleanup.
+		_ = exec.Command("sudo", "-n", "apt-get", "remove", "-y", pkg).Run()
+	})
+
+	runner := command.NewExecutor("")
+	err := apt.GetInstall(context.Background(), runner, []string{pkg})
+	require.NoError(t, err)
+
+	out, err := exec.Command("dpkg", "-l", pkg).CombinedOutput()
+	require.NoError(t, err, "dpkg -l output: %s", out)
+	assert.True(t, strings.Contains(string(out), "ii  "+pkg), "tree should be installed (status ii); got: %s", out)
+}

--- a/tests/system_validator_test.go
+++ b/tests/system_validator_test.go
@@ -30,7 +30,7 @@ func TestValidator_RealSystem(t *testing.T) {
 
 	runner := command.NewExecutor("")
 	versionFuncs := map[system.PackageManager]system.VersionFunc{
-		system.PackageManagerAPT: apt.VersionFunc(runner),
+		system.PackageManagerAPT: apt.New(runner).VersionFunc(),
 	}
 
 	v, err := system.NewValidator(distro, versionFuncs)


### PR DESCRIPTION
Adds the apt.GetInstall pure helper that runs
"sudo -n apt-get install -y <packages...>". This is the first in the
APT helper chain (#190 install → #191 remove → #192 update →
#193 dpkgCheck → #194 dpkgQueryVersion); the SystemPackageSet
concrete installer (#198) will be the first consumer.

Issue body specified `aptGetInstall` (lowercase, unexported) but:
- Existing precedent in the same file is exported (`VersionFunc`).
- Integration tests live under `tests/` (package `tests`); calling
  a private helper from there would force either an exported wrapper,
  a test in `internal/installer/apt/`, or a Makefile target change.
- golangci-lint's revive rule warns that `apt.AptGetInstall` stutters.
  `apt.GetInstall` keeps the apt-get/dpkg distinction (vs forthcoming
  apt.DpkgCheck) and reads cleanly at call sites.

So the function is exported as `apt.GetInstall`. Empty-packages input
returns an error (defense-in-depth; schema-layer ^\\S+$ validation
should reject this earlier, but the helper guards as well).

Tests:
- Unit (apt_test.go): 4 table-driven cases — single pkg, multiple pkgs,
  empty pkgs, runner-error wrapping. Extended `mockCommandRunner` to
  capture the `cmds` argument so the constructed shell string can be
  asserted.
- Integration (tests/apt_install_integration_test.go,
  //go:build integration): installs `tree` against the real apt-get,
  verifies via `dpkg -l` showing status `ii  tree`, then removes via
  raw exec.Command in t.Cleanup (#191's apt.GetRemove not yet
  implemented). Skips on non-Linux and when apt-get is absent from
  PATH. Requires passwordless sudo (CI ubuntu-latest has it by
  default).

Refs #163.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
