### PR TITLE
feat(apt): implement PackageSetInstaller.Remove (#191)

### DIFF
--- a/internal/installer/apt/apt.go
+++ b/internal/installer/apt/apt.go
@@ -118,6 +118,12 @@ func (p *PackageSetInstaller) Install(ctx context.Context, res *resource.SystemP
 // consulted because Remove may run after the spec was deleted from the
 // manifest.
 //
+// A nil state is treated as an error (defensive against corrupted state
+// files), but an empty Packages list is treated as a no-op so the
+// executor can still proceed to delete the state file. This diverges
+// from Install (which rejects empty input as a manifest mistake) — for
+// Remove, "nothing left to do" is the correct idempotent outcome.
+//
 // The shell command executed is:
 //
 //	sudo -n env DEBIAN_FRONTEND=noninteractive apt-get remove -y -o DPkg::Lock::Timeout=60 -- <packages>
@@ -128,7 +134,13 @@ func (p *PackageSetInstaller) Install(ctx context.Context, res *resource.SystemP
 // `apt-get remove` keeps the operation reversible (config files retained)
 // and avoids cascading removal of dependencies that other
 // SystemPackageSet resources may need.
-func (p *PackageSetInstaller) Remove(ctx context.Context, state *resource.SystemPackageSetState, _ string) error {
+func (p *PackageSetInstaller) Remove(ctx context.Context, state *resource.SystemPackageSetState, name string) error {
+	if state == nil {
+		return fmt.Errorf("apt: package set %q: nil state", name)
+	}
+	if len(state.Packages) == 0 {
+		return nil
+	}
 	return p.runRemove(ctx, state.Packages)
 }
 

--- a/internal/installer/apt/apt.go
+++ b/internal/installer/apt/apt.go
@@ -24,8 +24,8 @@ type CommandRunner interface {
 // errEmptyPackagesInstall is returned when the package list is empty.
 var errEmptyPackagesInstall = errors.New("apt: install requires at least one package")
 
-// errEmptyPackagesInstallRemove is returned when the package list is empty.
-var errEmptyPackagesInstallRemove = errors.New("apt: remove requires at least one package")
+// errEmptyPackagesRemove is returned when the package list is empty.
+var errEmptyPackagesRemove = errors.New("apt: remove requires at least one package")
 
 // disallowedInPackageName covers whitespace, shell metacharacters, and
 // shell-expansion characters (globs, tilde, comment) that would either
@@ -174,12 +174,12 @@ func (p *PackageSetInstaller) runInstall(ctx context.Context, packages []string)
 
 // runRemove executes "sudo -n env DEBIAN_FRONTEND=noninteractive apt-get
 // remove -y -o DPkg::Lock::Timeout=60 -- <packages>". Returns
-// errEmptyPackagesInstallRemove if packages is empty. Each name is rejected if
+// errEmptyPackagesRemove if packages is empty. Each name is rejected if
 // it is empty or contains whitespace / shell metacharacters / shell-
 // expansion characters.
 func (p *PackageSetInstaller) runRemove(ctx context.Context, packages []string) error {
 	if len(packages) == 0 {
-		return errEmptyPackagesInstallRemove
+		return errEmptyPackagesRemove
 	}
 	for _, pkg := range packages {
 		if pkg == "" {

--- a/internal/installer/apt/apt.go
+++ b/internal/installer/apt/apt.go
@@ -24,6 +24,9 @@ type CommandRunner interface {
 // errEmptyPackages is returned when the package list is empty.
 var errEmptyPackages = errors.New("apt: install requires at least one package")
 
+// errEmptyPackagesRemove is returned when the package list is empty.
+var errEmptyPackagesRemove = errors.New("apt: remove requires at least one package")
+
 // disallowedInPackageName covers whitespace, shell metacharacters, and
 // shell-expansion characters (globs, tilde, comment) that would either
 // split a package name across argv slots, allow injection through the
@@ -110,9 +113,23 @@ func (p *PackageSetInstaller) Install(ctx context.Context, res *resource.SystemP
 	}, nil
 }
 
-// Remove is a stub until the apt-get remove helper lands.
-func (p *PackageSetInstaller) Remove(_ context.Context, _ *resource.SystemPackageSetState, name string) error {
-	return fmt.Errorf("apt: package set %q: remove not yet implemented", name)
+// Remove runs the apt-get remove for the state's packages. state.Packages
+// (populated by Install) is the source of truth; the resource spec is not
+// consulted because Remove may run after the spec was deleted from the
+// manifest.
+//
+// The shell command executed is:
+//
+//	sudo -n env DEBIAN_FRONTEND=noninteractive apt-get remove -y -o DPkg::Lock::Timeout=60 -- <packages>
+//
+// stdout/stderr are drained line-by-line rather than buffered.
+//
+// `--purge` and `--auto-remove` are intentionally omitted: plain
+// `apt-get remove` keeps the operation reversible (config files retained)
+// and avoids cascading removal of dependencies that other
+// SystemPackageSet resources may need.
+func (p *PackageSetInstaller) Remove(ctx context.Context, state *resource.SystemPackageSetState, _ string) error {
+	return p.runRemove(ctx, state.Packages)
 }
 
 // runInstall executes "sudo -n env DEBIAN_FRONTEND=noninteractive apt-get
@@ -139,6 +156,34 @@ func (p *PackageSetInstaller) runInstall(ctx context.Context, packages []string)
 	// in memory; apt-get install output can be large.
 	if err := p.client.runner.ExecuteWithOutput(ctx, []string{cmd}, command.Vars{}, nil, nil); err != nil {
 		return fmt.Errorf("apt: install %q: %w", packages, err)
+	}
+	return nil
+}
+
+// runRemove executes "sudo -n env DEBIAN_FRONTEND=noninteractive apt-get
+// remove -y -o DPkg::Lock::Timeout=60 -- <packages>". Returns
+// errEmptyPackagesRemove if packages is empty. Each name is rejected if
+// it is empty or contains whitespace / shell metacharacters / shell-
+// expansion characters.
+func (p *PackageSetInstaller) runRemove(ctx context.Context, packages []string) error {
+	if len(packages) == 0 {
+		return errEmptyPackagesRemove
+	}
+	for _, pkg := range packages {
+		if pkg == "" {
+			return errors.New("apt: empty package name in remove list")
+		}
+		if strings.ContainsAny(pkg, disallowedInPackageName) {
+			return fmt.Errorf("apt: package %q contains disallowed characters", pkg)
+		}
+	}
+	cmd := "sudo -n " + debianFrontendNoninteractive +
+		" apt-get remove -y -o DPkg::Lock::Timeout=60 -- " +
+		strings.Join(packages, " ")
+	// nil callback drains stdout/stderr to io.Discard rather than buffering
+	// in memory; apt-get remove output (especially dependency hints) can be large.
+	if err := p.client.runner.ExecuteWithOutput(ctx, []string{cmd}, command.Vars{}, nil, nil); err != nil {
+		return fmt.Errorf("apt: remove %q: %w", packages, err)
 	}
 	return nil
 }

--- a/internal/installer/apt/apt.go
+++ b/internal/installer/apt/apt.go
@@ -95,7 +95,7 @@ var _ executor.Installer[*resource.SystemPackageSet, *resource.SystemPackageSetS
 //
 //	sudo -n env DEBIAN_FRONTEND=noninteractive apt-get install -y -o DPkg::Lock::Timeout=60 -- <packages>
 //
-// stdout/stderr are drained line-by-line rather than buffered.
+// stdout/stderr are drained (discarded, not buffered in memory).
 //
 // Callers are responsible for ensuring a recent "apt-get update" has run
 // when stale package indexes would cause 404s.
@@ -122,7 +122,7 @@ func (p *PackageSetInstaller) Install(ctx context.Context, res *resource.SystemP
 //
 //	sudo -n env DEBIAN_FRONTEND=noninteractive apt-get remove -y -o DPkg::Lock::Timeout=60 -- <packages>
 //
-// stdout/stderr are drained line-by-line rather than buffered.
+// stdout/stderr are drained (discarded, not buffered in memory).
 //
 // `--purge` and `--auto-remove` are intentionally omitted: plain
 // `apt-get remove` keeps the operation reversible (config files retained)

--- a/internal/installer/apt/apt.go
+++ b/internal/installer/apt/apt.go
@@ -21,11 +21,11 @@ type CommandRunner interface {
 	ExecuteWithOutput(ctx context.Context, cmds []string, vars command.Vars, env map[string]string, callback command.OutputCallback) error
 }
 
-// errEmptyPackages is returned when the package list is empty.
-var errEmptyPackages = errors.New("apt: install requires at least one package")
+// errEmptyPackagesInstall is returned when the package list is empty.
+var errEmptyPackagesInstall = errors.New("apt: install requires at least one package")
 
-// errEmptyPackagesRemove is returned when the package list is empty.
-var errEmptyPackagesRemove = errors.New("apt: remove requires at least one package")
+// errEmptyPackagesInstallRemove is returned when the package list is empty.
+var errEmptyPackagesInstallRemove = errors.New("apt: remove requires at least one package")
 
 // disallowedInPackageName covers whitespace, shell metacharacters, and
 // shell-expansion characters (globs, tilde, comment) that would either
@@ -146,12 +146,12 @@ func (p *PackageSetInstaller) Remove(ctx context.Context, state *resource.System
 
 // runInstall executes "sudo -n env DEBIAN_FRONTEND=noninteractive apt-get
 // install -y -o DPkg::Lock::Timeout=60 -- <packages>". Returns
-// errEmptyPackages if packages is empty. Each name is rejected if it is
+// errEmptyPackagesInstall if packages is empty. Each name is rejected if it is
 // empty or contains whitespace / shell metacharacters / shell-expansion
 // characters.
 func (p *PackageSetInstaller) runInstall(ctx context.Context, packages []string) error {
 	if len(packages) == 0 {
-		return errEmptyPackages
+		return errEmptyPackagesInstall
 	}
 	for _, pkg := range packages {
 		if pkg == "" {
@@ -174,12 +174,12 @@ func (p *PackageSetInstaller) runInstall(ctx context.Context, packages []string)
 
 // runRemove executes "sudo -n env DEBIAN_FRONTEND=noninteractive apt-get
 // remove -y -o DPkg::Lock::Timeout=60 -- <packages>". Returns
-// errEmptyPackagesRemove if packages is empty. Each name is rejected if
+// errEmptyPackagesInstallRemove if packages is empty. Each name is rejected if
 // it is empty or contains whitespace / shell metacharacters / shell-
 // expansion characters.
 func (p *PackageSetInstaller) runRemove(ctx context.Context, packages []string) error {
 	if len(packages) == 0 {
-		return errEmptyPackagesRemove
+		return errEmptyPackagesInstallRemove
 	}
 	for _, pkg := range packages {
 		if pkg == "" {

--- a/internal/installer/apt/apt_test.go
+++ b/internal/installer/apt/apt_test.go
@@ -230,11 +230,89 @@ func TestPackageSetInstaller_Install_PropagatesRepositoryRef(t *testing.T) {
 	assert.Equal(t, "docker", state.RepositoryRef)
 }
 
-func TestPackageSetInstaller_Remove_NotYetImplemented(t *testing.T) {
+func TestPackageSetInstaller_Remove(t *testing.T) {
 	t.Parallel()
-	runner := &mockCommandRunner{}
-	state := &resource.SystemPackageSetState{Packages: []string{"git"}}
-	err := New(runner).PackageSetInstaller().Remove(context.Background(), state, "cli-tools")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "remove not yet implemented")
+	tests := []struct {
+		name      string
+		packages  []string
+		runnerErr error
+		wantErr   string
+		wantCmd   string
+	}{
+		{
+			name:     "single package",
+			packages: []string{"git"},
+			wantCmd:  "sudo -n env DEBIAN_FRONTEND=noninteractive apt-get remove -y -o DPkg::Lock::Timeout=60 -- git",
+		},
+		{
+			name:     "multiple packages",
+			packages: []string{"git", "curl", "tree"},
+			wantCmd:  "sudo -n env DEBIAN_FRONTEND=noninteractive apt-get remove -y -o DPkg::Lock::Timeout=60 -- git curl tree",
+		},
+		{
+			name:     "empty packages",
+			packages: []string{},
+			wantErr:  "apt: remove requires at least one package",
+		},
+		{
+			name:     "empty string in packages slice",
+			packages: []string{""},
+			wantErr:  "apt: empty package name in remove list",
+		},
+		{
+			name:     "empty string among valid packages",
+			packages: []string{"git", "", "tree"},
+			wantErr:  "apt: empty package name in remove list",
+		},
+		{
+			name:     "package with semicolon rejected",
+			packages: []string{"git;curl evil|sh"},
+			wantErr:  "contains disallowed characters",
+		},
+		{
+			name:     "package with backtick rejected",
+			packages: []string{"git", "tree`whoami`"},
+			wantErr:  "contains disallowed characters",
+		},
+		{
+			name:     "package with embedded space rejected",
+			packages: []string{"git vim"},
+			wantErr:  "contains disallowed characters",
+		},
+		{
+			name:     "package with newline rejected",
+			packages: []string{"git\n"},
+			wantErr:  "contains disallowed characters",
+		},
+		{
+			name:     "package with glob star rejected",
+			packages: []string{"linux-image-*"},
+			wantErr:  "contains disallowed characters",
+		},
+		{
+			name:      "runner error wraps packages context",
+			packages:  []string{"nonexistent-pkg"},
+			runnerErr: errors.New("exit status 100"),
+			wantErr:   `apt: remove ["nonexistent-pkg"]`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			runner := &mockCommandRunner{captureErr: tt.runnerErr}
+			state := &resource.SystemPackageSetState{
+				InstallerRef: "apt",
+				Packages:     tt.packages,
+			}
+			err := New(runner).PackageSetInstaller().Remove(context.Background(), state, "cli-tools")
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				require.Len(t, runner.captureCmds, 1)
+				assert.Equal(t, tt.wantCmd, runner.captureCmds[0])
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
 }

--- a/internal/installer/apt/apt_test.go
+++ b/internal/installer/apt/apt_test.go
@@ -250,9 +250,10 @@ func TestPackageSetInstaller_Remove(t *testing.T) {
 			wantCmd:  "sudo -n env DEBIAN_FRONTEND=noninteractive apt-get remove -y -o DPkg::Lock::Timeout=60 -- git curl tree",
 		},
 		{
-			name:     "empty packages",
+			name:     "empty packages is a no-op",
 			packages: []string{},
-			wantErr:  "apt: remove requires at least one package",
+			// No error, no shell command issued — Remove short-circuits
+			// so the executor can still delete the state file.
 		},
 		{
 			name:     "empty string in packages slice",
@@ -305,14 +306,28 @@ func TestPackageSetInstaller_Remove(t *testing.T) {
 				Packages:     tt.packages,
 			}
 			err := New(runner).PackageSetInstaller().Remove(context.Background(), state, "cli-tools")
-			if tt.wantErr == "" {
+			switch {
+			case tt.wantErr != "":
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			case tt.wantCmd != "":
 				require.NoError(t, err)
 				require.Len(t, runner.captureCmds, 1)
 				assert.Equal(t, tt.wantCmd, runner.captureCmds[0])
-			} else {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
+			default:
+				// No-op: success without issuing any shell command.
+				require.NoError(t, err)
+				assert.Empty(t, runner.captureCmds)
 			}
 		})
 	}
+}
+
+func TestPackageSetInstaller_Remove_NilState(t *testing.T) {
+	t.Parallel()
+	runner := &mockCommandRunner{}
+	err := New(runner).PackageSetInstaller().Remove(context.Background(), nil, "cli-tools")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil state")
+	assert.Empty(t, runner.captureCmds)
 }

--- a/tests/apt_install_integration_test.go
+++ b/tests/apt_install_integration_test.go
@@ -4,9 +4,9 @@ package tests
 
 import (
 	"context"
+	"errors"
 	"os/exec"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,7 +50,15 @@ func TestPackageSetInstaller_RealSystem(t *testing.T) {
 	t.Cleanup(func() {
 		// Belt-and-suspenders cleanup using raw exec to avoid depending on
 		// installer.Remove (which is the primary subject under test below).
-		if err := exec.Command("sudo", "-n", "apt-get", "remove", "-y", pkg).Run(); err != nil {
+		// Mirror the production invocation's hardening (DEBIAN_FRONTEND,
+		// lock-timeout, `--` operand separator) so the safety net stays
+		// robust if pkg ever changes to something with shell-meaningful
+		// chars or if the cleanup races with apt-daily.
+		cleanup := exec.Command(
+			"sudo", "-n", "env", "DEBIAN_FRONTEND=noninteractive",
+			"apt-get", "remove", "-y", "-o", "DPkg::Lock::Timeout=60", "--", pkg,
+		)
+		if err := cleanup.Run(); err != nil {
 			t.Logf("cleanup: apt-get remove %s: %v", pkg, err)
 		}
 	})
@@ -78,13 +86,18 @@ func TestPackageSetInstaller_RealSystem(t *testing.T) {
 
 	out, err := exec.Command("dpkg", "-l", pkg).CombinedOutput()
 	require.NoError(t, err, "dpkg -l output: %s", out)
-	assert.True(t, strings.Contains(string(out), "ii  "+pkg), "%s should be installed (status ii); got: %s", pkg, out)
+	assert.Contains(t, string(out), "ii  "+pkg, "%s should be installed (status ii); got: %s", pkg, out)
 
 	require.NoError(t, installer.Remove(context.Background(), state, pkg+"-only"))
 
-	// After remove, dpkg -l should no longer show "ii  <pkg>". dpkg -l may
-	// exit 0 (entry retained as "rc") or non-zero (entry purged), so we
-	// don't check the exit code — only that the install marker is gone.
-	out, _ = exec.Command("dpkg", "-l", pkg).CombinedOutput()
-	assert.False(t, strings.Contains(string(out), "ii  "+pkg), "%s should not be installed (status ii) after Remove; got: %s", pkg, out)
+	// After remove, dpkg -l should no longer show "ii  <pkg>". dpkg -l
+	// may exit 0 (entry retained as "rc") or 1 (entry purged); we accept
+	// either, but a non-ExitError (e.g. dpkg binary missing, permission
+	// denied) is a real test failure that should not be swallowed.
+	out, dpkgErr := exec.Command("dpkg", "-l", pkg).CombinedOutput()
+	var exitErr *exec.ExitError
+	if dpkgErr != nil && !errors.As(dpkgErr, &exitErr) {
+		require.NoError(t, dpkgErr, "dpkg -l invocation failed: %s", out)
+	}
+	assert.NotContains(t, string(out), "ii  "+pkg, "%s should not be installed (status ii) after Remove; got: %s", pkg, out)
 }

--- a/tests/apt_install_integration_test.go
+++ b/tests/apt_install_integration_test.go
@@ -90,12 +90,13 @@ func TestPackageSetInstaller_RealSystem(t *testing.T) {
 
 	require.NoError(t, installer.Remove(context.Background(), state, pkg+"-only"))
 
-	// After remove, dpkg -l should no longer show "ii  <pkg>". dpkg-query
-	// exits 0 on success, 1 when no matching package exists (purged
-	// path), and 2+ on real errors. Exit 0 doesn't surface here as an
-	// error; only exit 1 is an acceptable non-zero status, anything
-	// else (or a non-ExitError such as dpkg binary missing / permission
-	// denied) is a genuine test failure that must not be swallowed.
+	// After remove, dpkg -l should no longer show "ii  <pkg>". `dpkg -l`
+	// (backed by dpkg-query) exits 0 on success, 1 when no matching
+	// package exists (purged path), and 2+ on real errors. Exit 0
+	// doesn't surface here as an error; only exit 1 is an acceptable
+	// non-zero status, anything else (or a non-ExitError such as the
+	// dpkg binary missing / permission denied) is a genuine test
+	// failure that must not be swallowed.
 	out, dpkgErr := exec.Command("dpkg", "-l", pkg).CombinedOutput()
 	if dpkgErr != nil {
 		var exitErr *exec.ExitError

--- a/tests/apt_install_integration_test.go
+++ b/tests/apt_install_integration_test.go
@@ -17,10 +17,11 @@ import (
 	"github.com/terassyi/tomei/internal/resource"
 )
 
-// TestPackageSetInstaller_RealSystem installs `tree` via the apt
-// PackageSetInstaller, verifies presence with dpkg, and removes in
-// t.Cleanup. Requires Linux + apt-get + dpkg + passwordless sudo
-// (CI: ubuntu-latest).
+// TestPackageSetInstaller_RealSystem installs `hello` via the apt
+// PackageSetInstaller, verifies presence with dpkg, runs Remove, and
+// re-verifies absence. t.Cleanup runs a raw apt-get remove as a
+// belt-and-suspenders safety net. Requires Linux + apt-get + dpkg +
+// passwordless sudo (CI: ubuntu-latest).
 func TestPackageSetInstaller_RealSystem(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("apt-get integration test requires Linux")
@@ -37,17 +38,18 @@ func TestPackageSetInstaller_RealSystem(t *testing.T) {
 		t.Skip("passwordless sudo not available")
 	}
 
-	const pkg = "tree"
-	// If pkg is already installed (developer environment), skip the whole
-	// test rather than just the cleanup: apt-get install could still
-	// upgrade the package, and a cleanup-skip would leave the upgrade in
-	// place. CI ubuntu-latest ships without tree, so the install path
-	// runs normally there.
+	// `hello` (GNU hello) is the canonical apt smoke-test package: small,
+	// no runtime dependencies, and not preinstalled on the GitHub
+	// `ubuntu-latest` runner image (whereas `tree`, our previous choice,
+	// is). On dev machines that already have it, we skip rather than risk
+	// mutating the host.
+	const pkg = "hello"
 	if err := exec.Command("dpkg", "-s", pkg).Run(); err == nil {
 		t.Skipf("%s is already installed; skipping to avoid mutating the host environment", pkg)
 	}
 	t.Cleanup(func() {
-		// AptGetRemove is tracked separately; use raw exec for test cleanup.
+		// Belt-and-suspenders cleanup using raw exec to avoid depending on
+		// installer.Remove (which is the primary subject under test below).
 		if err := exec.Command("sudo", "-n", "apt-get", "remove", "-y", pkg).Run(); err != nil {
 			t.Logf("cleanup: apt-get remove %s: %v", pkg, err)
 		}
@@ -68,12 +70,21 @@ func TestPackageSetInstaller_RealSystem(t *testing.T) {
 			Packages:     []string{pkg},
 		},
 	}
-	state, err := apt.New(runner).PackageSetInstaller().Install(context.Background(), res, "tree-only")
+	installer := apt.New(runner).PackageSetInstaller()
+	state, err := installer.Install(context.Background(), res, pkg+"-only")
 	require.NoError(t, err)
 	require.NotNil(t, state)
 	assert.Equal(t, []string{pkg}, state.Packages)
 
 	out, err := exec.Command("dpkg", "-l", pkg).CombinedOutput()
 	require.NoError(t, err, "dpkg -l output: %s", out)
-	assert.True(t, strings.Contains(string(out), "ii  "+pkg), "tree should be installed (status ii); got: %s", out)
+	assert.True(t, strings.Contains(string(out), "ii  "+pkg), "%s should be installed (status ii); got: %s", pkg, out)
+
+	require.NoError(t, installer.Remove(context.Background(), state, pkg+"-only"))
+
+	// After remove, dpkg -l should no longer show "ii  <pkg>". dpkg -l may
+	// exit 0 (entry retained as "rc") or non-zero (entry purged), so we
+	// don't check the exit code — only that the install marker is gone.
+	out, _ = exec.Command("dpkg", "-l", pkg).CombinedOutput()
+	assert.False(t, strings.Contains(string(out), "ii  "+pkg), "%s should not be installed (status ii) after Remove; got: %s", pkg, out)
 }

--- a/tests/apt_install_integration_test.go
+++ b/tests/apt_install_integration_test.go
@@ -90,14 +90,19 @@ func TestPackageSetInstaller_RealSystem(t *testing.T) {
 
 	require.NoError(t, installer.Remove(context.Background(), state, pkg+"-only"))
 
-	// After remove, dpkg -l should no longer show "ii  <pkg>". dpkg -l
-	// may exit 0 (entry retained as "rc") or 1 (entry purged); we accept
-	// either, but a non-ExitError (e.g. dpkg binary missing, permission
-	// denied) is a real test failure that should not be swallowed.
+	// After remove, dpkg -l should no longer show "ii  <pkg>". dpkg-query
+	// exits 0 on success, 1 when no matching package exists (purged
+	// path), and 2+ on real errors. Exit 0 doesn't surface here as an
+	// error; only exit 1 is an acceptable non-zero status, anything
+	// else (or a non-ExitError such as dpkg binary missing / permission
+	// denied) is a genuine test failure that must not be swallowed.
 	out, dpkgErr := exec.Command("dpkg", "-l", pkg).CombinedOutput()
-	var exitErr *exec.ExitError
-	if dpkgErr != nil && !errors.As(dpkgErr, &exitErr) {
-		require.NoError(t, dpkgErr, "dpkg -l invocation failed: %s", out)
+	if dpkgErr != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(dpkgErr, &exitErr) {
+			require.NoError(t, dpkgErr, "dpkg -l invocation failed: %s", out)
+		}
+		require.Equal(t, 1, exitErr.ExitCode(), "dpkg -l returned unexpected exit %d: %s", exitErr.ExitCode(), out)
 	}
 	assert.NotContains(t, string(out), "ii  "+pkg, "%s should not be installed (status ii) after Remove; got: %s", pkg, out)
 }


### PR DESCRIPTION
Fill the existing Remove stub. Mirrors Install symmetrically: same
disallowed-char gate, same `--` operand separator, same lock-timeout,
and the same DEBIAN_FRONTEND propagation via `sudo env` so sudoers
env_reset stays out of the way. state.Packages is the source of
truth — not the spec — so Remove keeps working after the manifest
has dropped the resource.

The shell command executed is:

    sudo -n env DEBIAN_FRONTEND=noninteractive apt-get remove -y \
        -o DPkg::Lock::Timeout=60 -- <packages>

Intentionally omits `--purge` (keeps removal reversible by retaining
config files) and `--auto-remove` (avoids cascading removal of deps
other SystemPackageSet resources may need).

Issue #191 sketches a free function `aptGetRemove`; we instead fill
the existing PackageSetInstaller.Remove stub, matching the Install
decision in #206. The consuming interface
(executor.Installer[*SystemPackageSet, *SystemPackageSetState]) is
already wired through SystemEngine, so an extra free function would
just bridge to the same method.

Drive-by: switch the apt integration test pkg from `tree` to `hello`.
`tree` is preinstalled on the GitHub `ubuntu-latest` runner image, so
the `dpkg -s` skip-guard at the top of the test had been firing on
every CI run — the integration test has been silently skipping since
PR #206 landed (verified against the CI log for run 25557404231).
`hello` is the canonical apt smoke-test package, small, dep-free, and
not preinstalled on ubuntu-24.04 runner images (verified against the
runner-image manifest). Also generalises the name argument from the
literal "tree-only" to pkg+"-only" so future renames stay localised.

Refs: #191
Follow-ups: #192 (Update), #193 (dpkgCheck for InstalledVersions),
#199 (replace skipPackageInstaller in cmd/tomei/system_engine.go)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
