### PR TITLE
feat(apt): add Client.Update helper (#192)

### DIFF
--- a/internal/installer/apt/apt.go
+++ b/internal/installer/apt/apt.go
@@ -88,7 +88,9 @@ func (c *Client) PackageSetInstaller() *PackageSetInstaller {
 //	sudo -n env DEBIAN_FRONTEND=noninteractive apt-get update
 //
 // stdout/stderr are drained (discarded, not buffered in memory). On
-// failure the wrapped error is the executor's exit-status error;
+// failure the returned error wraps the runner's error (typically
+// `command failed: <expanded>: <cause>` from command.Executor, where
+// <cause> may be an exit-status, start, expand, or context error);
 // callers needing diagnostic output should re-run "apt-get update"
 // manually.
 //

--- a/internal/installer/apt/apt.go
+++ b/internal/installer/apt/apt.go
@@ -76,6 +76,50 @@ func (c *Client) PackageSetInstaller() *PackageSetInstaller {
 	return &PackageSetInstaller{client: c}
 }
 
+// Update runs "apt-get update" to refresh the local APT package index.
+// It does NOT upgrade installed packages — that would be "apt-get
+// upgrade", which tomei does not perform automatically. Callers (e.g.
+// the future repository installer at #195, integration tests guarding
+// against stale indexes) invoke Update before Install when freshness
+// matters.
+//
+// The shell command executed is:
+//
+//	sudo -n env DEBIAN_FRONTEND=noninteractive apt-get update
+//
+// stdout/stderr are drained (discarded, not buffered in memory). On
+// failure the wrapped error is the executor's exit-status error;
+// callers needing diagnostic output should re-run "apt-get update"
+// manually.
+//
+// Note: apt-get update treats partial mirror failures (404 / DNS) as
+// success (exit 0, only a stderr `W: Failed to fetch` warning).
+// Update inherits that behavior — a subsequent Install failure with
+// "Unable to locate package" may indicate a stale or unreachable
+// source even when Update returned nil.
+//
+// The flags Install/Remove use are intentionally omitted here:
+//   - `-y`: apt-get update issues no y/N prompts.
+//   - `--`: there are no operands, so an option/operand separator is
+//     unnecessary, and consequently no package-list validation is
+//     needed (Install/Remove guard against shell-meaningful chars in
+//     package names; Update has no such surface).
+//   - lock-timeout flags: apt-get update primarily takes the apt
+//     cache/list locks (covered by `Acquire::Lock::Timeout`) rather
+//     than the dpkg-frontend lock that `DPkg::Lock::Timeout` covers;
+//     the uniform timeout pass across all helpers is being tracked
+//     in a separate follow-up.
+func (c *Client) Update(ctx context.Context) error {
+	cmd := "sudo -n " + debianFrontendNoninteractive + " apt-get update"
+	// nil callback drains stdout/stderr to io.Discard rather than
+	// buffering in memory; consistent with Install/Remove, we never
+	// surface apt-get's human-oriented output to callers.
+	if err := c.runner.ExecuteWithOutput(ctx, []string{cmd}, command.Vars{}, nil, nil); err != nil {
+		return fmt.Errorf("apt: update: %w", err)
+	}
+	return nil
+}
+
 // PackageSetInstaller installs and removes SystemPackageSet resources via
 // apt-get. It satisfies executor.Installer[*resource.SystemPackageSet,
 // *resource.SystemPackageSetState].

--- a/internal/installer/apt/apt_test.go
+++ b/internal/installer/apt/apt_test.go
@@ -118,6 +118,31 @@ func TestVersionFunc_ParseError(t *testing.T) {
 	assert.Contains(t, err.Error(), "unexpected apt-get --version output")
 }
 
+// --- Update tests ---
+
+func TestUpdate_Success(t *testing.T) {
+	t.Parallel()
+	runner := &mockCommandRunner{}
+	err := New(runner).Update(context.Background())
+	require.NoError(t, err)
+	require.Len(t, runner.captureCmds, 1)
+	assert.Equal(t,
+		"sudo -n env DEBIAN_FRONTEND=noninteractive apt-get update",
+		runner.captureCmds[0],
+	)
+}
+
+func TestUpdate_CommandError(t *testing.T) {
+	t.Parallel()
+	runner := &mockCommandRunner{captureErr: errors.New("exit status 100")}
+	err := New(runner).Update(context.Background())
+	require.Error(t, err)
+	// Pin the wrap structure (prefix + delimiter + wrapped cause) so a
+	// future rename of the wrap format is caught here, not just the
+	// substring "apt: update".
+	assert.EqualError(t, err, "apt: update: exit status 100")
+}
+
 // --- PackageSetInstaller tests ---
 
 func TestPackageSetInstaller_Install(t *testing.T) {

--- a/tests/apt_install_integration_test.go
+++ b/tests/apt_install_integration_test.go
@@ -54,6 +54,9 @@ func TestPackageSetInstaller_RealSystem(t *testing.T) {
 		// lock-timeout, `--` operand separator) so the safety net stays
 		// robust if pkg ever changes to something with shell-meaningful
 		// chars or if the cleanup races with apt-daily.
+		// Compare: the apt-get update call below uses Client.Update because
+		// that is the production path; cleanup intentionally does NOT use
+		// Client.Remove because Remove is itself one of the SUTs.
 		cleanup := exec.Command(
 			"sudo", "-n", "env", "DEBIAN_FRONTEND=noninteractive",
 			"apt-get", "remove", "-y", "-o", "DPkg::Lock::Timeout=60", "--", pkg,
@@ -63,22 +66,27 @@ func TestPackageSetInstaller_RealSystem(t *testing.T) {
 		}
 	})
 
-	// apt-get install can fail on minimal images / stale package indexes
-	// ("Unable to locate package", 404). Refresh the index first; if that
-	// fails (no network, etc.), skip rather than treat as test failure.
-	updateOut, err := exec.Command("sudo", "-n", "env", "DEBIAN_FRONTEND=noninteractive", "apt-get", "update").CombinedOutput()
-	if err != nil {
-		t.Skipf("apt-get update failed (cannot run integration test): %v\noutput: %s", err, updateOut)
-	}
+	client := apt.New(command.NewExecutor(""))
 
-	runner := command.NewExecutor("")
+	// apt-get install can fail on minimal images / stale package indexes
+	// ("Unable to locate package", 404). Refresh the index first via the
+	// Update helper; if that fails (no network, etc.), skip rather than
+	// treat as a test failure. Diagnostic output is no longer surfaced
+	// because Client.Update drains stdout/stderr — this is an intentional
+	// trade-off (see issue #192): we exercise the same client/runner
+	// shape as production rather than maintaining a parallel raw-exec
+	// path that could drift from the helper. To inspect a real failure,
+	// re-run `sudo apt-get update` manually outside the test.
+	if err := client.Update(context.Background()); err != nil {
+		t.Skipf("apt-get update failed (cannot run integration test): %v", err)
+	}
 	res := &resource.SystemPackageSet{
 		SystemPackageSetSpec: &resource.SystemPackageSetSpec{
 			InstallerRef: "apt",
 			Packages:     []string{pkg},
 		},
 	}
-	installer := apt.New(runner).PackageSetInstaller()
+	installer := client.PackageSetInstaller()
 	state, err := installer.Install(context.Background(), res, pkg+"-only")
 	require.NoError(t, err)
 	require.NotNil(t, state)


### PR DESCRIPTION
Add `apt.Client.Update`, which runs
`sudo -n env DEBIAN_FRONTEND=noninteractive apt-get update` to refresh
the local APT package index. Mirrors the Client-method shape of #190
(GetInstall) and #191 (PackageSetInstaller.Remove), so a single Client
binds the same runner across VersionFunc / PackageSetInstaller / Update
rather than introducing a free function with a separate runner argument.

The `-y`, `--`, and `DPkg::Lock::Timeout` flags Install/Remove use are
intentionally omitted: `apt-get update` issues no y/N prompts, takes no
operands (so no shell-meta validation is needed), and primarily holds
the apt cache/list lock (covered by `Acquire::Lock::Timeout`) rather
than the dpkg-frontend lock. Uniform lock-timeout passes across the
three helpers are tracked as a separate follow-up.

stdout/stderr are drained (nil callback -> io.Discard) for parity with
Install/Remove. apt-get update treats partial mirror failures as
success (exit 0, stderr `W: Failed to fetch`); Update inherits that
and the docstring points callers at a manual re-run for diagnostics.

Replace the raw-exec apt-get update prelude in
tests/apt_install_integration_test.go with `client.Update`, so the
integration test exercises the production helper path. The cleanup
hook intentionally keeps using raw exec because Remove is itself one
of the SUTs in that test.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
