### PR TITLE
feat(apt): add Client.PackageVersion helper (#194)

### DIFF
--- a/internal/installer/apt/apt.go
+++ b/internal/installer/apt/apt.go
@@ -174,6 +174,16 @@ func (c *Client) IsInstalled(ctx context.Context, pkg string) (bool, error) {
 	cmd := `dpkg-query -W -f='${db:Status-Status}\n' -- ` + pkg
 	output, err := c.runner.ExecuteCapture(ctx, []string{cmd}, command.Vars{}, nil)
 	if err != nil {
+		// ctx cancellation/timeout surfaces as a signal-kill on dpkg-query
+		// whose *exec.ExitError reports ExitCode() == -1. Without an
+		// explicit ctx check the cancellation would silently fall through
+		// to the generic wrap, leaving callers unable to detect it via
+		// errors.Is(err, context.Canceled / context.DeadlineExceeded).
+		// Check ctx.Err() first so the cancellation reason is preserved
+		// in the chain.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return false, fmt.Errorf("apt: status %q: %w", pkg, ctxErr)
+		}
 		// Unknown package: exit 1. command.IsExitCode walks the wrap
 		// chain (Executor.ExecuteCapture wraps cmd.Run()'s error via %w,
 		// preserving *exec.ExitError) so we can distinguish it from
@@ -194,6 +204,145 @@ func (c *Client) IsInstalled(ctx context.Context, pkg string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// PackageVersion returns the dpkg-recorded version of an installed package.
+// It is a read-only probe used by the SystemPackageSet reconciler (#198)
+// to populate SystemPackageSetState.InstalledVersions for each managed
+// package. NOTE: this is the version of the installed package per the
+// dpkg database — NOT the version of apt-get itself (see VersionFunc).
+//
+// The shell command executed is:
+//
+//	dpkg-query -W -f='${db:Status-Status} ${Version}\n' -- <pkg>
+//
+// The combined `${db:Status-Status} ${Version}` format directive is
+// deliberate: by emitting both the third Status sub-field and the
+// Version on the same line, the helper can filter to only those
+// packages whose status is exactly "installed". This protects against
+// the "stale version" pitfall where `apt-get remove pkg` (without
+// --purge) leaves an entry in dpkg db with status "config-files" and
+// the prior Version field intact. A naive `${Version}`-only query would
+// return that stale version even though the package is no longer
+// installed — PackageVersion treats such cases as not-installed.
+// Held packages (`apt-mark hold pkg` produces a Status of "hold ok
+// installed") are correctly reported as installed because only the
+// third Status sub-field is extracted; the helper behaves identically
+// to IsInstalled in this respect.
+//
+// `${db:Status-Status}` requires dpkg 1.17.11+ (Debian 8 jessie / Ubuntu
+// 16.04 LTS and later); tomei does not target older releases.
+//
+// Return values:
+//   - exit 0, exactly one line whose status sub-field is "installed"
+//     → (version, nil)
+//   - exit 0, no line with status "installed" (e.g. only "config-files",
+//     "not-installed", "half-installed") → ("", error
+//     `apt: package %q is not installed`).
+//   - exit 0, two or more lines with status "installed" (multi-arch
+//     ambiguity, e.g. libc6:amd64 + libc6:i386) → ("", error
+//     `apt: package %q is installed for multiple architectures;
+//     specify arch using <pkg>:<arch> syntax`). A reconciler must
+//     record version against an unambiguous identity to detect drift;
+//     emitting a non-deterministic first-line would create flaky state.
+//   - exit 1 (dpkg-query: "no packages found matching <pkg>") → ("",
+//     wrapped `apt: package %q is not installed: %w`). Callers needing
+//     to distinguish from genuine failures can use
+//     command.IsExitCode(err, 1).
+//   - exit ≥ 2 or a non-ExitError (dpkg-query missing, permission
+//     denied, signal, ctx cancellation, runner-side template error)
+//     → ("", wrapped `apt: version %q: %w`).
+//
+// Caller contract: when err is non-nil the returned version string is
+// always "" and MUST NOT be interpreted as data. Callers MUST check
+// err before consuming the version.
+//
+// pkg validation: rejected if empty or contains shell-meaningful
+// characters per disallowedInPackageName (whitespace, metacharacters,
+// expansion characters). The CUE layer's `=~"^\\S+$"` constraint
+// (cuemodule/schema/schema.cue) is the upstream allow-list; this guard
+// is defense-in-depth for non-CUE callers. ":" is intentionally
+// permitted to support Debian multi-arch syntax (e.g. "libc6:amd64").
+// A NUL byte in pkg is rejected by os/exec when constructing the
+// subprocess argv ("exec: argument contains NUL") and surfaces as a
+// wrapped error rather than reaching dpkg-query.
+//
+// Trust model: pkg is assumed to come from a trusted source (CUE
+// manifest under the user's control, or another in-process caller) per
+// command/executor.go's package-level Security Model. Callers exposing
+// PackageVersion to untrusted input (e.g. an HTTP API) MUST add their
+// own sanitization layer.
+//
+// Concurrency: dpkg-query reads /var/lib/dpkg/status (world-readable)
+// and does not take the dpkg-frontend lock. dpkg uses atomic rename to
+// update the status file, so dpkg-query can never observe a torn write
+// — but a probe performed concurrently with apt-get install/remove may
+// observe either the pre- or post-transaction state. Callers should
+// consume the result idempotently.
+//
+// No sudo, no DEBIAN_FRONTEND: dpkg-query is unprivileged and never
+// prompts.
+func (c *Client) PackageVersion(ctx context.Context, pkg string) (string, error) {
+	if pkg == "" {
+		return "", errors.New("apt: empty package name")
+	}
+	if strings.ContainsAny(pkg, disallowedInPackageName) {
+		return "", fmt.Errorf("apt: package %q contains disallowed characters", pkg)
+	}
+
+	// IMPORTANT: the format string is single-quoted in the shell argument
+	// so sh leaves "${db:Status-Status}" and "${Version}" as literals for
+	// dpkg-query to interpret. Changing this to double quotes would let
+	// sh expand them against the host environment (almost certainly to
+	// ""), silently breaking the helper. Keep it single-quoted.
+	// `--` operand separator guards against any future widening of
+	// allowed characters that could permit a leading `-`.
+	cmd := `dpkg-query -W -f='${db:Status-Status} ${Version}\n' -- ` + pkg
+	output, err := c.runner.ExecuteCapture(ctx, []string{cmd}, command.Vars{}, nil)
+	if err != nil {
+		// ctx cancellation/timeout surfaces as a signal-kill on dpkg-query
+		// whose *exec.ExitError reports ExitCode() == -1. Without an
+		// explicit ctx check the cancellation would silently fall through
+		// to the generic wrap or be misclassified as exit 1 ("not
+		// installed"), leaving callers unable to detect it via
+		// errors.Is(err, context.Canceled / context.DeadlineExceeded).
+		// Check ctx.Err() first so the cancellation reason is preserved
+		// in the chain.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", fmt.Errorf("apt: version %q: %w", pkg, ctxErr)
+		}
+		// Unknown package: exit 1. command.IsExitCode walks the wrap
+		// chain (Executor.ExecuteCapture wraps cmd.Run()'s error via
+		// %w, preserving *exec.ExitError) so we can distinguish it
+		// from exit ≥ 2 (genuine failure).
+		if command.IsExitCode(err, 1) {
+			return "", fmt.Errorf("apt: package %q is not installed: %w", pkg, err)
+		}
+		return "", fmt.Errorf("apt: version %q: %w", pkg, err)
+	}
+
+	// dpkg-query emits one line per matched package (multi-arch can
+	// yield >1 line). Each line is "<status> <version>" — split with
+	// strings.Fields to be robust to surrounding whitespace, and
+	// retain only the lines whose status is dpkgStatusInstalled.
+	var installedVersions []string
+	for line := range strings.SplitSeq(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[0] == dpkgStatusInstalled {
+			installedVersions = append(installedVersions, fields[1])
+		}
+	}
+	switch len(installedVersions) {
+	case 0:
+		return "", fmt.Errorf("apt: package %q is not installed", pkg)
+	case 1:
+		return installedVersions[0], nil
+	default:
+		return "", fmt.Errorf(
+			"apt: package %q is installed for multiple architectures; specify arch using <pkg>:<arch> syntax",
+			pkg,
+		)
+	}
 }
 
 // Update runs "apt-get update" to refresh the local APT package index.

--- a/internal/installer/apt/apt_test.go
+++ b/internal/installer/apt/apt_test.go
@@ -495,3 +495,172 @@ func TestIsInstalled_NonExitErrorPropagates(t *testing.T) {
 	require.EqualError(t, err, `apt: status "bash": exec: "dpkg-query": executable file not found in $PATH`)
 	require.ErrorIs(t, err, sentinel)
 }
+
+// TestIsInstalled_CtxCanceledTakesPriority verifies that when ctx is
+// canceled the cancellation reason is preserved in the chain even if
+// the runner returns an exit-1 *exec.ExitError that would normally be
+// mapped to (false, nil). Without the ctx.Err() pre-check at the top
+// of the err branch, cancellations would silently surface as
+// "package not installed", which is a wrong-answer bug for callers
+// that intend to retry on cancellation.
+func TestIsInstalled_CtxCanceledTakesPriority(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	runner := &mockCommandRunner{captureErr: wrapRunnerErr("bash", realExitError(t, 1))}
+
+	got, err := New(runner).IsInstalled(ctx, "bash")
+	require.Error(t, err)
+	assert.False(t, got)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// wrapVersionRunnerErr mimics command.Executor.ExecuteCapture's wrap
+// shape for the PackageVersion command. Pinned in one place to catch
+// drift in production wrap shape.
+func wrapVersionRunnerErr(pkg string, cause error) error {
+	return fmt.Errorf(`command failed: dpkg-query -W -f='${db:Status-Status} ${Version}\n' -- %s: %w`, pkg, cause)
+}
+
+// --- PackageVersion tests ---
+
+func TestPackageVersion(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		pkg       string
+		runnerOut string
+		runnerErr error
+		want      string
+		wantErr   string
+	}{
+		// success — simple
+		{name: "simple version", pkg: "bash", runnerOut: "installed 5.1-6ubuntu1\n", want: "5.1-6ubuntu1"},
+		{name: "epoch version", pkg: "vim", runnerOut: "installed 2:8.2.3995-1ubuntu2.13\n", want: "2:8.2.3995-1ubuntu2.13"},
+		{name: "ubuntu suffix", pkg: "git", runnerOut: "installed 1:2.34.1-1ubuntu1.10\n", want: "1:2.34.1-1ubuntu1.10"},
+		{name: "no trailing newline", pkg: "bash", runnerOut: "installed 5.1-6ubuntu1", want: "5.1-6ubuntu1"},
+		{name: "extra whitespace tolerated", pkg: "bash", runnerOut: "  installed   5.1-6ubuntu1  \n", want: "5.1-6ubuntu1"},
+
+		// success — multi-arch with only one installed (others non-installed)
+		{name: "one installed + one config-files", pkg: "libc6", runnerOut: "installed 2.35-0ubuntu3.5\nconfig-files 2.35-0ubuntu3.5\n", want: "2.35-0ubuntu3.5"},
+		{name: "one installed + one not-installed", pkg: "libc6", runnerOut: "installed 2.35-0ubuntu3.5\nnot-installed \n", want: "2.35-0ubuntu3.5"},
+		{name: "multi-arch suffix syntax (single match)", pkg: "libc6:amd64", runnerOut: "installed 2.35-0ubuntu3.5\n", want: "2.35-0ubuntu3.5"},
+
+		// success — boundary-of-allowed pkg names
+		{name: "hyphen pkg name", pkg: "linux-image-amd64", runnerOut: "installed 5.15.0.1\n", want: "5.15.0.1"},
+		{name: "plus pkg name", pkg: "g++", runnerOut: "installed 4:11.2.0-1ubuntu1\n", want: "4:11.2.0-1ubuntu1"},
+		{name: "dot pkg name", pkg: "python3.10", runnerOut: "installed 3.10.6-1~22.04\n", want: "3.10.6-1~22.04"},
+
+		// not-installed — exit 0 + 0 installed lines (stale-version protection)
+		{name: "config-files only treated as not installed", pkg: "vim", runnerOut: "config-files 8.2.0\n", wantErr: `apt: package "vim" is not installed`},
+		{name: "not-installed only treated as not installed", pkg: "ghost", runnerOut: "not-installed \n", wantErr: `apt: package "ghost" is not installed`},
+		{name: "half-installed treated as not installed", pkg: "broken", runnerOut: "half-installed 1.0\n", wantErr: `apt: package "broken" is not installed`},
+		{name: "half-configured treated as not installed", pkg: "broken", runnerOut: "half-configured 1.0\n", wantErr: `apt: package "broken" is not installed`},
+		{name: "multi-arch all config-files", pkg: "libc6", runnerOut: "config-files 2.35-0ubuntu3.5\nconfig-files 2.35-0ubuntu3.5\n", wantErr: `apt: package "libc6" is not installed`},
+
+		// multi-arch ambiguity — exit 0 + 2+ installed lines
+		{name: "multi-arch both installed (same version)", pkg: "libc6", runnerOut: "installed 2.35-0ubuntu3.5\ninstalled 2.35-0ubuntu3.5\n", wantErr: `apt: package "libc6" is installed for multiple architectures`},
+		{name: "multi-arch both installed (different versions)", pkg: "libc6", runnerOut: "installed 2.35-0ubuntu3.5\ninstalled 2.34-0ubuntu3.4\n", wantErr: `apt: package "libc6" is installed for multiple architectures`},
+
+		// degenerate / edge outputs
+		{name: "empty output", pkg: "ghost", runnerOut: "", wantErr: `apt: package "ghost" is not installed`},
+		{name: "newline-only output", pkg: "ghost", runnerOut: "\n\n", wantErr: `apt: package "ghost" is not installed`},
+		{name: "installed without version field", pkg: "broken", runnerOut: "installed\n", wantErr: `apt: package "broken" is not installed`},
+
+		// validation
+		{name: "empty pkg name rejected", pkg: "", wantErr: "apt: empty package name"},
+		{name: "pkg with semicolon rejected", pkg: "bash; rm -rf /", wantErr: "contains disallowed characters"},
+		{name: "pkg with backtick rejected", pkg: "bash`whoami`", wantErr: "contains disallowed characters"},
+		{name: "pkg with embedded space rejected", pkg: "bash vim", wantErr: "contains disallowed characters"},
+		{name: "pkg with newline rejected", pkg: "bash\n", wantErr: "contains disallowed characters"},
+		{name: "pkg with glob star rejected", pkg: "linux-image-*", wantErr: "contains disallowed characters"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			runner := &mockCommandRunner{captureOutput: tt.runnerOut, captureErr: tt.runnerErr}
+			got, err := New(runner).PackageVersion(context.Background(), tt.pkg)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Empty(t, got)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+			require.Len(t, runner.captureCmds, 1)
+			assert.Equal(t,
+				`dpkg-query -W -f='${db:Status-Status} ${Version}\n' -- `+tt.pkg,
+				runner.captureCmds[0],
+			)
+		})
+	}
+}
+
+// TestPackageVersion_NotInstalledExit1 verifies exit 1 (unknown package)
+// is mapped to a wrapped "is not installed" error using a real
+// *exec.ExitError, exercising the errors.As chain through
+// command.Executor's `command failed: %s: %w` wrap.
+func TestPackageVersion_NotInstalledExit1(t *testing.T) {
+	t.Parallel()
+	exitErr := realExitError(t, 1)
+	wrapped := wrapVersionRunnerErr("ghost-pkg", exitErr)
+	runner := &mockCommandRunner{captureErr: wrapped}
+
+	got, err := New(runner).PackageVersion(context.Background(), "ghost-pkg")
+	require.Error(t, err)
+	assert.Empty(t, got)
+	require.EqualError(t, err, fmt.Sprintf(`apt: package "ghost-pkg" is not installed: %s`, wrapped.Error()))
+	require.ErrorIs(t, err, exitErr)
+}
+
+// TestPackageVersion_GenuineFailureExit2 verifies non-1 exit codes
+// propagate with exactly `apt: version "<pkg>": <inner>`. EqualError
+// pin (instead of Contains) catches accidental rewording — the format
+// is part of the public contract per #207's precedent.
+func TestPackageVersion_GenuineFailureExit2(t *testing.T) {
+	t.Parallel()
+	exitErr := realExitError(t, 2)
+	wrapped := wrapVersionRunnerErr("bash", exitErr)
+	runner := &mockCommandRunner{captureErr: wrapped}
+
+	got, err := New(runner).PackageVersion(context.Background(), "bash")
+	require.Error(t, err)
+	assert.Empty(t, got)
+	require.EqualError(t, err, fmt.Sprintf(`apt: version "bash": %s`, wrapped.Error()))
+	require.ErrorIs(t, err, exitErr)
+}
+
+// TestPackageVersion_NonExitErrorPropagates verifies runner errors that
+// are not *exec.ExitError (binary not found, ctx canceled, permission
+// denied) bypass the exit-1 special case.
+func TestPackageVersion_NonExitErrorPropagates(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New(`exec: "dpkg-query": executable file not found in $PATH`)
+	runner := &mockCommandRunner{captureErr: sentinel}
+
+	got, err := New(runner).PackageVersion(context.Background(), "bash")
+	require.Error(t, err)
+	assert.Empty(t, got)
+	require.EqualError(t, err, `apt: version "bash": exec: "dpkg-query": executable file not found in $PATH`)
+	require.ErrorIs(t, err, sentinel)
+}
+
+// TestPackageVersion_CtxCanceledTakesPriority verifies that when ctx is
+// canceled the cancellation reason is preserved in the chain even if
+// the runner returns an exit-1 *exec.ExitError that would normally be
+// wrapped as "is not installed". Without the ctx.Err() pre-check at
+// the top of the err branch, cancellations would be misclassified as
+// "not installed", which is a wrong-answer bug for callers that intend
+// to retry on cancellation.
+func TestPackageVersion_CtxCanceledTakesPriority(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	runner := &mockCommandRunner{captureErr: wrapVersionRunnerErr("bash", realExitError(t, 1))}
+
+	got, err := New(runner).PackageVersion(ctx, "bash")
+	require.Error(t, err)
+	assert.Empty(t, got)
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/tests/apt_package_version_integration_test.go
+++ b/tests/apt_package_version_integration_test.go
@@ -1,0 +1,70 @@
+//go:build integration
+
+package tests
+
+import (
+	"context"
+	"os/exec"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/terassyi/tomei/internal/installer/apt"
+	"github.com/terassyi/tomei/internal/installer/command"
+)
+
+// TestPackageVersion_RealSystem exercises Client.PackageVersion against
+// the real dpkg database on a Linux runner. PackageVersion is a
+// read-only probe so the "preinstalled fixture" pitfall (where a
+// fixture happens to be preinstalled on the runner image and an
+// "if installed, skip" test silently no-ops) does not apply here —
+// we are not mutating host state, so a preinstalled fixture is a
+// feature, not a hazard.
+//
+//   - Phase 1 — bash: Essential: yes / Priority: required on
+//     Debian-family distros, so guaranteed installed on any sane Linux
+//     runner. Asserts the returned version is non-empty and contains
+//     at least one digit (sanity check that we got an actual version
+//     string and not a status keyword leaked through).
+//   - Phase 2 — definitely-not-a-real-package-tomei-test: a fixed
+//     sentinel chosen to be Debian-Policy-compliant but unlikely to
+//     exist in any APT repository. Verifies the exit-1 → wrapped
+//     "is not installed" mapping; the additional
+//     command.IsExitCode(err, 1) assertion confirms the underlying
+//     *exec.ExitError still reaches the public API through the wrap
+//     chain. Do NOT reuse this name in any install/remove integration
+//     test.
+//
+// Requires Linux + dpkg-query (no sudo, no apt). The install/remove
+// cycle is covered by TestPackageSetInstaller_RealSystem in a separate
+// file.
+func TestPackageVersion_RealSystem(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("dpkg-query integration test requires Linux")
+	}
+	if _, err := exec.LookPath("dpkg-query"); err != nil {
+		t.Skip("dpkg-query not found in PATH")
+	}
+
+	client := apt.New(command.NewExecutor(""))
+
+	// Phase 1: preinstalled package
+	got, err := client.PackageVersion(context.Background(), "bash")
+	require.NoError(t, err)
+	assert.NotEmpty(t, got, "bash should report a non-empty version")
+	assert.Regexp(t, `\d`, got, "version string should contain at least one digit")
+
+	// Phase 2: unknown package → "is not installed" error,
+	// chain still surfaces *exec.ExitError exit 1
+	got, err = client.PackageVersion(
+		context.Background(),
+		"definitely-not-a-real-package-tomei-test",
+	)
+	require.Error(t, err)
+	assert.Empty(t, got)
+	assert.Contains(t, err.Error(), "is not installed")
+	assert.True(t, command.IsExitCode(err, 1),
+		"exit 1 (unknown package) must reach the API via the wrap chain")
+}


### PR DESCRIPTION
Adds the read-only PackageVersion probe consumed by the SystemPackageSet
reconciler (#198) to populate SystemPackageSetState.InstalledVersions.
Uses the combined `${db:Status-Status} ${Version}` format directive so
that status==installed lines are filtered explicitly: this avoids the
stale-version pitfall where `apt-get remove pkg` (without --purge) leaves
the prior Version field intact with status config-files, and surfaces
multi-arch ambiguity (libc6:amd64 + libc6:i386 both installed) as an
actionable error rather than picking a non-deterministic first line.

Also fixes IsInstalled to check ctx.Err() before the exit-1 special
case so cancellation/timeout is preserved via errors.Is rather than
being silently mapped to "not installed".

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
