### PR TITLE
feat(cmd): wire SystemPackageRepository installer into apply/plan (#196)

### DIFF
--- a/cmd/tomei/apply.go
+++ b/cmd/tomei/apply.go
@@ -134,7 +134,7 @@ func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 			for _, r := range skipped {
 				slog.Info("skipping system resource (not yet implemented)", "kind", r.Kind(), "name", r.Name())
 			}
-			fmt.Fprintf(w, "%d system resource(s) skipped (not yet implemented: repository/package management).\n\n", len(skipped))
+			fmt.Fprintf(w, "%d system resource(s) skipped (not yet implemented: package management).\n\n", len(skipped))
 		}
 	}
 
@@ -267,7 +267,22 @@ func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 	// Create SystemEngine when --system is set. Even with zero system resources
 	// in the manifest, state may contain entries that need removal.
 	if system {
-		se, err := createSystemEngine(pathConfig.SystemDataDir())
+		// systemDownloader is an un-authenticated downloader (no GitHub token
+		// wrap) for SystemPackageRepository GPG-key fetches. It deliberately
+		// does NOT share dlClient with the user-tier downloader: dlClient
+		// wraps a GitHub PAT via github.WrapTransport, which host-scopes the
+		// token to github.com / *.githubusercontent.com. A manifest pointing
+		// keyUrl at a github-hosted URL would otherwise leak the PAT to the
+		// request log of any GitHub repo the manifest author controls.
+		// Vendor GPG keys (download.docker.com, dl.google.com, etc.) need
+		// no GitHub auth.
+		//
+		// cfg.timeout here bounds only the GPG-key HTTP fetch. The apt-get
+		// update invoked at the tail of the apt installer's Install runs via
+		// command.Executor (shell-out), independent of this timeout — on a
+		// slow mirror it may run longer than --timeout.
+		systemDownloader := download.NewDownloader(download.WithDownloadTimeout(cfg.timeout))
+		se, err := createSystemEngine(pathConfig.SystemDataDir(), systemDownloader)
 		if err != nil {
 			return fmt.Errorf("failed to create system engine: %w", err)
 		}

--- a/cmd/tomei/plan.go
+++ b/cmd/tomei/plan.go
@@ -476,6 +476,7 @@ func addSystemResourceInfo(info map[graph.NodeID]graph.ResourceInfo, resources [
 
 	store, err := state.NewStore[state.SystemState](systemDir)
 	if err != nil {
+		slog.Warn("failed to create system state store for plan", "error", err)
 		markAllSystemAsInstall(info, resources)
 		return
 	}
@@ -513,10 +514,12 @@ func addSystemResourceInfo(info map[graph.NodeID]graph.ResourceInfo, resources [
 	convertActions[*resource.SystemPackageRepository, *resource.SystemPackageRepositoryState](info, resource.KindSystemPackageRepository, repoActions)
 	convertActions[*resource.SystemPackageSet, *resource.SystemPackageSetState](info, resource.KindSystemPackageSet, pkgActions)
 
-	// Mark repo/package resources as skip when they would require actions,
-	// since concrete installers are not yet implemented.
+	// Mark SystemPackageSet resources as skip when they would require actions,
+	// since the concrete installer is not yet implemented (#198).
+	// SystemPackageRepository now has a concrete installer (#196), so it falls
+	// through with the reconciler-determined action.
 	for nodeID, ri := range info {
-		if ri.Kind == resource.KindSystemPackageRepository || ri.Kind == resource.KindSystemPackageSet {
+		if ri.Kind == resource.KindSystemPackageSet {
 			if ri.Action != resource.ActionNone {
 				ri.Action = resource.ActionSkip
 				info[nodeID] = ri
@@ -531,8 +534,9 @@ func markAllSystemAsInstall(info map[graph.NodeID]graph.ResourceInfo, resources 
 		if resource.IsSystemKind(res.Kind()) {
 			nodeID := graph.NewNodeID(res.Kind(), res.Name())
 			action := resource.ActionInstall
-			// repo/package not yet implemented — skip
-			if res.Kind() != resource.KindSystemInstaller {
+			// SystemPackageSet not yet implemented (#198) — skip.
+			// SystemInstaller and SystemPackageRepository have concrete installers.
+			if res.Kind() == resource.KindSystemPackageSet {
 				action = resource.ActionSkip
 			}
 			info[nodeID] = graph.ResourceInfo{

--- a/cmd/tomei/plan_test.go
+++ b/cmd/tomei/plan_test.go
@@ -1,13 +1,19 @@
 package main
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/terassyi/tomei/internal/graph"
+	"github.com/terassyi/tomei/internal/path"
 	"github.com/terassyi/tomei/internal/resource"
+	"github.com/terassyi/tomei/internal/state"
 )
 
 func TestCollectSkipInfos(t *testing.T) {
@@ -133,5 +139,204 @@ func TestAddDisabledResourceInfo(t *testing.T) {
 		require.Contains(t, info, nodeID)
 		assert.Equal(t, resource.ActionSkip, info[nodeID].Action)
 		assert.Empty(t, info[nodeID].Version)
+	})
+}
+
+// systemRepoResource returns a minimal SystemPackageRepository resource
+// suitable for first-install reconcile tests (state-absent → ActionInstall).
+func systemRepoResource(name string) *resource.SystemPackageRepository {
+	return &resource.SystemPackageRepository{
+		BaseResource: resource.BaseResource{
+			APIVersion:   "tomei.terassyi.net/v1beta1",
+			ResourceKind: resource.KindSystemPackageRepository,
+			Metadata:     resource.Metadata{Name: name},
+		},
+		SystemPackageRepositorySpec: &resource.SystemPackageRepositorySpec{
+			InstallerRef: resource.InstallerRefApt,
+			Apt: &resource.AptSource{
+				URL:        "https://download.docker.com/linux/ubuntu",
+				KeyURL:     "https://download.docker.com/linux/ubuntu/gpg",
+				KeyHash:    "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+				Suite:      "jammy",
+				Components: []string{"stable"},
+			},
+		},
+	}
+}
+
+func systemPackageSetResource(name string) *resource.SystemPackageSet {
+	return &resource.SystemPackageSet{
+		BaseResource: resource.BaseResource{
+			APIVersion:   "tomei.terassyi.net/v1beta1",
+			ResourceKind: resource.KindSystemPackageSet,
+			Metadata:     resource.Metadata{Name: name},
+		},
+		SystemPackageSetSpec: &resource.SystemPackageSetSpec{
+			InstallerRef: resource.InstallerRefApt,
+			Packages:     []string{"curl"},
+		},
+	}
+}
+
+func systemInstallerResource(name string) *resource.SystemInstaller {
+	// markAllSystemAsInstall only reads Kind() and Name(), so the spec
+	// content is unused here. Leave it nil to keep the helper minimal.
+	return &resource.SystemInstaller{
+		BaseResource: resource.BaseResource{
+			APIVersion:   "tomei.terassyi.net/v1beta1",
+			ResourceKind: resource.KindSystemInstaller,
+			Metadata:     resource.Metadata{Name: name},
+		},
+	}
+}
+
+func TestMarkAllSystemAsInstall(t *testing.T) {
+	t.Parallel()
+
+	t.Run("SystemInstaller gets ActionInstall", func(t *testing.T) {
+		t.Parallel()
+		info := make(map[graph.NodeID]graph.ResourceInfo)
+		markAllSystemAsInstall(info, []resource.Resource{systemInstallerResource("apt")})
+
+		nodeID := graph.NewNodeID(resource.KindSystemInstaller, "apt")
+		require.Contains(t, info, nodeID)
+		assert.Equal(t, resource.ActionInstall, info[nodeID].Action)
+	})
+
+	t.Run("SystemPackageRepository gets ActionInstall (#196 wiring)", func(t *testing.T) {
+		t.Parallel()
+		info := make(map[graph.NodeID]graph.ResourceInfo)
+		markAllSystemAsInstall(info, []resource.Resource{systemRepoResource("docker")})
+
+		nodeID := graph.NewNodeID(resource.KindSystemPackageRepository, "docker")
+		require.Contains(t, info, nodeID)
+		assert.Equal(t, resource.ActionInstall, info[nodeID].Action,
+			"SystemPackageRepository must NOT be downgraded to Skip after #196 wired the concrete installer")
+	})
+
+	t.Run("SystemPackageSet still gets ActionSkip (until #198)", func(t *testing.T) {
+		t.Parallel()
+		info := make(map[graph.NodeID]graph.ResourceInfo)
+		markAllSystemAsInstall(info, []resource.Resource{systemPackageSetResource("dev-tools")})
+
+		nodeID := graph.NewNodeID(resource.KindSystemPackageSet, "dev-tools")
+		require.Contains(t, info, nodeID)
+		assert.Equal(t, resource.ActionSkip, info[nodeID].Action,
+			"SystemPackageSet must still be downgraded to Skip until #198 lands the concrete installer")
+	})
+}
+
+func TestAddSystemResourceInfo(t *testing.T) {
+	t.Parallel()
+
+	// Setup: TempDir-backed Paths so LoadReadOnly returns an empty SystemState
+	// (state.json absent → zero-value state per Store.readState). With empty
+	// state, the reconciler emits ActionInstall for both kinds; plan.go's
+	// downgrade loop then converts only SystemPackageSet → ActionSkip.
+	setup := func(t *testing.T) *path.Paths {
+		t.Helper()
+		systemDir := t.TempDir()
+		paths, err := path.New(path.WithSystemDataDir(systemDir))
+		require.NoError(t, err)
+		return paths
+	}
+
+	t.Run("SystemPackageRepository gets ActionInstall (skip-downgrade removed)", func(t *testing.T) {
+		t.Parallel()
+		paths := setup(t)
+		info := make(map[graph.NodeID]graph.ResourceInfo)
+		addSystemResourceInfo(info, []resource.Resource{systemRepoResource("docker")}, paths)
+
+		nodeID := graph.NewNodeID(resource.KindSystemPackageRepository, "docker")
+		require.Contains(t, info, nodeID)
+		assert.Equal(t, resource.ActionInstall, info[nodeID].Action,
+			"reconciler emits ActionInstall; the addSystemResourceInfo skip-downgrade loop must NOT convert it back to Skip after #196")
+	})
+
+	t.Run("SystemPackageSet still gets ActionSkip (regression seatbelt)", func(t *testing.T) {
+		t.Parallel()
+		paths := setup(t)
+		info := make(map[graph.NodeID]graph.ResourceInfo)
+		addSystemResourceInfo(info, []resource.Resource{systemPackageSetResource("dev-tools")}, paths)
+
+		nodeID := graph.NewNodeID(resource.KindSystemPackageSet, "dev-tools")
+		require.Contains(t, info, nodeID)
+		assert.Equal(t, resource.ActionSkip, info[nodeID].Action,
+			"SystemPackageSet must still be downgraded to Skip until #198 wires the concrete installer")
+	})
+
+	t.Run("absent system data dir falls back to markAllSystemAsInstall", func(t *testing.T) {
+		t.Parallel()
+		// systemDir is intentionally a path that does not exist: plan must
+		// not create it (read-only contract) and must instead fall through
+		// to the first-run fallback.
+		paths, err := path.New(path.WithSystemDataDir(filepath.Join(t.TempDir(), "absent")))
+		require.NoError(t, err)
+
+		info := make(map[graph.NodeID]graph.ResourceInfo)
+		addSystemResourceInfo(info, []resource.Resource{
+			systemRepoResource("hashicorp"),
+			systemPackageSetResource("net-tools"),
+		}, paths)
+
+		repoID := graph.NewNodeID(resource.KindSystemPackageRepository, "hashicorp")
+		require.Contains(t, info, repoID)
+		assert.Equal(t, resource.ActionInstall, info[repoID].Action,
+			"first-run fallback must put SystemPackageRepository on the Install path")
+		pkgID := graph.NewNodeID(resource.KindSystemPackageSet, "net-tools")
+		require.Contains(t, info, pkgID)
+		assert.Equal(t, resource.ActionSkip, info[pkgID].Action,
+			"first-run fallback must still Skip SystemPackageSet until #198")
+	})
+
+	t.Run("corrupt state.json falls back to markAllSystemAsInstall", func(t *testing.T) {
+		t.Parallel()
+		systemDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(systemDir, "state.json"), []byte("{"), 0644))
+		paths, err := path.New(path.WithSystemDataDir(systemDir))
+		require.NoError(t, err)
+
+		info := make(map[graph.NodeID]graph.ResourceInfo)
+		addSystemResourceInfo(info, []resource.Resource{systemRepoResource("kubernetes")}, paths)
+
+		nodeID := graph.NewNodeID(resource.KindSystemPackageRepository, "kubernetes")
+		require.Contains(t, info, nodeID)
+		assert.Equal(t, resource.ActionInstall, info[nodeID].Action,
+			"corrupt state load must fall back to install path, not panic")
+	})
+
+	t.Run("SystemPackageRepository in state but absent from manifest gets ActionRemove", func(t *testing.T) {
+		t.Parallel()
+		// Pre-seed state with a SystemPackageRepository entry; pass an
+		// empty manifest. The reconciler emits ActionRemove; #196's
+		// skip-downgrade removal must NOT convert it to Skip.
+		systemDir := t.TempDir()
+		st := state.NewSystemState()
+		st.SystemPackageRepositories["docker"] = &resource.SystemPackageRepositoryState{
+			InstallerRef: resource.InstallerRefApt,
+			Apt: &resource.AptSource{
+				URL:        "https://download.docker.com/linux/ubuntu",
+				KeyURL:     "https://download.docker.com/linux/ubuntu/gpg",
+				KeyHash:    "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+				Suite:      "jammy",
+				Components: []string{"stable"},
+			},
+			InstalledFiles: []string{"/usr/share/keyrings/docker.gpg", "/etc/apt/sources.list.d/docker.list"},
+			UpdatedAt:      time.Now(),
+		}
+		data, err := json.Marshal(st)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(systemDir, "state.json"), data, 0644))
+
+		paths, err := path.New(path.WithSystemDataDir(systemDir))
+		require.NoError(t, err)
+
+		info := make(map[graph.NodeID]graph.ResourceInfo)
+		addSystemResourceInfo(info, nil, paths) // empty manifest → all state entries should be Remove
+
+		nodeID := graph.NewNodeID(resource.KindSystemPackageRepository, "docker")
+		require.Contains(t, info, nodeID)
+		assert.Equal(t, resource.ActionRemove, info[nodeID].Action,
+			"reconciler emits ActionRemove; the post-#196 skip-downgrade loop only touches SystemPackageSet so Remove must pass through")
 	})
 }

--- a/cmd/tomei/system_engine.go
+++ b/cmd/tomei/system_engine.go
@@ -146,8 +146,10 @@ func createSystemEngine(systemDataDir string, downloader download.Downloader) (*
 	// aptClient is constructed unconditionally: command.NewExecutor is stateless
 	// and the apt Client is the shared hub used by both the validator's
 	// VersionFunc and the repository installer. On non-apt hosts the Client
-	// exists but is never invoked (validator stays nil and selectRepoInstaller
-	// returns the placeholder).
+	// exists but is never invoked — selectRepoInstaller returns the placeholder
+	// when either (a) validator is nil because distro detection failed (macOS,
+	// minimal containers) or (b) validator is non-nil but the detected distro
+	// family does not list APT (Fedora/Arch/Alpine).
 	aptClient := apt.New(command.NewExecutor(""))
 
 	// Distro detection and validator creation are best-effort. When unavailable

--- a/cmd/tomei/system_engine.go
+++ b/cmd/tomei/system_engine.go
@@ -2,71 +2,93 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
 	"github.com/terassyi/tomei/internal/installer/apt"
 	"github.com/terassyi/tomei/internal/installer/command"
+	"github.com/terassyi/tomei/internal/installer/download"
 	"github.com/terassyi/tomei/internal/installer/engine"
+	"github.com/terassyi/tomei/internal/installer/executor"
 	"github.com/terassyi/tomei/internal/resource"
 	"github.com/terassyi/tomei/internal/state"
 	"github.com/terassyi/tomei/internal/system"
 )
 
-// validatorInstallerAdapter wraps system.Validator as executor.Installer
-// for SystemInstaller resources. Install validates the package manager;
-// Remove is a no-op that allows stale state entries to be cleaned up;
-// OS package managers themselves are not removed.
-type validatorInstallerAdapter struct {
+// validatorInstaller adapts *system.Validator into the
+// executor.Installer[*SystemInstaller, *SystemInstallerState] interface
+// expected by the system engine. Install validates the host's package
+// manager; Remove is a no-op so stale state entries can be cleaned up
+// without trying to uninstall an OS-managed package manager.
+type validatorInstaller struct {
 	validator *system.Validator
 }
 
-func (a *validatorInstallerAdapter) Install(ctx context.Context, res *resource.SystemInstaller, _ string) (*resource.SystemInstallerState, error) {
+func (a *validatorInstaller) Install(ctx context.Context, res *resource.SystemInstaller, _ string) (*resource.SystemInstallerState, error) {
 	if a.validator == nil {
-		return nil, fmt.Errorf("system package manager validation unavailable: distro detection failed or unsupported platform")
+		return nil, errors.New("system: installer: package manager validation unavailable (distro detection failed or unsupported platform)")
 	}
 	return a.validator.Validate(ctx, res)
 }
 
-func (a *validatorInstallerAdapter) Remove(_ context.Context, _ *resource.SystemInstallerState, _ string) error {
+func (a *validatorInstaller) Remove(_ context.Context, _ *resource.SystemInstallerState, _ string) error {
 	// System package managers are OS-managed and cannot actually be removed.
 	// Returning nil allows the executor to delete the stale state entry when
 	// a SystemInstaller is dropped from the manifest.
 	return nil
 }
 
-// skipRepoInstaller is a placeholder for SystemPackageRepository operations.
-// Concrete implementations (e.g., APT add-apt-repository) are tracked as a future issue.
-type skipRepoInstaller struct{}
+// unsupportedHostRepoInstaller is the placeholder used when distro detection
+// fails or the host lacks a supported package manager. Install surfaces a
+// clear platform-availability error instead of letting raw apt/gpg exec
+// failures escape. Remove returns nil so re-imaged hosts can drop stale
+// state entries; a warn log captures the host limitation and the orphaned
+// files so dotfile-sync users can audit the originating host.
+type unsupportedHostRepoInstaller struct{}
 
-func (*skipRepoInstaller) Install(_ context.Context, _ *resource.SystemPackageRepository, name string) (*resource.SystemPackageRepositoryState, error) {
-	return nil, fmt.Errorf("system package repository %q: repository management is not yet implemented", name)
+func (*unsupportedHostRepoInstaller) Install(_ context.Context, _ *resource.SystemPackageRepository, name string) (*resource.SystemPackageRepositoryState, error) {
+	// %q Go-quotes control chars in name, defanging log-injection via a
+	// crafted manifest name.
+	return nil, fmt.Errorf("system: repository %q: requires a supported Linux package manager (apt) on this host", name)
 }
 
-func (*skipRepoInstaller) Remove(_ context.Context, _ *resource.SystemPackageRepositoryState, name string) error {
-	return fmt.Errorf("system package repository %q: repository management is not yet implemented", name)
+func (*unsupportedHostRepoInstaller) Remove(_ context.Context, st *resource.SystemPackageRepositoryState, name string) error {
+	// Allow stale state cleanup on hosts that lost (or never had) apt support.
+	// Warn so cross-host state sync (e.g., dotfile sync between a Linux box
+	// and a macOS box) does not silently leave the actual /etc/apt files on
+	// the host that originally installed the repository. Surface the
+	// recorded InstalledFiles so a curious user can clean them up on the
+	// originating host.
+	var orphaned []string
+	if st != nil {
+		orphaned = st.InstalledFiles
+	}
+	slog.Warn("removing state entry for system package repository without touching actual files; this host cannot manage apt repositories",
+		"name", name, "orphaned_files", orphaned)
+	return nil
 }
 
 // skipPackageInstaller is a placeholder for SystemPackageSet operations.
-// Concrete implementations (e.g., APT apt-get install) are tracked as a future issue.
+// Concrete implementations (e.g., APT apt-get install) are tracked in #198.
 type skipPackageInstaller struct{}
 
 func (*skipPackageInstaller) Install(_ context.Context, _ *resource.SystemPackageSet, name string) (*resource.SystemPackageSetState, error) {
-	return nil, fmt.Errorf("system package set %q: package management is not yet implemented", name)
+	return nil, fmt.Errorf("system: package %q: not yet implemented", name)
 }
 
 func (*skipPackageInstaller) Remove(_ context.Context, _ *resource.SystemPackageSetState, name string) error {
-	return fmt.Errorf("system package set %q: package management is not yet implemented", name)
+	return fmt.Errorf("system: package %q: not yet implemented", name)
 }
 
-// filterSupportedSystemResources returns resources that have concrete installer
-// implementations (currently only SystemInstaller). Unsupported resources
-// (SystemPackageRepository, SystemPackageSet) are returned separately so the
-// caller can warn and skip them.
+// filterSupportedSystemResources splits system resources into those that have
+// a concrete installer (SystemInstaller, SystemPackageRepository) and those
+// that do not (currently SystemPackageSet, #198). Callers warn and skip the
+// unsupported group.
 func filterSupportedSystemResources(resources []resource.Resource) (supported, skipped []resource.Resource) {
 	for _, res := range resources {
 		switch res.Kind() {
-		case resource.KindSystemInstaller:
+		case resource.KindSystemInstaller, resource.KindSystemPackageRepository:
 			supported = append(supported, res)
 		default:
 			skipped = append(skipped, res)
@@ -75,39 +97,76 @@ func filterSupportedSystemResources(resources []resource.Resource) (supported, s
 	return supported, skipped
 }
 
-// createSystemEngine builds a SystemEngine with the available concrete
-// installers for the detected distribution. It auto-creates the system
-// state directory if it does not exist.
-func createSystemEngine(systemDataDir string) (*engine.SystemEngine, error) {
-	store, err := state.NewStore[state.SystemState](systemDataDir)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create system state store: %w", err)
+// selectRepoInstaller returns the executor.Installer for SystemPackageRepository
+// resources. When the host has a supported package manager (validator is non-
+// nil), the apt-backed installer is returned. Otherwise a placeholder is
+// returned whose Install fails with a clear "platform unsupported" error and
+// whose Remove permits state cleanup.
+//
+// Extracted as a pure helper so the validator-conditional wiring can be
+// unit-tested without depending on real distro detection. Defense-in-depth:
+// the helper falls back to the placeholder when aptClient or downloader is
+// nil, even though createSystemEngine's nil-downloader guard makes that
+// path unreachable from production code.
+func selectRepoInstaller(
+	validator *system.Validator,
+	aptClient *apt.Client,
+	downloader download.Downloader,
+) executor.Installer[*resource.SystemPackageRepository, *resource.SystemPackageRepositoryState] {
+	if validator == nil || aptClient == nil || downloader == nil {
+		return &unsupportedHostRepoInstaller{}
+	}
+	return aptClient.PackageRepositoryInstaller(downloader)
+}
+
+// createSystemEngine builds a SystemEngine wired with the concrete installers
+// available on this host. The system state directory is created lazily by
+// state.NewStore — createSystemEngine itself performs no filesystem writes.
+// downloader must be non-nil; pass an un-authenticated downloader (no GitHub
+// token wrapping) because vendor GPG keys do not require GitHub auth and
+// attaching a PAT to manifest-supplied github.com URLs would be a token-leak
+// risk.
+func createSystemEngine(systemDataDir string, downloader download.Downloader) (*engine.SystemEngine, error) {
+	if downloader == nil {
+		return nil, errors.New("downloader is required")
 	}
 
-	// Distro detection and validator creation are best-effort.
-	// When unavailable (e.g., macOS, minimal containers), the engine can
-	// still run removals (state cleanup) — only Install actions will fail.
-	var validator *system.Validator
-	distro, err := system.DetectDistro()
+	store, err := state.NewStore[state.SystemState](systemDataDir)
 	if err != nil {
+		return nil, fmt.Errorf("system: state store: %w", err)
+	}
+
+	// aptClient is constructed unconditionally: command.NewExecutor is stateless
+	// and the apt Client is the shared hub used by both the validator's
+	// VersionFunc and the repository installer. On non-apt hosts the Client
+	// exists but is never invoked (validator stays nil and selectRepoInstaller
+	// returns the placeholder).
+	aptClient := apt.New(command.NewExecutor(""))
+
+	// Distro detection and validator creation are best-effort. When unavailable
+	// (e.g., macOS, minimal containers), the engine can still run removals —
+	// only Install actions will fail with a clear platform-availability error.
+	// Each step uses if-init scoping to keep err local to its branch.
+	var validator *system.Validator
+	if distro, err := system.DetectDistro(); err != nil {
 		slog.Warn("system distro detection unavailable; system installer validation will be skipped", "error", err)
 	} else {
 		slog.Debug("detected distribution", "id", distro.ID, "id_like", distro.IDLike)
-		runner := command.NewExecutor("")
 		versionFuncs := map[system.PackageManager]system.VersionFunc{
-			system.PackageManagerAPT: apt.New(runner).VersionFunc(),
+			system.PackageManagerAPT: aptClient.VersionFunc(),
 		}
-		v, err := system.NewValidator(distro, versionFuncs)
-		if err != nil {
+		if v, err := system.NewValidator(distro, versionFuncs); err != nil {
 			slog.Warn("failed to create system validator; system installer validation will be skipped", "error", err)
 		} else {
 			validator = v
 		}
 	}
 
+	repoInstaller := selectRepoInstaller(validator, aptClient, downloader)
+
 	eng := engine.NewSystemEngine(
-		&validatorInstallerAdapter{validator: validator},
-		&skipRepoInstaller{},
+		&validatorInstaller{validator: validator},
+		repoInstaller,
 		&skipPackageInstaller{},
 		store,
 	)

--- a/cmd/tomei/system_engine.go
+++ b/cmd/tomei/system_engine.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 
 	"github.com/terassyi/tomei/internal/installer/apt"
 	"github.com/terassyi/tomei/internal/installer/command"
@@ -98,22 +99,28 @@ func filterSupportedSystemResources(resources []resource.Resource) (supported, s
 }
 
 // selectRepoInstaller returns the executor.Installer for SystemPackageRepository
-// resources. When the host has a supported package manager (validator is non-
-// nil), the apt-backed installer is returned. Otherwise a placeholder is
-// returned whose Install fails with a clear "platform unsupported" error and
-// whose Remove permits state cleanup.
+// resources. The apt-backed installer is returned only when distro detection
+// succeeded AND the detected distro family lists APT as a supported package
+// manager. On any other host (macOS, minimal containers, or non-apt Linux
+// distros such as Fedora/Arch/Alpine where DetectDistro succeeds but APT is
+// not native) the placeholder is returned, whose Install fails with the
+// documented "requires a supported Linux package manager (apt) on this host"
+// error and whose Remove permits state cleanup with a warn log.
 //
-// Extracted as a pure helper so the validator-conditional wiring can be
-// unit-tested without depending on real distro detection. Defense-in-depth:
-// the helper falls back to the placeholder when aptClient or downloader is
-// nil, even though createSystemEngine's nil-downloader guard makes that
-// path unreachable from production code.
+// Extracted as a pure helper so the conditional wiring can be unit-tested
+// without depending on real distro detection. Defense-in-depth: the helper
+// falls back to the placeholder when aptClient or downloader is nil, even
+// though createSystemEngine's nil-downloader guard makes that path
+// unreachable from production code.
 func selectRepoInstaller(
 	validator *system.Validator,
 	aptClient *apt.Client,
 	downloader download.Downloader,
 ) executor.Installer[*resource.SystemPackageRepository, *resource.SystemPackageRepositoryState] {
 	if validator == nil || aptClient == nil || downloader == nil {
+		return &unsupportedHostRepoInstaller{}
+	}
+	if !slices.Contains(validator.SupportedInstallers(), system.PackageManagerAPT) {
 		return &unsupportedHostRepoInstaller{}
 	}
 	return aptClient.PackageRepositoryInstaller(downloader)

--- a/cmd/tomei/system_engine_test.go
+++ b/cmd/tomei/system_engine_test.go
@@ -1,50 +1,110 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/terassyi/tomei/internal/installer/apt"
+	"github.com/terassyi/tomei/internal/installer/command"
+	"github.com/terassyi/tomei/internal/installer/download"
 	"github.com/terassyi/tomei/internal/resource"
+	"github.com/terassyi/tomei/internal/system"
 )
 
-func TestValidatorInstallerAdapter_Remove(t *testing.T) {
+func TestValidatorInstaller_Remove_IsNoOp(t *testing.T) {
 	t.Parallel()
-	adapter := &validatorInstallerAdapter{validator: nil}
 	// Remove is a no-op: system package managers are OS-managed, so
 	// "removing" just cleans the state entry.
-	err := adapter.Remove(context.Background(), nil, "apt")
+	a := &validatorInstaller{validator: nil}
+	err := a.Remove(context.Background(), nil, "apt")
 	require.NoError(t, err)
 }
 
-func TestValidatorInstallerAdapter_Install_NilValidator(t *testing.T) {
+func TestValidatorInstaller_Install_NilValidator(t *testing.T) {
 	t.Parallel()
 	// When distro detection fails, validator is nil.
 	// Install should return a clear error instead of panicking.
-	adapter := &validatorInstallerAdapter{validator: nil}
-	_, err := adapter.Install(context.Background(), nil, "apt")
+	a := &validatorInstaller{validator: nil}
+	_, err := a.Install(context.Background(), nil, "apt")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "distro detection failed")
+	assert.Contains(t, err.Error(), "package manager validation unavailable")
 }
 
-func TestSkipRepoInstaller(t *testing.T) {
+func TestUnsupportedHostRepoInstaller_Install(t *testing.T) {
 	t.Parallel()
-	installer := &skipRepoInstaller{}
+	installer := &unsupportedHostRepoInstaller{}
 
-	t.Run("Install", func(t *testing.T) {
-		t.Parallel()
-		_, err := installer.Install(context.Background(), nil, "docker-repo")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "not yet implemented")
-		assert.Contains(t, err.Error(), "docker-repo")
+	_, err := installer.Install(context.Background(), nil, "docker-repo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires a supported Linux package manager")
+	assert.Contains(t, err.Error(), "docker-repo")
+}
+
+func TestUnsupportedHostRepoInstaller_Install_QuotesControlChars(t *testing.T) {
+	t.Parallel()
+	// %q Go-quotes control characters in the name, defanging log-injection
+	// via crafted manifest names. Verify the literal \n (two chars) appears
+	// in the error string rather than a raw newline.
+	installer := &unsupportedHostRepoInstaller{}
+
+	_, err := installer.Install(context.Background(), nil, "repo\nINJECT")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `\n`, "name with newline must be Go-quoted in error message")
+	assert.NotContains(t, err.Error(), "repo\nINJECT", "raw newline must not appear in error message")
+}
+
+func TestUnsupportedHostRepoInstaller_Remove(t *testing.T) {
+	// Cannot t.Parallel(): slog.SetDefault mutates global state.
+	// Subtests below run sequentially for the same reason — DO NOT add
+	// t.Parallel() inside the subtests; capture-then-cleanup breaks because
+	// parallel siblings would race on the same process-global default
+	// logger.
+	installer := &unsupportedHostRepoInstaller{}
+
+	capture := func(t *testing.T) *bytes.Buffer {
+		t.Helper()
+		// Pattern mirrors internal/state/store_test.go.
+		var buf bytes.Buffer
+		handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
+		oldLogger := slog.Default()
+		slog.SetDefault(slog.New(handler))
+		t.Cleanup(func() { slog.SetDefault(oldLogger) })
+		return &buf
+	}
+
+	t.Run("nil state returns nil and warns", func(t *testing.T) {
+		buf := capture(t)
+		err := installer.Remove(context.Background(), nil, "docker-repo")
+		require.NoError(t, err, "Remove must return nil so stale state can be cleaned up")
+		assert.Contains(t, buf.String(), "name=docker-repo", "warn log must include the repo name attribute for cross-host visibility")
+		assert.Contains(t, buf.String(), "package repository", "warn log must mention the resource kind")
 	})
 
-	t.Run("Remove", func(t *testing.T) {
-		t.Parallel()
-		err := installer.Remove(context.Background(), nil, "docker-repo")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "not yet implemented")
+	t.Run("non-nil state surfaces orphaned files", func(t *testing.T) {
+		buf := capture(t)
+		st := &resource.SystemPackageRepositoryState{
+			InstalledFiles: []string{"/usr/share/keyrings/docker.gpg", "/etc/apt/sources.list.d/docker.list"},
+		}
+		err := installer.Remove(context.Background(), st, "docker-repo")
+		require.NoError(t, err)
+		// Forensic visibility: which actual files survive on the originating host.
+		assert.Contains(t, buf.String(), "/usr/share/keyrings/docker.gpg",
+			"warn log must include InstalledFiles so dotfile-sync users can audit the originating host")
+	})
+
+	t.Run("name with control chars is escaped in warn log", func(t *testing.T) {
+		buf := capture(t)
+		err := installer.Remove(context.Background(), nil, "repo\nINJECT")
+		require.NoError(t, err)
+		// slog.NewTextHandler quotes string attributes that contain control
+		// chars (logfmt-style strconv-quoted), so a raw newline does not
+		// land in the log stream.
+		assert.NotContains(t, buf.String(), "\nINJECT",
+			"control chars in name must not produce a raw newline in the warn log")
 	})
 }
 
@@ -57,6 +117,7 @@ func TestSkipPackageInstaller(t *testing.T) {
 		_, err := installer.Install(context.Background(), nil, "dev-tools")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not yet implemented")
+		assert.Contains(t, err.Error(), "system: package")
 		assert.Contains(t, err.Error(), "dev-tools")
 	})
 
@@ -65,7 +126,71 @@ func TestSkipPackageInstaller(t *testing.T) {
 		err := installer.Remove(context.Background(), nil, "dev-tools")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not yet implemented")
+		assert.Contains(t, err.Error(), "system: package")
 	})
+}
+
+func TestSelectRepoInstaller(t *testing.T) {
+	t.Parallel()
+	aptClient := apt.New(command.NewExecutor(""))
+	downloader := download.NewDownloader()
+
+	t.Run("validator nil returns placeholder", func(t *testing.T) {
+		t.Parallel()
+		got := selectRepoInstaller(nil, aptClient, downloader)
+		_, ok := got.(*unsupportedHostRepoInstaller)
+		assert.True(t, ok, "nil validator must return *unsupportedHostRepoInstaller, got %T", got)
+	})
+
+	t.Run("validator+aptClient+downloader returns non-placeholder", func(t *testing.T) {
+		t.Parallel()
+		// Empty *system.Validator is enough: selectRepoInstaller only
+		// checks the pointer for nil-ness, it never invokes methods.
+		got := selectRepoInstaller(&system.Validator{}, aptClient, downloader)
+		require.NotNil(t, got)
+		// Negative assertion (rather than positive type-assert against
+		// *apt.PackageRepositoryInstaller) — keeps the test resilient to
+		// a future apt type rename. We only care that the placeholder is
+		// NOT returned when a validator exists.
+		_, isPlaceholder := got.(*unsupportedHostRepoInstaller)
+		assert.False(t, isPlaceholder, "non-nil validator must not return placeholder, got %T", got)
+	})
+
+	t.Run("nil aptClient returns placeholder (defense-in-depth)", func(t *testing.T) {
+		t.Parallel()
+		got := selectRepoInstaller(&system.Validator{}, nil, downloader)
+		_, ok := got.(*unsupportedHostRepoInstaller)
+		assert.True(t, ok, "nil aptClient must return placeholder, got %T", got)
+	})
+
+	t.Run("nil downloader returns placeholder (defense-in-depth)", func(t *testing.T) {
+		t.Parallel()
+		got := selectRepoInstaller(&system.Validator{}, aptClient, nil)
+		_, ok := got.(*unsupportedHostRepoInstaller)
+		assert.True(t, ok, "nil downloader must return placeholder, got %T", got)
+	})
+}
+
+func TestCreateSystemEngine_NilDownloader(t *testing.T) {
+	t.Parallel()
+	// Defense-in-depth: the sole production caller (apply.go) always
+	// constructs a real downloader, but a nil here would surface as a panic
+	// deep inside Install. Fail fast with a clear error instead.
+	_, err := createSystemEngine(t.TempDir(), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "downloader is required")
+}
+
+func TestCreateSystemEngine_HappyPath(t *testing.T) {
+	t.Parallel()
+	// Smoke test: catches future signature drift in state.NewStore or
+	// engine.NewSystemEngine. Distro detection may or may not succeed
+	// depending on the host running the test — both branches produce a
+	// non-nil engine (selectRepoInstaller falls back to the placeholder
+	// when validator is nil), so this test is host-agnostic.
+	eng, err := createSystemEngine(t.TempDir(), download.NewDownloader())
+	require.NoError(t, err)
+	assert.NotNil(t, eng)
 }
 
 func TestFilterSupportedSystemResources(t *testing.T) {
@@ -81,23 +206,48 @@ func TestFilterSupportedSystemResources(t *testing.T) {
 	t.Run("installer only", func(t *testing.T) {
 		t.Parallel()
 		resources := []resource.Resource{
-			&resource.SystemInstaller{BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "apt"}}},
+			&resource.SystemInstaller{BaseResource: resource.BaseResource{ResourceKind: resource.KindSystemInstaller, Metadata: resource.Metadata{Name: "apt"}}},
 		}
 		supported, skipped := filterSupportedSystemResources(resources)
 		assert.Len(t, supported, 1)
 		assert.Empty(t, skipped)
 	})
 
+	t.Run("repo only", func(t *testing.T) {
+		t.Parallel()
+		resources := []resource.Resource{
+			&resource.SystemPackageRepository{BaseResource: resource.BaseResource{ResourceKind: resource.KindSystemPackageRepository, Metadata: resource.Metadata{Name: "docker-repo"}}},
+		}
+		supported, skipped := filterSupportedSystemResources(resources)
+		require.Len(t, supported, 1)
+		assert.Equal(t, "docker-repo", supported[0].Name())
+		assert.Empty(t, skipped)
+	})
+
+	t.Run("packageset only", func(t *testing.T) {
+		t.Parallel()
+		resources := []resource.Resource{
+			&resource.SystemPackageSet{BaseResource: resource.BaseResource{ResourceKind: resource.KindSystemPackageSet, Metadata: resource.Metadata{Name: "dev-tools"}}},
+		}
+		supported, skipped := filterSupportedSystemResources(resources)
+		assert.Empty(t, supported)
+		require.Len(t, skipped, 1)
+		assert.Equal(t, "dev-tools", skipped[0].Name())
+	})
+
 	t.Run("mixed", func(t *testing.T) {
 		t.Parallel()
 		resources := []resource.Resource{
-			&resource.SystemInstaller{BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "apt"}}},
-			&resource.SystemPackageRepository{BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "docker-repo"}}},
-			&resource.SystemPackageSet{BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "dev-tools"}}},
+			&resource.SystemInstaller{BaseResource: resource.BaseResource{ResourceKind: resource.KindSystemInstaller, Metadata: resource.Metadata{Name: "apt"}}},
+			&resource.SystemPackageRepository{BaseResource: resource.BaseResource{ResourceKind: resource.KindSystemPackageRepository, Metadata: resource.Metadata{Name: "docker-repo"}}},
+			&resource.SystemPackageSet{BaseResource: resource.BaseResource{ResourceKind: resource.KindSystemPackageSet, Metadata: resource.Metadata{Name: "dev-tools"}}},
 		}
 		supported, skipped := filterSupportedSystemResources(resources)
-		assert.Len(t, supported, 1)
+		require.Len(t, supported, 2)
+		// Order matches input order — append-based filter is deterministic.
 		assert.Equal(t, "apt", supported[0].Name())
-		assert.Len(t, skipped, 2)
+		assert.Equal(t, "docker-repo", supported[1].Name())
+		require.Len(t, skipped, 1)
+		assert.Equal(t, "dev-tools", skipped[0].Name())
 	})
 }

--- a/cmd/tomei/system_engine_test.go
+++ b/cmd/tomei/system_engine_test.go
@@ -135,6 +135,14 @@ func TestSelectRepoInstaller(t *testing.T) {
 	aptClient := apt.New(command.NewExecutor(""))
 	downloader := download.NewDownloader()
 
+	// aptValidator and dnfValidator are constructed via system.NewValidator
+	// so SupportedInstallers() returns a real list backed by the distro
+	// family map (debian → [apt], fedora → [dnf]).
+	aptValidator, err := system.NewValidator(&system.DistroInfo{ID: "debian"}, nil)
+	require.NoError(t, err)
+	dnfValidator, err := system.NewValidator(&system.DistroInfo{ID: "fedora"}, nil)
+	require.NoError(t, err)
+
 	t.Run("validator nil returns placeholder", func(t *testing.T) {
 		t.Parallel()
 		got := selectRepoInstaller(nil, aptClient, downloader)
@@ -142,30 +150,40 @@ func TestSelectRepoInstaller(t *testing.T) {
 		assert.True(t, ok, "nil validator must return *unsupportedHostRepoInstaller, got %T", got)
 	})
 
-	t.Run("validator+aptClient+downloader returns non-placeholder", func(t *testing.T) {
+	t.Run("apt-supporting distro returns non-placeholder", func(t *testing.T) {
 		t.Parallel()
-		// Empty *system.Validator is enough: selectRepoInstaller only
-		// checks the pointer for nil-ness, it never invokes methods.
-		got := selectRepoInstaller(&system.Validator{}, aptClient, downloader)
+		got := selectRepoInstaller(aptValidator, aptClient, downloader)
 		require.NotNil(t, got)
 		// Negative assertion (rather than positive type-assert against
-		// *apt.PackageRepositoryInstaller) — keeps the test resilient to
-		// a future apt type rename. We only care that the placeholder is
-		// NOT returned when a validator exists.
+		// *apt.PackageRepositoryInstaller) keeps the test resilient to a
+		// future apt type rename. We only care that the placeholder is
+		// NOT returned on an apt host.
 		_, isPlaceholder := got.(*unsupportedHostRepoInstaller)
-		assert.False(t, isPlaceholder, "non-nil validator must not return placeholder, got %T", got)
+		assert.False(t, isPlaceholder, "apt-supporting distro must not return placeholder, got %T", got)
+	})
+
+	t.Run("non-apt distro returns placeholder", func(t *testing.T) {
+		t.Parallel()
+		// Fedora supports DNF, not APT. Distro detection succeeds, so the
+		// validator is non-nil — but the host has no APT support. Without
+		// this gate the apt installer would run on Fedora and surface raw
+		// apt/gpg errors instead of the documented platform-availability
+		// error.
+		got := selectRepoInstaller(dnfValidator, aptClient, downloader)
+		_, ok := got.(*unsupportedHostRepoInstaller)
+		assert.True(t, ok, "non-apt distro must return placeholder, got %T", got)
 	})
 
 	t.Run("nil aptClient returns placeholder (defense-in-depth)", func(t *testing.T) {
 		t.Parallel()
-		got := selectRepoInstaller(&system.Validator{}, nil, downloader)
+		got := selectRepoInstaller(aptValidator, nil, downloader)
 		_, ok := got.(*unsupportedHostRepoInstaller)
 		assert.True(t, ok, "nil aptClient must return placeholder, got %T", got)
 	})
 
 	t.Run("nil downloader returns placeholder (defense-in-depth)", func(t *testing.T) {
 		t.Parallel()
-		got := selectRepoInstaller(&system.Validator{}, aptClient, nil)
+		got := selectRepoInstaller(aptValidator, aptClient, nil)
 		_, ok := got.(*unsupportedHostRepoInstaller)
 		assert.True(t, ok, "nil downloader must return placeholder, got %T", got)
 	})

--- a/docs/cue-schema.md
+++ b/docs/cue-schema.md
@@ -283,7 +283,7 @@ System-level package manager. Requires `--system` to be applied. Only `apt` is c
 - error contains `package manager "<x>" is not supported on this system` (with appended distro context such as `(ID=..., ID_LIKE=...)`) — the host's distro does not match
 - error contains `no version function registered for package manager "<x>"` — the package manager is not yet wired up in tomei
 - error contains `failed to get version for "<x>"` — the version probe itself failed (e.g., the package manager binary is missing or returned an unexpected output)
-- error contains `system package manager validation unavailable: distro detection failed or unsupported platform` — running on a host where distro detection isn't available (e.g., macOS, minimal containers)
+- error contains `system: installer: package manager validation unavailable (distro detection failed or unsupported platform)` — running on a host where distro detection isn't available (e.g., macOS, minimal containers)
 
 `metadata.name` must match a known package manager identifier (`apt`, `dnf`, `zypper`, `pacman`, `apk`); identifiers other than `apt` are not currently supported by the engine.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -246,10 +246,10 @@ SystemInstaller → SystemPackageRepository → SystemPackageSet
 |----------|--------|
 | `SystemInstaller` (`apt`) | Validates that `apt-get` exists on the host and captures its version |
 | `SystemInstaller` (other) | Schema accepts `dnf`/`zypper`/`pacman`/`apk`, but only `apt` is currently wired. Other package managers fail validation either with "package manager is not supported on this system" (distro mismatch) or "no version function registered" (supported by distro detection but not yet wired in the engine) |
-| `SystemPackageRepository` | Concrete installer not yet implemented (planned: `add-apt-repository`, GPG key management). Recognized by plan/apply but skipped at runtime |
+| `SystemPackageRepository` | Concrete installer wired (APT). Places the GPG keyring under `/usr/share/keyrings/<name>.gpg`, writes the source entry to `/etc/apt/sources.list.d/<name>.list`, and runs `apt-get update`. On hosts where distro detection fails or no supported package manager is present, install fails with `system: repository "<name>": requires a supported Linux package manager (apt) on this host`; Remove returns successfully with a warn log so stale state can be drained without touching the originating host's files. |
 | `SystemPackageSet` | Concrete installer not yet implemented (planned: `apt-get install`). Recognized by plan/apply but skipped at runtime |
 
-`tomei plan --system` and `tomei apply --system` recognize all three kinds. Resources without a concrete installer are shown as `skip` in plan and skipped at apply time with a warning, so that declaring them does not produce a false success.
+`tomei plan --system` and `tomei apply --system` recognize all three kinds. `SystemPackageSet` is still shown as `skip` in plan and skipped at apply time with a warning. `SystemInstaller` and `SystemPackageRepository` execute through their respective concrete installers.
 
 `SystemInstaller` removal does not uninstall the OS package manager — it only clears the state entry.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -271,7 +271,7 @@ System resources:
 | Kind | Purpose |
 |------|---------|
 | `SystemInstaller` | Declares a host package manager (currently `apt` only). Validates the package manager is available and captures its version. |
-| `SystemPackageRepository` | Third-party APT repository (e.g., Docker, Kubernetes). Concrete installer is **not yet implemented** — declared resources are shown as `skip` in plan when changes would be required. |
+| `SystemPackageRepository` | Third-party APT repository (e.g., Docker, Kubernetes). Concrete installer (APT-based) places the GPG keyring at `/usr/share/keyrings/<name>.gpg`, writes the source entry to `/etc/apt/sources.list.d/<name>.list`, and runs `apt-get update`. On non-apt hosts the resource fails with a clear "platform unsupported" error. |
 | `SystemPackage` | Single-package shorthand for `SystemPackageSet`. Expands to a one-element set at load time; same skip behavior. |
 | `SystemPackageSet` | Set of system packages to install. Concrete installer is **not yet implemented** — declared resources are shown as `skip` in plan when changes would be required. |
 
@@ -322,7 +322,7 @@ Behavior notes:
 - **Multi-user limitation.** Each user maintains an independent view of system package state. tomei does not coordinate between users on the same host and does not detect out-of-band changes (e.g., manual `apt install` or distro upgrades). For shared servers, use a configuration management tool instead.
 - **Sudo behavior.** tomei prompts for the sudo password once per run and reuses the cached credential. With passwordless sudo (e.g., `NOPASSWD` in `/etc/sudoers`, common in CI), no prompt is shown. Do not run `sudo tomei apply --system` — it may create or write state files as root, leaving permission issues later or operating on root's home directory instead of the invoking user's.
 - **Removing a `SystemInstaller`.** Drops only the state entry — the underlying OS package manager is not uninstalled.
-- **Unsupported platforms.** On non-Linux hosts (e.g., macOS) or distros without a registered package manager, distro detection falls back gracefully: removals (state cleanup) still work, but `Install` actions fail with `system package manager validation unavailable: distro detection failed or unsupported platform`.
+- **Unsupported platforms.** On non-Linux hosts (e.g., macOS) or distros without a registered package manager, distro detection falls back gracefully: removals (state cleanup) still work, but `Install` actions fail with errors of the form `system: installer: package manager validation unavailable (distro detection failed or unsupported platform)` for `SystemInstaller` and `system: repository "<name>": requires a supported Linux package manager (apt) on this host` for `SystemPackageRepository`.
 
 ### Version Resolvers
 


### PR DESCRIPTION
Wire apt.PackageRepositoryInstaller (from #195) into createSystemEngine
via a new selectRepoInstaller helper. Rename skipRepoInstaller →
unsupportedHostRepoInstaller so non-apt hosts surface a clear platform
error from Install while Remove still drains stale state with a warn log
that includes the orphaned /etc/apt files for cross-host audit.

filterSupportedSystemResources allows KindSystemPackageRepository through;
addSystemResourceInfo / markAllSystemAsInstall no longer downgrade it to
Skip. SystemPackageSet remains Skip until #198.

Use a separate un-authenticated systemDownloader (download.NewDownloader,
no github.WrapTransport) for GPG-key fetches: the user-tier downloader
attaches the GitHub PAT to any github.com / *.githubusercontent.com host,
so a manifest pointing keyUrl at a github-hosted URL would otherwise leak
the token. Vendor GPG keys (download.docker.com, dl.google.com, etc.)
need no GitHub auth.

Adds tests covering selectRepoInstaller's four branches, the placeholder's
Install/Remove paths (including %q control-char escaping and orphaned-file
logging), createSystemEngine's nil-downloader guard and happy path, plan
output for repo Install/Remove and the absent / corrupt state fallbacks.
Updates docs/usage.md, docs/design.md, docs/cue-schema.md to reflect the
new wiring and error format.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
