### PR TITLE
test(e2e): add SystemPackageRepository plan coverage (#197)

### DIFF
--- a/e2e/config/system-package-test/manifest.cue
+++ b/e2e/config/system-package-test/manifest.cue
@@ -34,3 +34,34 @@ cliTools: {
 		packages: ["jq", "curl"]
 	}
 }
+
+// pgdgRepo declares the PostgreSQL APT repository (PGDG) as the canonical
+// SystemPackageRepository fixture for E2E coverage of #196 / #197. The
+// armored signing key at spec.apt.keyUrl is pinned via spec.apt.keyHash —
+// if the upstream key rotates, the SHA256 below must be re-derived from
+// `curl -fsSL https://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc |
+// sha256sum` and the e2e Go const pgdgKeyHashSHA256 updated in lockstep.
+//
+// Validate and plan only read the manifest — they do NOT fetch keyUrl or
+// hit the network. apply (currently declared as Ginkgo Pending via PIt in
+// e2e/system_package_test.go, awaiting gnupg in the runner image) is the
+// only path that fetches the key, verifies the hash, and reaches the
+// suite. The suite below uses the PGDG-specific naming convention
+// `<codename>-pgdg` (not bare `<codename>`): the PostgreSQL project ships
+// distributions under e.g. `noble-pgdg`, `jammy-pgdg`, `bookworm-pgdg`.
+// Using a bare suite name would 404 the moment apply lands.
+pgdgRepo: {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "SystemPackageRepository"
+	metadata: name: "pgdg"
+	spec: {
+		installerRef: "apt"
+		apt: {
+			url:     "https://apt.postgresql.org/pub/repos/apt"
+			keyUrl:  "https://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc"
+			keyHash: "sha256:0144068502a1eddd2a0280ede10ef607d1ec592ce819940991203941564e8e76"
+			suite:   "noble-pgdg"
+			components: ["main"]
+		}
+	}
+}

--- a/e2e/executor.go
+++ b/e2e/executor.go
@@ -196,6 +196,18 @@ func (e *nativeExecutor) Setup() error {
 	return nil
 }
 
+// e2eConfigPath returns the absolute path of a fixture under e2e/config/.
+// The path is anchored on this source file via runtime.Caller(0), so the
+// resolution is independent of the runner's cwd — `go test ./e2e`, `dlv
+// test`, and pre-built test binaries all resolve to the repo's checked-in
+// e2e/config tree. Tests that need to read raw fixture bytes (e.g. drift
+// detectors over manifest.cue pins) should use this helper rather than
+// duplicating the runtime.Caller dance.
+func e2eConfigPath(parts ...string) string {
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Join(append([]string{filepath.Dir(filename), "config"}, parts...)...)
+}
+
 func (e *nativeExecutor) copyTestConfigs() error {
 	// Find e2e/config directory relative to test file location
 	_, filename, _, ok := runtime.Caller(0)

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -3,9 +3,65 @@
 package e2e
 
 import (
+	"os"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+// pgdgSuite is the second half of the rotation contract: the suite name
+// used in the manifest must stay in lockstep with this Go const. PGDG ships
+// distributions under the `<codename>-pgdg` convention; using a bare
+// `<codename>` would 404 at apt-get-update time. Pinned here because the
+// tree-printer plan output does not currently render AptSource fields, so
+// only this drift detector catches a regression of the manifest's suite
+// back to a bare codename.
+const pgdgSuite = "noble-pgdg"
+
+// pgdgUbuntuRelease is the Ubuntu release that the e2e container image
+// (e2e/containers/ubuntu/Dockerfile) bases on. The PGDG suite encodes the
+// release's *codename*, while the Dockerfile encodes the *version number*
+// — both halves must agree or `apt-get update` 404s at apply time. The
+// drift detector below enforces this third leg of the rotation contract
+// at test time so a Dockerfile bump without a suite bump (or vice versa)
+// cannot pass CI silently.
+const pgdgUbuntuRelease = "24.04"
+
+// ubuntuReleaseToCodename pins the version-number ↔ codename mapping for
+// the Ubuntu LTS releases tomei targets. The drift detector below uses
+// this to close the rotation triangle:
+//
+//	pgdgUbuntuRelease  ── version-number leg (Dockerfile FROM)
+//	         │
+//	         ▼  ubuntuReleaseToCodename[pgdgUbuntuRelease]
+//	      codename  ── codename leg
+//	         │
+//	         ▼  pgdgSuite = "<codename>-pgdg"
+//	     pgdgSuite  ── PGDG suite leg
+//
+// Without this map, an editor could update the Dockerfile and
+// pgdgUbuntuRelease together while leaving pgdgSuite pointing at the old
+// codename, and every individual pair-wise drift check would still pass.
+// New Ubuntu LTS releases land here in lockstep with the Dockerfile bump.
+var ubuntuReleaseToCodename = map[string]string{
+	"22.04": "jammy",
+	"24.04": "noble",
+}
+
+// pgdgKeyHashSHA256 is the pinned SHA256 of the PostgreSQL APT signing
+// key referenced from e2e/config/system-package-test/manifest.cue. The
+// value is derived from
+//
+//	curl -fsSL https://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc \
+//	  | sha256sum
+//
+// and must stay in lockstep with spec.apt.keyHash in that manifest. If
+// upstream rotates the ACCC4CF8 signing key the manifest and this const
+// MUST be updated together — the production AptSource validation refuses
+// to install without a sha256:<64hex> KeyHash, so a missing or stale pin
+// breaks `tomei apply --system` rather than silently trusting an
+// unverified key.
+const pgdgKeyHashSHA256 = "sha256:0144068502a1eddd2a0280ede10ef607d1ec592ce819940991203941564e8e76"
 
 func systemPackageTests() {
 	const cfgPath = "~/system-package-test/"
@@ -42,5 +98,171 @@ func systemPackageTests() {
 		Expect(out).To(ContainSubstring("SystemInstaller/apt"))
 		Expect(out).To(ContainSubstring("SystemPackageSet/tree"))
 		Expect(out).To(ContainSubstring("SystemPackageSet/cli-tools"))
+	})
+
+	// SystemPackageRepository coverage (#197). Mirrors the validate/plan
+	// surface above for SystemInstaller / SystemPackageSet but anchors the
+	// post-#196 contract that SystemPackageRepository is NOT skip-downgraded
+	// the way SystemPackageSet still is: with --system the reconciler-
+	// determined action passes through to the printer, so plan shows
+	// "[+ install]" for an uninstalled pgdg.
+	//
+	// The apply / removal / idempotency arms of the spec are declared as
+	// Ginkgo Pending specs (PIt) rather than running real apply against
+	// the host. Rationale:
+	//
+	//   - The e2e runner image (e2e/containers/ubuntu/Dockerfile) does
+	//     not currently install gnupg, so apt.PackageRepositoryInstaller's
+	//     `gpg --dearmor` step would fail. Adding gnupg is out of scope
+	//     for this PR; #197 follow-up will land the Dockerfile bump plus
+	//     promote these PIt specs to It with real assertions.
+	//   - Even with gnupg present, apply --system mutates host state
+	//     (/usr/share/keyrings/pgdg.gpg and /etc/apt/sources.list.d/pgdg.list)
+	//     which would persist across containerised tests if the runner is
+	//     reused, and would reach apt.postgresql.org over the network at
+	//     test time — a brittle dependency for CI. The PIt bodies
+	//     document the expected post-apply invariants so the follow-up
+	//     PR has a single place to flip PIt -> It.
+	Context("SystemPackageRepository (#197)", func() {
+		It("validates the manifest", func() {
+			out, err := testExec.Exec("tomei", "validate", cfgPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).To(ContainSubstring("Validation successful"))
+			Expect(out).To(ContainSubstring("SystemPackageRepository/pgdg"))
+		})
+
+		It("manifest pins match the Go consts (drift detector)", func() {
+			// Defends against the contract documented in the manifest.cue
+			// header comment and the Go const docstrings: rotating the
+			// upstream PGDG signing key — or changing the PGDG suite
+			// naming convention — requires updating BOTH the manifest and
+			// the corresponding Go const in the same commit. A drift here
+			// would silently break `tomei apply --system` once the apply
+			// specs are unblocked (the suite drift is especially insidious
+			// because `tomei plan` does not render AptSource fields, so
+			// no plan-time assertion would catch the regression).
+			//
+			// Paths are anchored via e2eConfigPath (runtime.Caller in
+			// executor.go) so the detector works under `go test`,
+			// `go test -c`, and `dlv test` regardless of cwd.
+			//
+			// Assertions pin the exact CUE field syntax rather than bare
+			// substring so a comment block that happens to mention the
+			// value, or a near-miss like `suite: "noble-pgdg-staging"`,
+			// cannot pass silently.
+			raw, err := os.ReadFile(e2eConfigPath("system-package-test", "manifest.cue"))
+			Expect(err).NotTo(HaveOccurred(), "manifest.cue must exist at the canonical e2e fixture path")
+			Expect(string(raw)).To(ContainSubstring(`keyHash: "`+pgdgKeyHashSHA256+`"`),
+				"manifest.cue spec.apt.keyHash and the Go const pgdgKeyHashSHA256 must stay in lockstep — see the manifest header comment for the rotation procedure")
+			Expect(string(raw)).To(ContainSubstring(`suite:   "`+pgdgSuite+`"`),
+				"manifest.cue spec.apt.suite and the Go const pgdgSuite must stay in lockstep — PGDG uses the <codename>-pgdg convention, a bare codename would 404 at apt-get update")
+		})
+
+		It("Dockerfile Ubuntu release matches pgdgUbuntuRelease and pgdgSuite codename (rotation contract)", func() {
+			// Third leg of the rotation contract. The PGDG suite encodes
+			// the Ubuntu codename ("noble-pgdg"); the Dockerfile encodes
+			// the version number ("24.04"). The three pins must agree
+			// pairwise AND transitively or `apt-get update` 404s at apply
+			// time — neither the manifest pin nor the suite pin would
+			// catch a transitive break on its own.
+			dockerfilePath := e2eConfigPath("..", "containers", "ubuntu", "Dockerfile")
+			raw, err := os.ReadFile(dockerfilePath)
+			Expect(err).NotTo(HaveOccurred(), "Dockerfile must exist at the canonical e2e path")
+			Expect(string(raw)).To(ContainSubstring("FROM ubuntu:"+pgdgUbuntuRelease),
+				"e2e/containers/ubuntu/Dockerfile FROM line and the Go const pgdgUbuntuRelease must stay in lockstep — a Dockerfile bump without a pgdgUbuntuRelease bump would 404 at apt-get update")
+
+			// Transitive closure: pgdgUbuntuRelease must map to a known
+			// codename, and that codename must be the prefix of pgdgSuite.
+			// Without this, an editor could update the Dockerfile and
+			// pgdgUbuntuRelease together while leaving pgdgSuite stale
+			// (the pair-wise Dockerfile↔release check would still pass).
+			codename, known := ubuntuReleaseToCodename[pgdgUbuntuRelease]
+			Expect(known).To(BeTrue(),
+				"pgdgUbuntuRelease %q has no entry in ubuntuReleaseToCodename — add the version-number ↔ codename mapping in lockstep with any Dockerfile bump",
+				pgdgUbuntuRelease)
+			Expect(pgdgSuite).To(Equal(codename+"-pgdg"),
+				"pgdgSuite must follow the PGDG <codename>-pgdg convention for the Ubuntu release pinned by pgdgUbuntuRelease — bump pgdgSuite to %q to match",
+				codename+"-pgdg")
+		})
+
+		It("plan without --system shows the repository as skipped", func() {
+			// Without --system every system resource — including
+			// SystemPackageRepository, which post-#196 has a concrete
+			// installer — is forced to ActionSkip by buildResourceInfo.
+			//
+			// MatchRegexp pins the action label to the pgdg LINE so
+			// the assertion is meaningful even when other system
+			// resources appear in the same output with different
+			// actions. A loose ContainSubstring would still pass if
+			// SystemPackageRepository/pgdg were rendered with the
+			// wrong action and a sibling SystemPackageSet happened to
+			// be marked skip.
+			out, err := testExec.Exec("tomei", "plan", cfgPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).To(MatchRegexp(`SystemPackageRepository/pgdg[^\n]*\[⊘ skip\]`),
+				"plan output must show SystemPackageRepository/pgdg with the [⊘ skip] marker on the same line; got:\n%s", out)
+		})
+
+		It("plan --system shows install action for the repository", func() {
+			// Post-#196 contract: SystemPackageRepository is NOT
+			// skip-downgraded by addSystemResourceInfo. With --system and
+			// no prior state, the reconciler emits ActionInstall and the
+			// tree printer renders "[+ install]" on the pgdg line. This
+			// is the assertion that #214 (installer wiring) actually
+			// reaches the plan path.
+			//
+			// MatchRegexp pins [+ install] to the pgdg LINE specifically.
+			// On a first-run --system plan SystemInstaller/apt is also
+			// marked install, so a loose ContainSubstring would still
+			// pass even if the repository were silently downgraded.
+			out, err := testExec.Exec("tomei", "plan", "--system", cfgPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).To(MatchRegexp(`SystemPackageRepository/pgdg[^\n]*\[\+ install\]`),
+				"plan output must show SystemPackageRepository/pgdg with the [+ install] marker on the same line; got:\n%s", out)
+		})
+
+		// The three apply / idempotency / removal arms are PENDING rather
+		// than Skip()'d-with-a-message. Ginkgo's PIt reports the spec as
+		// "P" (pending, distinct from "S" skipped) in the suite summary,
+		// preserves the Label() for `ginkgo --label-filter` opt-in, and
+		// — crucially — distinguishes a stub-pending-implementation from
+		// an environment-gated Skip (a Skip() reading "needs gnupg" would
+		// silently disappear if the next contributor adds gnupg but
+		// forgets to flip the spec, while a PIt body remains a no-op
+		// until promoted to It). The follow-up PR will flip PIt -> It
+		// once gnupg lands in the runner image and the assertions are
+		// wired against real host state.
+		PIt("apply --system installs the repository on the host",
+			Label("needs-gnupg", "needs-network", "pending-197-followup"),
+			func() {
+				// Pending follow-up. When flipped to It, this spec must:
+				//   - assert /usr/share/keyrings/pgdg.gpg is present with
+				//     mode 0644 root:root,
+				//   - assert /etc/apt/sources.list.d/pgdg.list is present
+				//     and contains signed-by=/usr/share/keyrings/pgdg.gpg,
+				//     the spec URL, and "noble-pgdg main",
+				//   - assert ~/.local/share/tomei/system/state.json contains
+				//     a systemPackageRepositories.pgdg entry pinning
+				//     pgdgKeyHashSHA256.
+				_ = pgdgKeyHashSHA256
+			})
+
+		PIt("apply --system twice is idempotent",
+			Label("needs-gnupg", "needs-network", "pending-197-followup"),
+			func() {
+				// Pending follow-up. When flipped to It, run apply twice
+				// and assert the second `tomei plan --system` between runs
+				// shows no changes for SystemPackageRepository/pgdg.
+			})
+
+		PIt("removing the repo from the manifest cleans up files and state",
+			Label("needs-gnupg", "needs-network", "pending-197-followup"),
+			func() {
+				// Pending follow-up. When flipped to It, write a sibling
+				// manifest without pgdgRepo, re-apply, and assert that
+				//   - /usr/share/keyrings/pgdg.gpg is gone,
+				//   - /etc/apt/sources.list.d/pgdg.list is gone, and
+				//   - state.json no longer mentions pgdg.
+			})
 	})
 }


### PR DESCRIPTION
Mirror the existing SystemInstaller/SystemPackage validate+plan e2e
specs onto SystemPackageRepository so the post-#196 plan contract is
pinned: with --system the reconciler-determined action passes through
to the printer ([+ install] for an uninstalled repo) rather than the
skip-downgrade SystemPackageSet still receives. The PGDG repo
fixture (apt.postgresql.org) provides a stable third-party APT source
with a SHA256-pinned signing key (ACCC4CF8).

The apply / idempotency / removal arms remain Skip()'d stubs with
in-place documentation of the expected post-apply invariants. Adding
real apply coverage requires gnupg in the e2e runner image and stable
network access to apt.postgresql.org from CI, both out of scope for
this PR and tracked as the #197 follow-up.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
