### PR TITLE
feat(cmd): wire SystemPackageSet installer + populate InstalledVersions (#198)

### DIFF
--- a/cmd/tomei/apply.go
+++ b/cmd/tomei/apply.go
@@ -114,6 +114,14 @@ func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 		return fmt.Errorf("failed to expand sets: %w", err)
 	}
 
+	// Reject overlapping SystemPackageSet declarations before any host
+	// mutation. See resource.ValidateSystemPackageSetOverlap for the
+	// full rationale on why the apt installer's Remove / upgrade-drain
+	// paths are unsafe under multi-owner package state today.
+	if err := resource.ValidateSystemPackageSetOverlap(resources); err != nil {
+		return fmt.Errorf("apply rejected: %w", err)
+	}
+
 	// Split resources into user-kind and system-kind
 	userResources, systemResources := resource.FilterSystemKinds(resources)
 

--- a/cmd/tomei/apply.go
+++ b/cmd/tomei/apply.go
@@ -114,14 +114,6 @@ func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 		return fmt.Errorf("failed to expand sets: %w", err)
 	}
 
-	// Reject overlapping SystemPackageSet declarations before any host
-	// mutation. See resource.ValidateSystemPackageSetOverlap for the
-	// full rationale on why the apt installer's Remove / upgrade-drain
-	// paths are unsafe under multi-owner package state today.
-	if err := resource.ValidateSystemPackageSetOverlap(resources); err != nil {
-		return fmt.Errorf("apply rejected: %w", err)
-	}
-
 	// Split resources into user-kind and system-kind
 	userResources, systemResources := resource.FilterSystemKinds(resources)
 
@@ -135,6 +127,15 @@ func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 		fmt.Fprintf(w, "%d system resource(s) skipped. Use 'tomei apply --system' to manage.\n\n", len(systemResources))
 	}
 	if system && len(systemResources) > 0 {
+		// Reject overlapping SystemPackageSet declarations before any
+		// host mutation. Gated on `system` because without --system the
+		// system resources are skipped entirely and overlap is moot.
+		// See resource.ValidateSystemPackageSetOverlap for the full
+		// rationale on why the apt installer's Remove / upgrade-drain
+		// paths are unsafe under multi-owner package state today.
+		if err := resource.ValidateSystemPackageSetOverlap(systemResources); err != nil {
+			return fmt.Errorf("apply rejected: %w", err)
+		}
 		// Filter to resources with concrete installer implementations. As
 		// of #198 all system kinds have installers; the helper is retained
 		// so future system kinds can be staged through this channel.

--- a/cmd/tomei/apply.go
+++ b/cmd/tomei/apply.go
@@ -127,14 +127,16 @@ func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 		fmt.Fprintf(w, "%d system resource(s) skipped. Use 'tomei apply --system' to manage.\n\n", len(systemResources))
 	}
 	if system && len(systemResources) > 0 {
-		// Filter to resources with concrete installer implementations
+		// Filter to resources with concrete installer implementations. As
+		// of #198 all system kinds have installers; the helper is retained
+		// so future system kinds can be staged through this channel.
 		supported, skipped := filterSupportedSystemResources(systemResources)
 		supportedSystemResources = supported
 		if len(skipped) > 0 {
 			for _, r := range skipped {
-				slog.Info("skipping system resource (not yet implemented)", "kind", r.Kind(), "name", r.Name())
+				slog.Info("skipping system resource (no installer wired)", "kind", r.Kind(), "name", r.Name())
 			}
-			fmt.Fprintf(w, "%d system resource(s) skipped (not yet implemented: package management).\n\n", len(skipped))
+			fmt.Fprintf(w, "%d system resource(s) skipped (no installer wired for this kind).\n\n", len(skipped))
 		}
 	}
 

--- a/cmd/tomei/plan.go
+++ b/cmd/tomei/plan.go
@@ -101,9 +101,13 @@ func runPlan(cmd *cobra.Command, args []string) error {
 
 	// Reject overlapping SystemPackageSet declarations before plan emits
 	// an Upgrade/Remove that would tear down a multi-owner package.
+	// Gated on systemMode because without --system the system resources
+	// are forced to ActionSkip by buildResourceInfo and overlap is moot.
 	// See resource.ValidateSystemPackageSetOverlap for the rationale.
-	if err := resource.ValidateSystemPackageSetOverlap(resources); err != nil {
-		return fmt.Errorf("plan rejected: %w", err)
+	if systemMode {
+		if err := resource.ValidateSystemPackageSetOverlap(resources); err != nil {
+			return fmt.Errorf("plan rejected: %w", err)
+		}
 	}
 
 	updateCfg := engine.UpdateConfig{

--- a/cmd/tomei/plan.go
+++ b/cmd/tomei/plan.go
@@ -513,36 +513,19 @@ func addSystemResourceInfo(info map[graph.NodeID]graph.ResourceInfo, resources [
 	convertActions[*resource.SystemInstaller, *resource.SystemInstallerState](info, resource.KindSystemInstaller, installerActions)
 	convertActions[*resource.SystemPackageRepository, *resource.SystemPackageRepositoryState](info, resource.KindSystemPackageRepository, repoActions)
 	convertActions[*resource.SystemPackageSet, *resource.SystemPackageSetState](info, resource.KindSystemPackageSet, pkgActions)
-
-	// Mark SystemPackageSet resources as skip when they would require actions,
-	// since the concrete installer is not yet implemented (#198).
-	// SystemPackageRepository now has a concrete installer (#196), so it falls
-	// through with the reconciler-determined action.
-	for nodeID, ri := range info {
-		if ri.Kind == resource.KindSystemPackageSet {
-			if ri.Action != resource.ActionNone {
-				ri.Action = resource.ActionSkip
-				info[nodeID] = ri
-			}
-		}
-	}
 }
 
 // markAllSystemAsInstall marks all system resources as ActionInstall (first-run fallback).
+// All system kinds (SystemInstaller, SystemPackageRepository, SystemPackageSet)
+// have concrete installers as of #198, so every kind goes on the Install path.
 func markAllSystemAsInstall(info map[graph.NodeID]graph.ResourceInfo, resources []resource.Resource) {
 	for _, res := range resources {
 		if resource.IsSystemKind(res.Kind()) {
 			nodeID := graph.NewNodeID(res.Kind(), res.Name())
-			action := resource.ActionInstall
-			// SystemPackageSet not yet implemented (#198) — skip.
-			// SystemInstaller and SystemPackageRepository have concrete installers.
-			if res.Kind() == resource.KindSystemPackageSet {
-				action = resource.ActionSkip
-			}
 			info[nodeID] = graph.ResourceInfo{
 				Kind:   res.Kind(),
 				Name:   res.Name(),
-				Action: action,
+				Action: resource.ActionInstall,
 			}
 		}
 	}

--- a/cmd/tomei/plan.go
+++ b/cmd/tomei/plan.go
@@ -99,6 +99,13 @@ func runPlan(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to expand sets: %w", err)
 	}
 
+	// Reject overlapping SystemPackageSet declarations before plan emits
+	// an Upgrade/Remove that would tear down a multi-owner package.
+	// See resource.ValidateSystemPackageSetOverlap for the rationale.
+	if err := resource.ValidateSystemPackageSetOverlap(resources); err != nil {
+		return fmt.Errorf("plan rejected: %w", err)
+	}
+
 	updateCfg := engine.UpdateConfig{
 		SyncMode:       planCfg.syncRegistry,
 		UpdateTools:    planCfg.updateTools || planCfg.updateAll,

--- a/cmd/tomei/plan_test.go
+++ b/cmd/tomei/plan_test.go
@@ -203,7 +203,7 @@ func TestMarkAllSystemAsInstall(t *testing.T) {
 		assert.Equal(t, resource.ActionInstall, info[nodeID].Action)
 	})
 
-	t.Run("SystemPackageRepository gets ActionInstall (#196 wiring)", func(t *testing.T) {
+	t.Run("SystemPackageRepository gets ActionInstall (#196/#198 wiring)", func(t *testing.T) {
 		t.Parallel()
 		info := make(map[graph.NodeID]graph.ResourceInfo)
 		markAllSystemAsInstall(info, []resource.Resource{systemRepoResource("docker")})
@@ -214,15 +214,15 @@ func TestMarkAllSystemAsInstall(t *testing.T) {
 			"SystemPackageRepository must NOT be downgraded to Skip after #196 wired the concrete installer")
 	})
 
-	t.Run("SystemPackageSet still gets ActionSkip (until #198)", func(t *testing.T) {
+	t.Run("SystemPackageSet gets ActionInstall (post-#198)", func(t *testing.T) {
 		t.Parallel()
 		info := make(map[graph.NodeID]graph.ResourceInfo)
 		markAllSystemAsInstall(info, []resource.Resource{systemPackageSetResource("dev-tools")})
 
 		nodeID := graph.NewNodeID(resource.KindSystemPackageSet, "dev-tools")
 		require.Contains(t, info, nodeID)
-		assert.Equal(t, resource.ActionSkip, info[nodeID].Action,
-			"SystemPackageSet must still be downgraded to Skip until #198 lands the concrete installer")
+		assert.Equal(t, resource.ActionInstall, info[nodeID].Action,
+			"SystemPackageSet must NOT be downgraded to Skip after #198 wired the concrete installer")
 	})
 }
 
@@ -231,8 +231,9 @@ func TestAddSystemResourceInfo(t *testing.T) {
 
 	// Setup: TempDir-backed Paths so LoadReadOnly returns an empty SystemState
 	// (state.json absent → zero-value state per Store.readState). With empty
-	// state, the reconciler emits ActionInstall for both kinds; plan.go's
-	// downgrade loop then converts only SystemPackageSet → ActionSkip.
+	// state, the reconciler emits ActionInstall for both kinds; post-#198 the
+	// skip-downgrade loop is removed entirely, so every system kind passes
+	// through with the reconciler-determined action.
 	setup := func(t *testing.T) *path.Paths {
 		t.Helper()
 		systemDir := t.TempDir()
@@ -253,7 +254,7 @@ func TestAddSystemResourceInfo(t *testing.T) {
 			"reconciler emits ActionInstall; the addSystemResourceInfo skip-downgrade loop must NOT convert it back to Skip after #196")
 	})
 
-	t.Run("SystemPackageSet still gets ActionSkip (regression seatbelt)", func(t *testing.T) {
+	t.Run("SystemPackageSet gets ActionInstall (post-#198)", func(t *testing.T) {
 		t.Parallel()
 		paths := setup(t)
 		info := make(map[graph.NodeID]graph.ResourceInfo)
@@ -261,8 +262,8 @@ func TestAddSystemResourceInfo(t *testing.T) {
 
 		nodeID := graph.NewNodeID(resource.KindSystemPackageSet, "dev-tools")
 		require.Contains(t, info, nodeID)
-		assert.Equal(t, resource.ActionSkip, info[nodeID].Action,
-			"SystemPackageSet must still be downgraded to Skip until #198 wires the concrete installer")
+		assert.Equal(t, resource.ActionInstall, info[nodeID].Action,
+			"reconciler emits ActionInstall; the addSystemResourceInfo skip-downgrade loop was removed in #198 so SystemPackageSet must pass through")
 	})
 
 	t.Run("absent system data dir falls back to markAllSystemAsInstall", func(t *testing.T) {
@@ -285,8 +286,8 @@ func TestAddSystemResourceInfo(t *testing.T) {
 			"first-run fallback must put SystemPackageRepository on the Install path")
 		pkgID := graph.NewNodeID(resource.KindSystemPackageSet, "net-tools")
 		require.Contains(t, info, pkgID)
-		assert.Equal(t, resource.ActionSkip, info[pkgID].Action,
-			"first-run fallback must still Skip SystemPackageSet until #198")
+		assert.Equal(t, resource.ActionInstall, info[pkgID].Action,
+			"first-run fallback must put SystemPackageSet on the Install path post-#198")
 	})
 
 	t.Run("corrupt state.json falls back to markAllSystemAsInstall", func(t *testing.T) {
@@ -308,8 +309,8 @@ func TestAddSystemResourceInfo(t *testing.T) {
 	t.Run("SystemPackageRepository in state but absent from manifest gets ActionRemove", func(t *testing.T) {
 		t.Parallel()
 		// Pre-seed state with a SystemPackageRepository entry; pass an
-		// empty manifest. The reconciler emits ActionRemove; #196's
-		// skip-downgrade removal must NOT convert it to Skip.
+		// empty manifest. The reconciler emits ActionRemove; with the
+		// skip-downgrade loop removed in #198, the action must pass through.
 		systemDir := t.TempDir()
 		st := state.NewSystemState()
 		st.SystemPackageRepositories["docker"] = &resource.SystemPackageRepositoryState{
@@ -337,6 +338,6 @@ func TestAddSystemResourceInfo(t *testing.T) {
 		nodeID := graph.NewNodeID(resource.KindSystemPackageRepository, "docker")
 		require.Contains(t, info, nodeID)
 		assert.Equal(t, resource.ActionRemove, info[nodeID].Action,
-			"reconciler emits ActionRemove; the post-#196 skip-downgrade loop only touches SystemPackageSet so Remove must pass through")
+			"reconciler emits ActionRemove; the skip-downgrade loop was removed in #198 so Remove must pass through")
 	})
 }

--- a/cmd/tomei/system_engine.go
+++ b/cmd/tomei/system_engine.go
@@ -70,26 +70,47 @@ func (*unsupportedHostRepoInstaller) Remove(_ context.Context, st *resource.Syst
 	return nil
 }
 
-// skipPackageInstaller is a placeholder for SystemPackageSet operations.
-// Concrete implementations (e.g., APT apt-get install) are tracked in #198.
-type skipPackageInstaller struct{}
+// unsupportedHostPackageInstaller is the placeholder used when distro detection
+// fails or the host lacks a supported package manager. Install surfaces a
+// clear platform-availability error instead of letting raw apt exec failures
+// escape. Remove returns nil so re-imaged hosts can drop stale state entries;
+// a warn log captures the host limitation and the orphaned packages so
+// dotfile-sync users can audit the originating host.
+type unsupportedHostPackageInstaller struct{}
 
-func (*skipPackageInstaller) Install(_ context.Context, _ *resource.SystemPackageSet, name string) (*resource.SystemPackageSetState, error) {
-	return nil, fmt.Errorf("system: package %q: not yet implemented", name)
+func (*unsupportedHostPackageInstaller) Install(_ context.Context, _ *resource.SystemPackageSet, name string) (*resource.SystemPackageSetState, error) {
+	// %q Go-quotes control chars in name, defanging log-injection via a
+	// crafted manifest name.
+	return nil, fmt.Errorf("system: package %q: requires a supported Linux package manager (apt) on this host", name)
 }
 
-func (*skipPackageInstaller) Remove(_ context.Context, _ *resource.SystemPackageSetState, name string) error {
-	return fmt.Errorf("system: package %q: not yet implemented", name)
+func (*unsupportedHostPackageInstaller) Remove(_ context.Context, st *resource.SystemPackageSetState, name string) error {
+	// Allow stale state cleanup on hosts that lost (or never had) apt support.
+	// Warn so cross-host state sync (e.g., dotfile sync between a Linux box
+	// and a macOS box) does not silently leave the actual packages installed
+	// on the host that originally ran the install. Surface the recorded
+	// Packages list so a curious user can clean them up on the originating
+	// host.
+	var orphaned []string
+	if st != nil {
+		orphaned = st.Packages
+	}
+	slog.Warn("removing state entry for system package set without touching actual packages; this host cannot manage apt packages",
+		"name", name, "orphaned_packages", orphaned)
+	return nil
 }
 
 // filterSupportedSystemResources splits system resources into those that have
-// a concrete installer (SystemInstaller, SystemPackageRepository) and those
-// that do not (currently SystemPackageSet, #198). Callers warn and skip the
-// unsupported group.
+// a concrete installer (SystemInstaller, SystemPackageRepository,
+// SystemPackageSet) and those that do not. Callers warn and skip the
+// unsupported group. As of #198 all system kinds have concrete installers,
+// so the unsupported set is empty in practice — the helper is retained so
+// future system kinds can be staged through the same skip channel without
+// reshaping apply.go.
 func filterSupportedSystemResources(resources []resource.Resource) (supported, skipped []resource.Resource) {
 	for _, res := range resources {
 		switch res.Kind() {
-		case resource.KindSystemInstaller, resource.KindSystemPackageRepository:
+		case resource.KindSystemInstaller, resource.KindSystemPackageRepository, resource.KindSystemPackageSet:
 			supported = append(supported, res)
 		default:
 			skipped = append(skipped, res)
@@ -126,6 +147,34 @@ func selectRepoInstaller(
 	return aptClient.PackageRepositoryInstaller(downloader)
 }
 
+// selectPackageInstaller returns the executor.Installer for SystemPackageSet
+// resources. Mirrors selectRepoInstaller: the apt-backed installer is
+// returned only when distro detection succeeded AND the detected distro
+// family lists APT as a supported package manager. On any other host
+// (macOS, minimal containers, or non-apt Linux distros such as
+// Fedora/Arch/Alpine where DetectDistro succeeds but APT is not native)
+// the placeholder is returned, whose Install fails with the documented
+// "requires a supported Linux package manager (apt) on this host" error
+// and whose Remove permits state cleanup with a warn log.
+//
+// Extracted as a pure helper so the conditional wiring can be unit-tested
+// without depending on real distro detection. Defense-in-depth: the helper
+// falls back to the placeholder when aptClient is nil, even though
+// createSystemEngine constructs aptClient unconditionally and that path is
+// unreachable from production code.
+func selectPackageInstaller(
+	validator *system.Validator,
+	aptClient *apt.Client,
+) executor.Installer[*resource.SystemPackageSet, *resource.SystemPackageSetState] {
+	if validator == nil || aptClient == nil {
+		return &unsupportedHostPackageInstaller{}
+	}
+	if !slices.Contains(validator.SupportedInstallers(), system.PackageManagerAPT) {
+		return &unsupportedHostPackageInstaller{}
+	}
+	return aptClient.PackageSetInstaller()
+}
+
 // createSystemEngine builds a SystemEngine wired with the concrete installers
 // available on this host. The system state directory is created lazily by
 // state.NewStore — createSystemEngine itself performs no filesystem writes.
@@ -133,6 +182,11 @@ func selectRepoInstaller(
 // token wrapping) because vendor GPG keys do not require GitHub auth and
 // attaching a PAT to manifest-supplied github.com URLs would be a token-leak
 // risk.
+//
+// On non-apt hosts (macOS, minimal containers, or non-apt Linux distros such
+// as Fedora/Arch/Alpine) selectRepoInstaller and selectPackageInstaller
+// return platform-availability placeholders whose Install fails with a clear
+// error and whose Remove permits state cleanup with a warn log.
 func createSystemEngine(systemDataDir string, downloader download.Downloader) (*engine.SystemEngine, error) {
 	if downloader == nil {
 		return nil, errors.New("downloader is required")
@@ -144,12 +198,13 @@ func createSystemEngine(systemDataDir string, downloader download.Downloader) (*
 	}
 
 	// aptClient is constructed unconditionally: command.NewExecutor is stateless
-	// and the apt Client is the shared hub used by both the validator's
-	// VersionFunc and the repository installer. On non-apt hosts the Client
-	// exists but is never invoked — selectRepoInstaller returns the placeholder
-	// when either (a) validator is nil because distro detection failed (macOS,
-	// minimal containers) or (b) validator is non-nil but the detected distro
-	// family does not list APT (Fedora/Arch/Alpine).
+	// and the apt Client is the shared hub used by the validator's VersionFunc,
+	// the repository installer, and the package set installer. On non-apt
+	// hosts the Client exists but is never invoked — selectRepoInstaller and
+	// selectPackageInstaller return placeholders when either (a) validator is
+	// nil because distro detection failed (macOS, minimal containers) or (b)
+	// validator is non-nil but the detected distro family does not list APT
+	// (Fedora/Arch/Alpine).
 	aptClient := apt.New(command.NewExecutor(""))
 
 	// Distro detection and validator creation are best-effort. When unavailable
@@ -172,11 +227,12 @@ func createSystemEngine(systemDataDir string, downloader download.Downloader) (*
 	}
 
 	repoInstaller := selectRepoInstaller(validator, aptClient, downloader)
+	packageInstaller := selectPackageInstaller(validator, aptClient)
 
 	eng := engine.NewSystemEngine(
 		&validatorInstaller{validator: validator},
 		repoInstaller,
-		&skipPackageInstaller{},
+		packageInstaller,
 		store,
 	)
 	return eng, nil

--- a/cmd/tomei/system_engine.go
+++ b/cmd/tomei/system_engine.go
@@ -197,6 +197,29 @@ func createSystemEngine(systemDataDir string, downloader download.Downloader) (*
 		return nil, fmt.Errorf("system: state store: %w", err)
 	}
 
+	// Detect legacy state-overlap drift before building the engine.
+	// state.json could contain overlapping SystemPackageSet entries from
+	// an older tomei version that didn't enforce desired-state overlap
+	// (or from manual edits). If we proceeded, a subsequent Remove or
+	// upgrade drain on one of the overlapping sets would tear down a
+	// package another set still claims to own — with no manifest-side
+	// gate to catch it (the desired-state validator only sees current
+	// resources). Refuse to build the engine; the user must edit
+	// state.json so each package has exactly one owner before re-running.
+	if st, err := store.LoadReadOnly(); err != nil {
+		// LoadReadOnly returns an empty state when the file is missing,
+		// so any error here is a real problem (permission, malformed
+		// JSON). Surface it as a warn — the executor will error more
+		// precisely when it tries to write, and we should not block
+		// `tomei apply --system` on a read-side hiccup the executor
+		// can recover from.
+		slog.Warn("system: failed to read state for overlap drift check; proceeding", "error", err)
+	} else if st != nil {
+		if err := resource.ValidateSystemPackageSetStateOverlap(st.SystemPackages); err != nil {
+			return nil, fmt.Errorf("system: %w", err)
+		}
+	}
+
 	// aptClient is constructed unconditionally: command.NewExecutor is stateless
 	// and the apt Client is the shared hub used by the validator's VersionFunc,
 	// the repository installer, and the package set installer. On non-apt

--- a/cmd/tomei/system_engine_test.go
+++ b/cmd/tomei/system_engine_test.go
@@ -108,25 +108,78 @@ func TestUnsupportedHostRepoInstaller_Remove(t *testing.T) {
 	})
 }
 
-func TestSkipPackageInstaller(t *testing.T) {
+func TestUnsupportedHostPackageInstaller_Install(t *testing.T) {
 	t.Parallel()
-	installer := &skipPackageInstaller{}
+	installer := &unsupportedHostPackageInstaller{}
 
-	t.Run("Install", func(t *testing.T) {
-		t.Parallel()
-		_, err := installer.Install(context.Background(), nil, "dev-tools")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "not yet implemented")
-		assert.Contains(t, err.Error(), "system: package")
-		assert.Contains(t, err.Error(), "dev-tools")
+	_, err := installer.Install(context.Background(), nil, "dev-tools")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires a supported Linux package manager")
+	assert.Contains(t, err.Error(), "dev-tools")
+}
+
+func TestUnsupportedHostPackageInstaller_Install_QuotesControlChars(t *testing.T) {
+	t.Parallel()
+	// %q Go-quotes control characters in the name, defanging log-injection
+	// via crafted manifest names. Verify the literal \n (two chars) appears
+	// in the error string rather than a raw newline.
+	installer := &unsupportedHostPackageInstaller{}
+
+	_, err := installer.Install(context.Background(), nil, "pkg\nINJECT")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `\n`, "name with newline must be Go-quoted in error message")
+	assert.NotContains(t, err.Error(), "pkg\nINJECT", "raw newline must not appear in error message")
+}
+
+func TestUnsupportedHostPackageInstaller_Remove(t *testing.T) {
+	// Cannot t.Parallel(): slog.SetDefault mutates global state.
+	// Subtests below run sequentially for the same reason — DO NOT add
+	// t.Parallel() inside the subtests; capture-then-cleanup breaks because
+	// parallel siblings would race on the same process-global default
+	// logger.
+	installer := &unsupportedHostPackageInstaller{}
+
+	capture := func(t *testing.T) *bytes.Buffer {
+		t.Helper()
+		// Pattern mirrors internal/state/store_test.go.
+		var buf bytes.Buffer
+		handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
+		oldLogger := slog.Default()
+		slog.SetDefault(slog.New(handler))
+		t.Cleanup(func() { slog.SetDefault(oldLogger) })
+		return &buf
+	}
+
+	t.Run("nil state returns nil and warns", func(t *testing.T) {
+		buf := capture(t)
+		err := installer.Remove(context.Background(), nil, "dev-tools")
+		require.NoError(t, err, "Remove must return nil so stale state can be cleaned up")
+		assert.Contains(t, buf.String(), "name=dev-tools", "warn log must include the package set name attribute for cross-host visibility")
+		assert.Contains(t, buf.String(), "package set", "warn log must mention the resource kind")
 	})
 
-	t.Run("Remove", func(t *testing.T) {
-		t.Parallel()
-		err := installer.Remove(context.Background(), nil, "dev-tools")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "not yet implemented")
-		assert.Contains(t, err.Error(), "system: package")
+	t.Run("non-nil state surfaces orphaned packages", func(t *testing.T) {
+		buf := capture(t)
+		st := &resource.SystemPackageSetState{
+			Packages: []string{"git", "curl"},
+		}
+		err := installer.Remove(context.Background(), st, "dev-tools")
+		require.NoError(t, err)
+		// Forensic visibility: which actual packages survive on the originating host.
+		assert.Contains(t, buf.String(), "orphaned_packages",
+			"warn log must include orphaned_packages so dotfile-sync users can audit the originating host")
+		assert.Contains(t, buf.String(), "git", "warn log must include the orphaned package names")
+	})
+
+	t.Run("name with control chars is escaped in warn log", func(t *testing.T) {
+		buf := capture(t)
+		err := installer.Remove(context.Background(), nil, "pkg\nINJECT")
+		require.NoError(t, err)
+		// slog.NewTextHandler quotes string attributes that contain control
+		// chars (logfmt-style strconv-quoted), so a raw newline does not
+		// land in the log stream.
+		assert.NotContains(t, buf.String(), "\nINJECT",
+			"control chars in name must not produce a raw newline in the warn log")
 	})
 }
 
@@ -189,6 +242,53 @@ func TestSelectRepoInstaller(t *testing.T) {
 	})
 }
 
+func TestSelectPackageInstaller(t *testing.T) {
+	t.Parallel()
+	aptClient := apt.New(command.NewExecutor(""))
+
+	aptValidator, err := system.NewValidator(&system.DistroInfo{ID: "debian"}, nil)
+	require.NoError(t, err)
+	dnfValidator, err := system.NewValidator(&system.DistroInfo{ID: "fedora"}, nil)
+	require.NoError(t, err)
+
+	t.Run("validator nil returns placeholder", func(t *testing.T) {
+		t.Parallel()
+		got := selectPackageInstaller(nil, aptClient)
+		_, ok := got.(*unsupportedHostPackageInstaller)
+		assert.True(t, ok, "nil validator must return *unsupportedHostPackageInstaller, got %T", got)
+	})
+
+	t.Run("apt-supporting distro returns non-placeholder", func(t *testing.T) {
+		t.Parallel()
+		got := selectPackageInstaller(aptValidator, aptClient)
+		require.NotNil(t, got)
+		// Negative assertion (rather than positive type-assert against
+		// *apt.PackageSetInstaller) keeps the test resilient to a future
+		// apt type rename. We only care that the placeholder is NOT
+		// returned on an apt host.
+		_, isPlaceholder := got.(*unsupportedHostPackageInstaller)
+		assert.False(t, isPlaceholder, "apt-supporting distro must not return placeholder, got %T", got)
+	})
+
+	t.Run("non-apt distro returns placeholder", func(t *testing.T) {
+		t.Parallel()
+		// Fedora supports DNF, not APT. Distro detection succeeds, so the
+		// validator is non-nil — but the host has no APT support. Without
+		// this gate the apt installer would run on Fedora and surface raw
+		// apt errors instead of the documented platform-availability error.
+		got := selectPackageInstaller(dnfValidator, aptClient)
+		_, ok := got.(*unsupportedHostPackageInstaller)
+		assert.True(t, ok, "non-apt distro must return placeholder, got %T", got)
+	})
+
+	t.Run("nil aptClient returns placeholder (defense-in-depth)", func(t *testing.T) {
+		t.Parallel()
+		got := selectPackageInstaller(aptValidator, nil)
+		_, ok := got.(*unsupportedHostPackageInstaller)
+		assert.True(t, ok, "nil aptClient must return placeholder, got %T", got)
+	})
+}
+
 func TestCreateSystemEngine_NilDownloader(t *testing.T) {
 	t.Parallel()
 	// Defense-in-depth: the sole production caller (apply.go) always
@@ -244,28 +344,33 @@ func TestFilterSupportedSystemResources(t *testing.T) {
 
 	t.Run("packageset only", func(t *testing.T) {
 		t.Parallel()
+		// SystemPackageSet has a concrete installer as of #198, so it
+		// goes into supported.
 		resources := []resource.Resource{
 			&resource.SystemPackageSet{BaseResource: resource.BaseResource{ResourceKind: resource.KindSystemPackageSet, Metadata: resource.Metadata{Name: "dev-tools"}}},
 		}
 		supported, skipped := filterSupportedSystemResources(resources)
-		assert.Empty(t, supported)
-		require.Len(t, skipped, 1)
-		assert.Equal(t, "dev-tools", skipped[0].Name())
+		require.Len(t, supported, 1)
+		assert.Equal(t, "dev-tools", supported[0].Name())
+		assert.Empty(t, skipped)
 	})
 
 	t.Run("mixed", func(t *testing.T) {
 		t.Parallel()
+		// All three system kinds now have concrete installers (#196 +
+		// #198); the helper is retained for future kinds so the skipped
+		// channel is intentionally empty here.
 		resources := []resource.Resource{
 			&resource.SystemInstaller{BaseResource: resource.BaseResource{ResourceKind: resource.KindSystemInstaller, Metadata: resource.Metadata{Name: "apt"}}},
 			&resource.SystemPackageRepository{BaseResource: resource.BaseResource{ResourceKind: resource.KindSystemPackageRepository, Metadata: resource.Metadata{Name: "docker-repo"}}},
 			&resource.SystemPackageSet{BaseResource: resource.BaseResource{ResourceKind: resource.KindSystemPackageSet, Metadata: resource.Metadata{Name: "dev-tools"}}},
 		}
 		supported, skipped := filterSupportedSystemResources(resources)
-		require.Len(t, supported, 2)
+		require.Len(t, supported, 3)
 		// Order matches input order — append-based filter is deterministic.
 		assert.Equal(t, "apt", supported[0].Name())
 		assert.Equal(t, "docker-repo", supported[1].Name())
-		require.Len(t, skipped, 1)
-		assert.Equal(t, "dev-tools", skipped[0].Name())
+		assert.Equal(t, "dev-tools", supported[2].Name())
+		assert.Empty(t, skipped)
 	})
 }

--- a/cmd/tomei/validate.go
+++ b/cmd/tomei/validate.go
@@ -53,6 +53,15 @@ func runValidate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("validation failed: %w", err)
 	}
 
+	// Reject manifests where the same OS package is declared by more
+	// than one SystemPackageSet. Without this gate, dropping one of the
+	// overlapping sets would uninstall the package while the other
+	// set's state still recorded it as installed — see
+	// resource.ValidateSystemPackageSetOverlap for the full rationale.
+	if err := resource.ValidateSystemPackageSetOverlap(resources); err != nil {
+		return fmt.Errorf("validation failed: %w", err)
+	}
+
 	// Validate each resource's spec
 	cmd.Println("Resources:")
 	validationFailed := false

--- a/docs/cue-schema.md
+++ b/docs/cue-schema.md
@@ -392,8 +392,6 @@ Single-package shorthand for [SystemPackageSet](#systempackageset). A `SystemPac
 
 Use `SystemPackage` when you want to declare an OS package as its own resource (one resource per package, with its own `metadata.name` and dependency edges). Use [SystemPackageSet](#systempackageset) for batched declarations.
 
-> **Note:** Like `SystemPackageSet`, the concrete installer is **not yet implemented** — declared `SystemPackage` resources expand to `SystemPackageSet` and are shown as `skip` in plan when changes would be required, then skipped at apply time with a warning.
-
 ```cue
 git: {
     apiVersion: "tomei.terassyi.net/v1beta1"
@@ -430,7 +428,7 @@ docker: {
 
 ### SystemPackageSet
 
-Set of system packages installed via a [SystemInstaller](#systeminstaller). The CUE schema accepts the resource and the reconciler computes plan actions, but the concrete installer is **not yet implemented** — declared package sets (and their shorthand [SystemPackage](#systempackage)) are shown as `skip` in plan when changes would be required, and skipped at apply time with a warning.
+Set of system packages installed via a [SystemInstaller](#systeminstaller). The concrete installer (APT-based) runs `apt-get install` / `apt-get remove` and probes installed versions via `dpkg-query` after install. On non-apt hosts the resource fails with a clear "platform unsupported" error.
 
 ```cue
 // Distribution-provided packages — no repositoryRef

--- a/docs/design.md
+++ b/docs/design.md
@@ -247,17 +247,13 @@ SystemInstaller → SystemPackageRepository → SystemPackageSet
 | `SystemInstaller` (`apt`) | Validates that `apt-get` exists on the host and captures its version |
 | `SystemInstaller` (other) | Schema accepts `dnf`/`zypper`/`pacman`/`apk`, but only `apt` is currently wired. Other package managers fail validation either with "package manager is not supported on this system" (distro mismatch) or "no version function registered" (supported by distro detection but not yet wired in the engine) |
 | `SystemPackageRepository` | Concrete installer wired (APT). Places the GPG keyring under `/usr/share/keyrings/<name>.gpg`, writes the source entry to `/etc/apt/sources.list.d/<name>.list`, and runs `apt-get update`. On hosts where distro detection fails or no supported package manager is present, install fails with `system: repository "<name>": requires a supported Linux package manager (apt) on this host`; Remove returns successfully with a warn log so stale state can be drained without touching the originating host's files. |
-| `SystemPackageSet` | Concrete installer not yet implemented (planned: `apt-get install`). Recognized by plan/apply but skipped at runtime |
+| `SystemPackageSet` | Concrete installer wired (APT). Runs `apt-get install` / `apt-get remove` and probes installed versions via `dpkg-query` after install. On hosts where distro detection fails or no supported package manager is present, install fails with `system: package "<name>": requires a supported Linux package manager (apt) on this host`; Remove returns successfully with a warn log so stale state can be drained without touching the originating host's packages. |
 
-`tomei plan --system` and `tomei apply --system` recognize all three kinds. `SystemPackageSet` is still shown as `skip` in plan and skipped at apply time with a warning. `SystemInstaller` and `SystemPackageRepository` execute through their respective concrete installers.
+`tomei plan --system` and `tomei apply --system` recognize all three kinds and execute through their respective concrete installers.
 
 `SystemInstaller` removal does not uninstall the OS package manager — it only clears the state entry.
 
 ## 11. Roadmap
-
-### System package installers
-
-Concrete installer implementations for `SystemPackageRepository` (`add-apt-repository`, `apt-key` / `/etc/apt/keyrings`) and `SystemPackageSet` (`apt-get install` / `apt-get remove`) are tracked in [#162](https://github.com/terassyi/tomei/issues/162).
 
 ### Private repository access
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -272,8 +272,8 @@ System resources:
 |------|---------|
 | `SystemInstaller` | Declares a host package manager (currently `apt` only). Validates the package manager is available and captures its version. |
 | `SystemPackageRepository` | Third-party APT repository (e.g., Docker, Kubernetes). Concrete installer (APT-based) places the GPG keyring at `/usr/share/keyrings/<name>.gpg`, writes the source entry to `/etc/apt/sources.list.d/<name>.list`, and runs `apt-get update`. On non-apt hosts the resource fails with a clear "platform unsupported" error. |
-| `SystemPackage` | Single-package shorthand for `SystemPackageSet`. Expands to a one-element set at load time; same skip behavior. |
-| `SystemPackageSet` | Set of system packages to install. Concrete installer is **not yet implemented** — declared resources are shown as `skip` in plan when changes would be required. |
+| `SystemPackage` | Single-package shorthand for `SystemPackageSet`. Expands to a one-element set at load time; same execution path. |
+| `SystemPackageSet` | Set of system packages to install. Concrete installer (APT-based) runs `apt-get install` / `apt-get remove` and probes installed versions via `dpkg-query`. On non-apt hosts the resource fails with a clear "platform unsupported" error. |
 
 Example manifest (no preset ships for `apt` — declare it inline):
 

--- a/internal/installer/apt/apt.go
+++ b/internal/installer/apt/apt.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -420,6 +421,65 @@ func (c *Client) Update(ctx context.Context) error {
 	return nil
 }
 
+// SimulateRemoveCascade returns the full list of packages apt-get would
+// remove if asked to remove `pkgs`, including transitive cascades that
+// apt's reverse-dependency handling pulls in. Used to pre-flight an
+// upgrade drain so a cascade that would remove a package the manifest
+// still relies on surfaces as a clear error before any host mutation.
+//
+// The shell command executed is:
+//
+//	sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get -s remove -y -o DPkg::Lock::Timeout=60 -- <pkgs>
+//
+// LC_ALL=C is load-bearing: apt prefixes each removal line with the
+// literal "Remv " in C locale; non-C locales translate the prefix and
+// would silently break the parser.
+//
+// The returned list is sorted and deduplicated. Empty input returns
+// (nil, nil) without invoking apt-get.
+func (c *Client) SimulateRemoveCascade(ctx context.Context, pkgs []string) ([]string, error) {
+	if len(pkgs) == 0 {
+		return nil, nil
+	}
+	for _, pkg := range pkgs {
+		if pkg == "" {
+			return nil, errors.New("apt: empty package name in simulate-remove list")
+		}
+		if strings.ContainsAny(pkg, disallowedInPackageName) {
+			return nil, fmt.Errorf("apt: package %q contains disallowed characters", pkg)
+		}
+	}
+	cmd := "sudo -n " + aptGetEnvPrefix +
+		" apt-get -s remove -y -o DPkg::Lock::Timeout=60 -- " +
+		strings.Join(pkgs, " ")
+	output, err := c.runner.ExecuteCapture(ctx, []string{cmd}, command.Vars{}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("apt: simulate-remove %q: %w", pkgs, err)
+	}
+	seen := make(map[string]bool)
+	var removed []string
+	for line := range strings.SplitSeq(output, "\n") {
+		line = strings.TrimSpace(line)
+		// apt's simulate-mode emits one "Remv PKGNAME [VERSION]" line per
+		// package it would actually uninstall (target + cascades). Any
+		// other apt status line (Inst, Conf, Reading, etc.) is ignored.
+		if !strings.HasPrefix(line, "Remv ") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		pkg := fields[1]
+		if !seen[pkg] {
+			seen[pkg] = true
+			removed = append(removed, pkg)
+		}
+	}
+	sort.Strings(removed)
+	return removed, nil
+}
+
 // PackageSetInstaller installs and removes SystemPackageSet resources via
 // apt-get. It satisfies executor.Installer[*resource.SystemPackageSet,
 // *resource.SystemPackageSetState].
@@ -559,6 +619,27 @@ func (p *PackageSetInstaller) Install(ctx context.Context, res *resource.SystemP
 			}
 		}
 		if len(toRemove) > 0 {
+			// Pre-flight the drain via apt-get -s to detect cascades.
+			// apt's reverse-dependency handling can pull packages we
+			// did NOT name into the removal — including packages the
+			// new spec still relies on (e.g. shrinking [cowsay, perl]
+			// → [cowsay] would normally cascade-remove cowsay because
+			// cowsay depends on perl). Catching this BEFORE the actual
+			// remove avoids a state-vs-host drift where state.json
+			// records "cowsay installed" but the host no longer has it.
+			cascade, err := p.client.SimulateRemoveCascade(ctx, toRemove)
+			if err != nil {
+				return nil, fmt.Errorf("apt: package set %q: simulate upgrade drain %v: %w", name, toRemove, err)
+			}
+			var cascadeIntoSpec []string
+			for _, pkg := range cascade {
+				if newSet[pkg] {
+					cascadeIntoSpec = append(cascadeIntoSpec, pkg)
+				}
+			}
+			if len(cascadeIntoSpec) > 0 {
+				return nil, fmt.Errorf("apt: package set %q: upgrade drain %v would cascade-remove %v from the new spec; do not split dependent packages across SystemPackageSets (consider declaring the dependency chain in a single set)", name, toRemove, cascadeIntoSpec)
+			}
 			if err := p.runRemove(ctx, toRemove); err != nil {
 				return nil, fmt.Errorf("apt: package set %q: upgrade drain %v: %w", name, toRemove, err)
 			}

--- a/internal/installer/apt/apt.go
+++ b/internal/installer/apt/apt.go
@@ -499,9 +499,14 @@ func (p *PackageSetInstaller) Install(ctx context.Context, res *resource.SystemP
 			// The rollback uses a fresh ctx with a bounded timeout
 			// (not the caller's ctx) so a caller cancellation that
 			// triggered the probe failure does not cascade into the
-			// undo. 60s is slightly above DPkg::Lock::Timeout=60 so a
-			// genuinely-stuck dpkg-frontend lock surfaces as a
-			// rollback failure rather than blocking apply indefinitely.
+			// undo. The deadline is strictly GREATER than apt-get's own
+			// DPkg::Lock::Timeout=60 so that under lock contention the
+			// child apt-get reaches its lock-timeout error and returns
+			// a meaningful exit status before this ctx kills it from
+			// outside (which would surface only as ctx.DeadlineExceeded
+			// and lose the lock-contention root cause). 90s = 60s lock
+			// wait + 30s headroom for the rollback's own dpkg
+			// transaction (worst-case ≪ install transaction).
 			var toRollback []string
 			for _, p := range spec.Packages {
 				if !wasInstalled[p] {
@@ -509,7 +514,7 @@ func (p *PackageSetInstaller) Install(ctx context.Context, res *resource.SystemP
 				}
 			}
 			if len(toRollback) > 0 {
-				rbCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+				rbCtx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 				if rbErr := p.runRemove(rbCtx, toRollback); rbErr != nil {
 					slog.Warn("apt: package set rollback failed; host may have orphaned packages",
 						"reason", "after post-install version probe failure",

--- a/internal/installer/apt/apt.go
+++ b/internal/installer/apt/apt.go
@@ -10,6 +10,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
+	"slices"
 	"strings"
 	"time"
 
@@ -430,8 +432,10 @@ type PackageSetInstaller struct {
 var _ executor.Installer[*resource.SystemPackageSet, *resource.SystemPackageSetState] = (*PackageSetInstaller)(nil)
 
 // Install runs the apt-get install for the resource's packages and returns
-// the new state. The InstalledVersions field is left empty until the
-// dpkg-query helper lands; the install action itself is complete.
+// the new state. InstalledVersions is populated via dpkg-query per package
+// after the install completes; a probe failure aborts the Install. A
+// successful Install for which we cannot read versions is a state-store
+// consistency bug, so we surface it rather than degrade to an empty map.
 //
 // The shell command executed is:
 //
@@ -441,16 +445,103 @@ var _ executor.Installer[*resource.SystemPackageSet, *resource.SystemPackageSetS
 //
 // Callers are responsible for ensuring a recent "apt-get update" has run
 // when stale package indexes would cause 404s.
-func (p *PackageSetInstaller) Install(ctx context.Context, res *resource.SystemPackageSet, _ string) (*resource.SystemPackageSetState, error) {
+func (p *PackageSetInstaller) Install(ctx context.Context, res *resource.SystemPackageSet, name string) (*resource.SystemPackageSetState, error) {
+	if res == nil || res.SystemPackageSetSpec == nil {
+		return nil, fmt.Errorf("apt: package set %q: nil spec", name)
+	}
 	spec := res.SystemPackageSetSpec
+	// Validate at the apt boundary as defense-in-depth: the CUE schema
+	// and the spec's own Validate are upstream layers, but the apt
+	// installer must not assume callers ran them. Mirrors the
+	// PackageRepository installer's `apt: repository %q: %w` wrap.
+	if err := spec.Validate(); err != nil {
+		return nil, fmt.Errorf("apt: package set %q: %w", name, err)
+	}
+	// Upgrade-time package drainage: when the executor invokes Install
+	// as part of an Upgrade/Reinstall action, it surfaces the prior
+	// state's package list via executor.OldPackagesFromContext. Any
+	// package present in the old state but absent from the new spec
+	// must be uninstalled from the host — otherwise the generic
+	// "upgrade = re-run Install" flow leaves dropped packages running
+	// with no state tracking. Drainage runs BEFORE the new-spec install
+	// so a runInstall failure does not leave the host in a half-drained
+	// state with orphan packages that have already been removed.
+	if oldPkgs := executor.OldPackagesFromContext(ctx); len(oldPkgs) > 0 {
+		newSet := make(map[string]bool, len(spec.Packages))
+		for _, pkg := range spec.Packages {
+			newSet[pkg] = true
+		}
+		var toRemove []string
+		for _, pkg := range oldPkgs {
+			if !newSet[pkg] {
+				toRemove = append(toRemove, pkg)
+			}
+		}
+		if len(toRemove) > 0 {
+			if err := p.runRemove(ctx, toRemove); err != nil {
+				return nil, fmt.Errorf("apt: package set %q: upgrade drain %v: %w", name, toRemove, err)
+			}
+		}
+	}
+	// Snapshot pre-install state so a later rollback removes ONLY the
+	// packages this Install action placed. Without this snapshot, a
+	// probe failure for one package would uninstall every package in
+	// the spec — including ones the user (or another SystemPackageSet)
+	// had on the host before this apply. apt-get install no-ops on an
+	// already-installed package, so the post-install state alone cannot
+	// distinguish "this Install placed it" from "it was already here."
+	wasInstalled := make(map[string]bool, len(spec.Packages))
+	for _, pkg := range spec.Packages {
+		installed, err := p.client.IsInstalled(ctx, pkg)
+		if err != nil {
+			return nil, fmt.Errorf("apt: package set %q: snapshot pre-install state of %q: %w", name, pkg, err)
+		}
+		wasInstalled[pkg] = installed
+	}
 	if err := p.runInstall(ctx, spec.Packages); err != nil {
 		return nil, err
+	}
+	versions := make(map[string]string, len(spec.Packages))
+	for _, pkg := range spec.Packages {
+		v, err := p.client.PackageVersion(ctx, pkg)
+		if err != nil {
+			// runInstall placed the packages on the host, but the
+			// post-install probe cannot read a consistent version map
+			// — Install must not return a state that lies about what
+			// is on the host. Mirror PackageRepositoryInstaller's
+			// best-effort rollback (repository.go) and undo only the
+			// packages this Install action newly placed.
+			//
+			// The rollback uses a fresh ctx with a bounded timeout
+			// (not the caller's ctx) so a caller cancellation that
+			// triggered the probe failure does not cascade into the
+			// undo. 60s is slightly above DPkg::Lock::Timeout=60 so a
+			// genuinely-stuck dpkg-frontend lock surfaces as a
+			// rollback failure rather than blocking apply indefinitely.
+			var toRollback []string
+			for _, p := range spec.Packages {
+				if !wasInstalled[p] {
+					toRollback = append(toRollback, p)
+				}
+			}
+			if len(toRollback) > 0 {
+				rbCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+				if rbErr := p.runRemove(rbCtx, toRollback); rbErr != nil {
+					slog.Warn("apt: package set rollback failed; host may have orphaned packages",
+						"reason", "after post-install version probe failure",
+						"name", name, "packages", toRollback, "rollback_error", rbErr, "trigger_error", err)
+				}
+				cancel()
+			}
+			return nil, fmt.Errorf("apt: package set %q: probe version of %q: %w", name, pkg, err)
+		}
+		versions[pkg] = v
 	}
 	return &resource.SystemPackageSetState{
 		InstallerRef:      spec.InstallerRef,
 		RepositoryRef:     spec.RepositoryRef,
-		Packages:          append([]string(nil), spec.Packages...),
-		InstalledVersions: map[string]string{},
+		Packages:          slices.Clone(spec.Packages),
+		InstalledVersions: versions,
 		UpdatedAt:         time.Now(),
 	}, nil
 }

--- a/internal/installer/apt/apt.go
+++ b/internal/installer/apt/apt.go
@@ -457,31 +457,15 @@ func (p *PackageSetInstaller) Install(ctx context.Context, res *resource.SystemP
 	if err := spec.Validate(); err != nil {
 		return nil, fmt.Errorf("apt: package set %q: %w", name, err)
 	}
-	// Upgrade-time package drainage: when the executor invokes Install
-	// as part of an Upgrade/Reinstall action, it surfaces the prior
-	// state's package list via executor.OldPackagesFromContext. Any
-	// package present in the old state but absent from the new spec
-	// must be uninstalled from the host — otherwise the generic
-	// "upgrade = re-run Install" flow leaves dropped packages running
-	// with no state tracking. Drainage runs BEFORE the new-spec install
-	// so a runInstall failure does not leave the host in a half-drained
-	// state with orphan packages that have already been removed.
-	if oldPkgs := executor.OldPackagesFromContext(ctx); len(oldPkgs) > 0 {
-		newSet := make(map[string]bool, len(spec.Packages))
-		for _, pkg := range spec.Packages {
-			newSet[pkg] = true
-		}
-		var toRemove []string
-		for _, pkg := range oldPkgs {
-			if !newSet[pkg] {
-				toRemove = append(toRemove, pkg)
-			}
-		}
-		if len(toRemove) > 0 {
-			if err := p.runRemove(ctx, toRemove); err != nil {
-				return nil, fmt.Errorf("apt: package set %q: upgrade drain %v: %w", name, toRemove, err)
-			}
-		}
+	// Pin the installer to APT at the boundary: SystemPackageSetSpec.Validate
+	// only checks that installerRef is non-empty (the CUE schema layer
+	// constrains the literal value upstream). Without this check, a non-
+	// CUE caller — or a future selectPackageInstaller mis-routing — could
+	// land a SystemPackageSet whose installerRef is "dnf" / "zypper" here
+	// and tomei would happily run apt-get on it, then persist the non-APT
+	// installerRef into state.
+	if spec.InstallerRef != resource.InstallerRefApt {
+		return nil, fmt.Errorf("apt: package set %q: installerRef %q is not %q", name, spec.InstallerRef, resource.InstallerRefApt)
 	}
 	// Snapshot pre-install state so a later rollback removes ONLY the
 	// packages this Install action placed. Without this snapshot, a
@@ -536,6 +520,44 @@ func (p *PackageSetInstaller) Install(ctx context.Context, res *resource.SystemP
 			return nil, fmt.Errorf("apt: package set %q: probe version of %q: %w", name, pkg, err)
 		}
 		versions[pkg] = v
+	}
+	// Upgrade-time package drainage runs LAST — after the new-spec install
+	// and the per-package version probes have both succeeded. Two failure
+	// modes are bounded by this ordering:
+	//
+	//   - runInstall fails → no drainage attempted, host stays at old
+	//     state (matches state.json which still records old packages).
+	//   - Version probe fails → the post-probe rollback removes only the
+	//     newly-placed packages (delta from the pre-install snapshot);
+	//     no drainage has happened yet, so dropped packages remain on the
+	//     host. State.json still records old packages, host has old
+	//     packages — state and host agree.
+	//   - Drainage fails → Install returns error; state.json keeps the
+	//     OLD package list (no save happened); host has old packages
+	//     plus any newly-placed ones (re-applying will re-emit Upgrade
+	//     and retry drainage; apt-get install is idempotent).
+	//
+	// Earlier drafts drained BEFORE install for symmetry with the
+	// pre-install snapshot, but that ordering leaves a window where the
+	// host has FEWER packages than state.json claims if install or probe
+	// fails — the inverse of the orphan-packages problem and harder to
+	// recover from because dropped packages do not auto-re-install.
+	if oldPkgs := executor.OldPackagesFromContext(ctx); len(oldPkgs) > 0 {
+		newSet := make(map[string]bool, len(spec.Packages))
+		for _, pkg := range spec.Packages {
+			newSet[pkg] = true
+		}
+		var toRemove []string
+		for _, pkg := range oldPkgs {
+			if !newSet[pkg] {
+				toRemove = append(toRemove, pkg)
+			}
+		}
+		if len(toRemove) > 0 {
+			if err := p.runRemove(ctx, toRemove); err != nil {
+				return nil, fmt.Errorf("apt: package set %q: upgrade drain %v: %w", name, toRemove, err)
+			}
+		}
 	}
 	return &resource.SystemPackageSetState{
 		InstallerRef:      spec.InstallerRef,

--- a/internal/installer/apt/apt_test.go
+++ b/internal/installer/apt/apt_test.go
@@ -224,6 +224,101 @@ func TestUpdate_CommandError(t *testing.T) {
 	assert.EqualError(t, err, "apt: update: exit status 100")
 }
 
+// --- SimulateRemoveCascade tests ---
+
+func TestSimulateRemoveCascade(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		pkgs      []string
+		output    string
+		runnerErr error
+		want      []string
+		wantErr   string
+		wantCmd   string
+	}{
+		{
+			name:    "empty input is no-op",
+			pkgs:    nil,
+			wantCmd: "",
+		},
+		{
+			name: "single target, no cascade",
+			pkgs: []string{"jq"},
+			output: "Reading package lists... Done\n" +
+				"Building dependency tree... Done\n" +
+				"Remv jq [1.6-2.1ubuntu3]\n",
+			want:    []string{"jq"},
+			wantCmd: "sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get -s remove -y -o DPkg::Lock::Timeout=60 -- jq",
+		},
+		{
+			name: "cascade picks up dependent",
+			pkgs: []string{"perl"},
+			output: "Reading package lists... Done\n" +
+				"The following packages will be REMOVED:\n  cowsay perl\n" +
+				"Remv cowsay [3.7.0-3]\n" +
+				"Remv perl [5.34.0-3ubuntu1.3]\n",
+			want:    []string{"cowsay", "perl"},
+			wantCmd: "sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get -s remove -y -o DPkg::Lock::Timeout=60 -- perl",
+		},
+		{
+			name: "duplicate Remv lines deduped",
+			pkgs: []string{"jq"},
+			output: "Remv jq [1.6-2.1ubuntu3]\n" +
+				"Remv jq [1.6-2.1ubuntu3]\n",
+			want:    []string{"jq"},
+			wantCmd: "sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get -s remove -y -o DPkg::Lock::Timeout=60 -- jq",
+		},
+		{
+			name:    "no Remv lines returns nil",
+			pkgs:    []string{"jq"},
+			output:  "Reading package lists... Done\nBuilding dependency tree... Done\n",
+			want:    nil,
+			wantCmd: "sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get -s remove -y -o DPkg::Lock::Timeout=60 -- jq",
+		},
+		{
+			name:      "runner error wraps simulate context",
+			pkgs:      []string{"jq"},
+			runnerErr: errors.New("exit status 100"),
+			wantErr:   `apt: simulate-remove ["jq"]`,
+		},
+		{
+			name:    "empty package name rejected",
+			pkgs:    []string{""},
+			wantErr: "apt: empty package name in simulate-remove list",
+		},
+		{
+			name:    "shell-meta package name rejected",
+			pkgs:    []string{"jq;rm -rf /"},
+			wantErr: "contains disallowed characters",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			runner := &mockCommandRunner{
+				captureOutput: tt.output,
+				captureErr:    tt.runnerErr,
+			}
+			got, err := New(runner).SimulateRemoveCascade(context.Background(), tt.pkgs)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+			if tt.wantCmd != "" {
+				require.Len(t, runner.captureCmds, 1)
+				assert.Equal(t, tt.wantCmd, runner.captureCmds[0])
+			} else {
+				assert.Empty(t, runner.captureCmds, "empty input must not invoke apt-get")
+			}
+		})
+	}
+}
+
 // --- PackageSetInstaller tests ---
 
 func TestPackageSetInstaller_Install(t *testing.T) {
@@ -490,8 +585,16 @@ func TestPackageSetInstaller_Install_Upgrade_DrainsDroppedPackages(t *testing.T)
 		//   index 0: pre-install IsInstalled(tree) → "installed\n".
 		//   index 1: apt-get install tree (no-op, already installed).
 		//   index 2: dpkg-query version(tree).
-		//   index 3: drainage apt-get remove jq.
-		captureOutputs: []string{"installed\n", "", "installed 1.8.0-5build1\n", ""},
+		//   index 3: apt-get -s remove jq (cascade simulation) — only
+		//            "jq" itself would be removed; no cascade.
+		//   index 4: apt-get remove jq (real drain).
+		captureOutputs: []string{
+			"installed\n",
+			"",
+			"installed 1.8.0-5build1\n",
+			"Reading package lists... Done\nBuilding dependency tree... Done\nRemv jq [1.6-2.1ubuntu3]\n",
+			"",
+		},
 	}
 	res := &resource.SystemPackageSet{
 		SystemPackageSetSpec: &resource.SystemPackageSetSpec{
@@ -504,7 +607,7 @@ func TestPackageSetInstaller_Install_Upgrade_DrainsDroppedPackages(t *testing.T)
 	require.NoError(t, err)
 	require.NotNil(t, state)
 	assert.Equal(t, []string{"tree"}, state.Packages, "state reflects the new spec only")
-	require.Len(t, runner.captureCmds, 4)
+	require.Len(t, runner.captureCmds, 5)
 	assert.Equal(t, `dpkg-query -W -f='${db:Status-Status}\n' -- tree`, runner.captureCmds[0])
 	assert.Equal(t,
 		"sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get install -y -o DPkg::Lock::Timeout=60 -- tree",
@@ -513,10 +616,66 @@ func TestPackageSetInstaller_Install_Upgrade_DrainsDroppedPackages(t *testing.T)
 	)
 	assert.Equal(t, `dpkg-query -W -f='${db:Status-Status} ${Version}\n' -- tree`, runner.captureCmds[2])
 	assert.Equal(t,
-		"sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get remove -y -o DPkg::Lock::Timeout=60 -- jq",
+		"sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get -s remove -y -o DPkg::Lock::Timeout=60 -- jq",
 		runner.captureCmds[3],
-		"drainage removes jq (in old state, not in new spec) AFTER the install+probe succeed",
+		"simulate the drain first to detect cascade-removal of new-spec packages",
 	)
+	assert.Equal(t,
+		"sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get remove -y -o DPkg::Lock::Timeout=60 -- jq",
+		runner.captureCmds[4],
+		"actual drain runs ONLY after the simulation confirms no cascade into new spec",
+	)
+}
+
+// TestPackageSetInstaller_Install_Upgrade_CascadeAbortsBeforeRemove
+// asserts the simulate-then-execute drain guard: if apt's pre-flight
+// simulation shows the drain would cascade-remove a package the new
+// spec still relies on, Install aborts BEFORE the real apt-get remove
+// runs. The cascade can happen when a dependency chain is split across
+// SystemPackageSets — e.g. spec shrinks [cowsay, perl] → [cowsay], and
+// removing perl would also force apt to remove cowsay (which depends
+// on perl). Without this guard, Install would record state saying
+// cowsay is installed while the host no longer has it.
+func TestPackageSetInstaller_Install_Upgrade_CascadeAbortsBeforeRemove(t *testing.T) {
+	t.Parallel()
+	runner := &mockCommandRunner{
+		// New spec = [cowsay], old packages = [cowsay, perl]. The
+		// simulation output reports that removing perl would also
+		// cascade-remove cowsay — which is in the new spec, so Install
+		// must abort BEFORE running the real apt-get remove.
+		//
+		// Sequence:
+		//   index 0: pre-install IsInstalled(cowsay) → "installed\n".
+		//   index 1: apt-get install cowsay (no-op).
+		//   index 2: dpkg-query version(cowsay).
+		//   index 3: apt-get -s remove perl → cascade includes cowsay.
+		captureOutputs: []string{
+			"installed\n",
+			"",
+			"installed 3.7.0-3\n",
+			"Reading package lists... Done\nBuilding dependency tree... Done\nRemv cowsay [3.7.0-3]\nRemv perl [5.34.0-3ubuntu1.3]\n",
+		},
+	}
+	res := &resource.SystemPackageSet{
+		SystemPackageSetSpec: &resource.SystemPackageSetSpec{
+			InstallerRef: "apt",
+			Packages:     []string{"cowsay"},
+		},
+	}
+	ctx := executor.WithOldPackages(context.Background(), []string{"cowsay", "perl"})
+	state, err := New(runner).PackageSetInstaller().Install(ctx, res, "cli-tools")
+	require.Error(t, err)
+	assert.Nil(t, state)
+	assert.Contains(t, err.Error(),
+		`apt: package set "cli-tools": upgrade drain [perl] would cascade-remove [cowsay] from the new spec`)
+	// Exactly 4 commands: snapshot + install + probe + simulate.
+	// The REAL apt-get remove must NOT fire.
+	require.Len(t, runner.captureCmds, 4,
+		"cascade detected by simulation must abort BEFORE the real apt-get remove")
+	for _, cmd := range runner.captureCmds {
+		assert.NotContains(t, cmd, "apt-get remove -y -o",
+			"real apt-get remove (non-simulate) must not run; got %q", cmd)
+	}
 }
 
 // TestPackageSetInstaller_Install_Upgrade_NoDrainWhenSpecGrows asserts
@@ -565,13 +724,21 @@ func TestPackageSetInstaller_Install_Upgrade_DrainFailureAborts(t *testing.T) {
 	t.Parallel()
 	drainErr := errors.New("apt-get remove: exit status 100")
 	runner := &mockCommandRunner{
-		// Sequence: install succeeds, probe succeeds, drain fails.
+		// Sequence: install succeeds, probe succeeds, simulate
+		// succeeds (no cascade), real drain fails.
 		//   index 0: pre-install IsInstalled(tree).
 		//   index 1: apt-get install tree.
 		//   index 2: dpkg-query version(tree).
-		//   index 3: drainage apt-get remove jq → drainErr.
-		captureOutputs: []string{"installed\n", "", "installed 1.8.0-5build1\n", ""},
-		captureErrs:    []error{nil, nil, nil, drainErr},
+		//   index 3: apt-get -s remove jq (no cascade).
+		//   index 4: apt-get remove jq → drainErr.
+		captureOutputs: []string{
+			"installed\n",
+			"",
+			"installed 1.8.0-5build1\n",
+			"Remv jq [1.6-2.1ubuntu3]\n",
+			"",
+		},
+		captureErrs: []error{nil, nil, nil, nil, drainErr},
 	}
 	res := &resource.SystemPackageSet{
 		SystemPackageSetSpec: &resource.SystemPackageSetSpec{
@@ -584,7 +751,7 @@ func TestPackageSetInstaller_Install_Upgrade_DrainFailureAborts(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, state)
 	assert.Contains(t, err.Error(), `apt: package set "cli-tools": upgrade drain`)
-	require.Len(t, runner.captureCmds, 4, "drainage failure surfaces after install+probe complete")
+	require.Len(t, runner.captureCmds, 5, "drainage failure surfaces after install+probe+simulate complete")
 }
 
 // TestPackageSetInstaller_Install_RejectsNonAPTInstallerRef asserts the

--- a/internal/installer/apt/apt_test.go
+++ b/internal/installer/apt/apt_test.go
@@ -479,12 +479,14 @@ func TestPackageSetInstaller_Install_Upgrade_DrainsDroppedPackages(t *testing.T)
 	t.Parallel()
 	runner := &mockCommandRunner{
 		// Sequence (new spec = [tree], old packages = [tree, jq] from
-		// executor ctx):
-		//   index 0: drainage apt-get remove jq.
-		//   index 1: pre-install IsInstalled(tree) → "installed\n".
-		//   index 2: apt-get install tree (no-op, already installed).
-		//   index 3: dpkg-query version(tree).
-		captureOutputs: []string{"", "installed\n", "", "installed 1.8.0-5build1\n"},
+		// executor ctx). Drainage runs LAST so install / probe failures
+		// do not leave the host with FEWER packages than state.json
+		// claims (see Install docstring for the failure-mode analysis):
+		//   index 0: pre-install IsInstalled(tree) → "installed\n".
+		//   index 1: apt-get install tree (no-op, already installed).
+		//   index 2: dpkg-query version(tree).
+		//   index 3: drainage apt-get remove jq.
+		captureOutputs: []string{"installed\n", "", "installed 1.8.0-5build1\n", ""},
 	}
 	res := &resource.SystemPackageSet{
 		SystemPackageSetSpec: &resource.SystemPackageSetSpec{
@@ -498,15 +500,17 @@ func TestPackageSetInstaller_Install_Upgrade_DrainsDroppedPackages(t *testing.T)
 	require.NotNil(t, state)
 	assert.Equal(t, []string{"tree"}, state.Packages, "state reflects the new spec only")
 	require.Len(t, runner.captureCmds, 4)
-	assert.Equal(t,
-		"sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get remove -y -o DPkg::Lock::Timeout=60 -- jq",
-		runner.captureCmds[0],
-		"drainage must remove jq (in old state, not in new spec) BEFORE the install",
-	)
-	assert.Equal(t, `dpkg-query -W -f='${db:Status-Status}\n' -- tree`, runner.captureCmds[1])
+	assert.Equal(t, `dpkg-query -W -f='${db:Status-Status}\n' -- tree`, runner.captureCmds[0])
 	assert.Equal(t,
 		"sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get install -y -o DPkg::Lock::Timeout=60 -- tree",
-		runner.captureCmds[2],
+		runner.captureCmds[1],
+		"install must run BEFORE drainage so a failed install leaves the host at old state, not partially drained",
+	)
+	assert.Equal(t, `dpkg-query -W -f='${db:Status-Status} ${Version}\n' -- tree`, runner.captureCmds[2])
+	assert.Equal(t,
+		"sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get remove -y -o DPkg::Lock::Timeout=60 -- jq",
+		runner.captureCmds[3],
+		"drainage removes jq (in old state, not in new spec) AFTER the install+probe succeed",
 	)
 }
 
@@ -543,16 +547,26 @@ func TestPackageSetInstaller_Install_Upgrade_NoDrainWhenSpecGrows(t *testing.T) 
 }
 
 // TestPackageSetInstaller_Install_Upgrade_DrainFailureAborts asserts
-// that a drainage failure (apt-get remove returning an error) aborts the
-// Install before any apt-get install runs. The host stays in its
-// pre-Install state if apt-get remove fails on the dropped packages.
+// that a drainage failure (apt-get remove returning an error) at the END
+// of Install causes the wrapped error to surface. The host has the new
+// install applied successfully but state.json is NOT saved (Install
+// returns an error) — on retry the reconciler emits Upgrade again and
+// drainage is re-attempted. State.json says OLD packages, host has OLD
+// (preinstalled) + NEW (just-placed) packages, with drainage pending
+// retry. See Install's drainage-order docstring for why this is preferred
+// over the inverse failure mode (drain-before-install would leave the
+// host with FEWER packages than state.json claims).
 func TestPackageSetInstaller_Install_Upgrade_DrainFailureAborts(t *testing.T) {
 	t.Parallel()
 	drainErr := errors.New("apt-get remove: exit status 100")
 	runner := &mockCommandRunner{
-		// Drainage (index 0) fails. The pre-install probes and
-		// apt-get install MUST NOT run.
-		captureErrs: []error{drainErr},
+		// Sequence: install succeeds, probe succeeds, drain fails.
+		//   index 0: pre-install IsInstalled(tree).
+		//   index 1: apt-get install tree.
+		//   index 2: dpkg-query version(tree).
+		//   index 3: drainage apt-get remove jq → drainErr.
+		captureOutputs: []string{"installed\n", "", "installed 1.8.0-5build1\n", ""},
+		captureErrs:    []error{nil, nil, nil, drainErr},
 	}
 	res := &resource.SystemPackageSet{
 		SystemPackageSetSpec: &resource.SystemPackageSetSpec{
@@ -565,7 +579,31 @@ func TestPackageSetInstaller_Install_Upgrade_DrainFailureAborts(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, state)
 	assert.Contains(t, err.Error(), `apt: package set "cli-tools": upgrade drain`)
-	require.Len(t, runner.captureCmds, 1, "drainage failure must abort BEFORE the install step")
+	require.Len(t, runner.captureCmds, 4, "drainage failure surfaces after install+probe complete")
+}
+
+// TestPackageSetInstaller_Install_RejectsNonAPTInstallerRef asserts the
+// APT-boundary check on spec.InstallerRef. SystemPackageSetSpec.Validate
+// only checks that installerRef is non-empty; if a SystemPackageSet
+// somehow lands here with installerRef = "dnf" (a non-CUE caller, a
+// future routing bug in selectPackageInstaller), the apt installer would
+// otherwise happily run apt-get and persist "dnf" into state — leaving
+// the engine unable to invoke the correct concrete installer on the
+// next apply.
+func TestPackageSetInstaller_Install_RejectsNonAPTInstallerRef(t *testing.T) {
+	t.Parallel()
+	runner := &mockCommandRunner{}
+	res := &resource.SystemPackageSet{
+		SystemPackageSetSpec: &resource.SystemPackageSetSpec{
+			InstallerRef: "dnf",
+			Packages:     []string{"tree"},
+		},
+	}
+	state, err := New(runner).PackageSetInstaller().Install(context.Background(), res, "cli-tools")
+	require.Error(t, err)
+	assert.Nil(t, state)
+	assert.Contains(t, err.Error(), `apt: package set "cli-tools": installerRef "dnf" is not "apt"`)
+	assert.Empty(t, runner.captureCmds, "no apt-get must run when installerRef is non-APT")
 }
 
 // TestPackageSetInstaller_Install_VersionProbeError verifies that a

--- a/internal/installer/apt/apt_test.go
+++ b/internal/installer/apt/apt_test.go
@@ -470,11 +470,16 @@ func TestPackageSetInstaller_Install_PopulatesVersions(t *testing.T) {
 // asserts the upgrade-time package drainage. When the executor invokes
 // Install with executor.WithOldPackages on the ctx (as it does for any
 // ActionUpgrade / ActionReinstall on a state implementing GetPackages),
-// the installer MUST uninstall the diff (old - new) BEFORE running
-// apt-get install for the new spec. Without this, a user shrinking the
-// spec from [tree, jq] to [tree] would leave jq installed on the host
-// with no state tracking — the executor's generic "upgrade = re-run
+// the installer MUST uninstall the diff (old - new) so a user shrinking
+// the spec from [tree, jq] to [tree] does not leave jq installed on the
+// host with no state tracking — the executor's generic "upgrade = re-run
 // Install" flow has no other place to do this cleanup.
+//
+// Ordering: drainage runs AFTER the new-spec install and per-package
+// version probes have both succeeded. Earlier drafts drained before the
+// install, but that left the host with FEWER packages than state.json
+// claimed if install/probe failed. The post-probe ordering is
+// documented in detail on PackageSetInstaller.Install in apt.go.
 func TestPackageSetInstaller_Install_Upgrade_DrainsDroppedPackages(t *testing.T) {
 	t.Parallel()
 	runner := &mockCommandRunner{

--- a/internal/installer/apt/apt_test.go
+++ b/internal/installer/apt/apt_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/terassyi/tomei/internal/installer/command"
+	"github.com/terassyi/tomei/internal/installer/executor"
 	"github.com/terassyi/tomei/internal/resource"
 )
 
@@ -227,37 +228,77 @@ func TestUpdate_CommandError(t *testing.T) {
 
 func TestPackageSetInstaller_Install(t *testing.T) {
 	t.Parallel()
+	// Runner call sequence:
+	//
+	//	indices 0..N-1: pre-install IsInstalled probes (one per package).
+	//	                Empty output ⇒ not installed (the bottom of
+	//	                IsInstalled returns false, nil when no status line
+	//	                matches "installed"). Used to snapshot which
+	//	                packages this Install action newly placed for the
+	//	                rollback differential.
+	//	index   N    : apt-get install (no output read).
+	//	indices N+1..2N: post-install dpkg-query version probes (one per
+	//	                package, in spec order). probeOutputs[i] is the
+	//	                output returned for the i-th version probe.
 	tests := []struct {
-		name      string
-		packages  []string
-		runnerErr error
-		wantErr   string
-		wantCmd   string
+		name         string
+		packages     []string
+		probeOutputs []string
+		runnerErr    error
+		wantErr      string
+		wantCmds     []string
+		wantVersions map[string]string
 	}{
 		{
-			name:     "single package",
-			packages: []string{"git"},
-			wantCmd:  "sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get install -y -o DPkg::Lock::Timeout=60 -- git",
+			name:         "single package",
+			packages:     []string{"git"},
+			probeOutputs: []string{"installed 1:2.34.1-1ubuntu1.10\n"},
+			wantCmds: []string{
+				`dpkg-query -W -f='${db:Status-Status}\n' -- git`,
+				"sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get install -y -o DPkg::Lock::Timeout=60 -- git",
+				`dpkg-query -W -f='${db:Status-Status} ${Version}\n' -- git`,
+			},
+			wantVersions: map[string]string{"git": "1:2.34.1-1ubuntu1.10"},
 		},
 		{
 			name:     "multiple packages",
 			packages: []string{"git", "curl", "tree"},
-			wantCmd:  "sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get install -y -o DPkg::Lock::Timeout=60 -- git curl tree",
+			probeOutputs: []string{
+				"installed 1:2.34.1-1ubuntu1.10\n",
+				"installed 7.81.0-1ubuntu1.13\n",
+				"installed 1.8.0-5build1\n",
+			},
+			wantCmds: []string{
+				`dpkg-query -W -f='${db:Status-Status}\n' -- git`,
+				`dpkg-query -W -f='${db:Status-Status}\n' -- curl`,
+				`dpkg-query -W -f='${db:Status-Status}\n' -- tree`,
+				"sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get install -y -o DPkg::Lock::Timeout=60 -- git curl tree",
+				`dpkg-query -W -f='${db:Status-Status} ${Version}\n' -- git`,
+				`dpkg-query -W -f='${db:Status-Status} ${Version}\n' -- curl`,
+				`dpkg-query -W -f='${db:Status-Status} ${Version}\n' -- tree`,
+			},
+			wantVersions: map[string]string{
+				"git":  "1:2.34.1-1ubuntu1.10",
+				"curl": "7.81.0-1ubuntu1.13",
+				"tree": "1.8.0-5build1",
+			},
 		},
 		{
 			name:     "empty packages",
 			packages: []string{},
-			wantErr:  "apt: install requires at least one package",
+			// spec.Validate() catches this at the apt boundary before
+			// runInstall, producing the package-set-scoped wrap.
+			wantErr: `apt: package set "cli-tools": at least one package is required`,
 		},
 		{
 			name:     "empty string in packages slice",
 			packages: []string{""},
-			wantErr:  "apt: empty package name in install list",
+			wantErr:  `apt: package set "cli-tools": packages[0] must not be empty`,
 		},
 		{
 			name:     "empty string among valid packages",
 			packages: []string{"git", "", "tree"},
-			wantErr:  "apt: empty package name in install list",
+			wantErr:  `apt: package set "cli-tools": packages[1] must not be empty`,
 		},
 		{
 			name:     "package with semicolon rejected",
@@ -288,13 +329,27 @@ func TestPackageSetInstaller_Install(t *testing.T) {
 			name:      "runner error wraps packages context",
 			packages:  []string{"nonexistent-pkg"},
 			runnerErr: errors.New("exit status 100"),
-			wantErr:   `apt: install ["nonexistent-pkg"]`,
+			// Pre-install IsInstalled probe fires first and is the call
+			// that surfaces the runner error. The probe wrap is
+			// "apt: status %q" (from Client.IsInstalled) which is then
+			// scoped by Install as "apt: package set %q: snapshot
+			// pre-install state of %q: <probe wrap>: <runner err>".
+			wantErr: `apt: package set "cli-tools": snapshot pre-install state of "nonexistent-pkg"`,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			runner := &mockCommandRunner{captureErr: tt.runnerErr}
+			// Pre-install IsInstalled probes (N) + apt-get install (1) all
+			// consume default "" (empty output) — IsInstalled treats no
+			// "installed" line as "not installed", apt-get install does
+			// not have its output read. probeOutputs feeds the version
+			// probes starting at index N+1.
+			captureOutputs := append(make([]string, len(tt.packages)+1), tt.probeOutputs...)
+			runner := &mockCommandRunner{
+				captureErr:     tt.runnerErr,
+				captureOutputs: captureOutputs,
+			}
 			res := &resource.SystemPackageSet{
 				SystemPackageSetSpec: &resource.SystemPackageSetSpec{
 					InstallerRef: "apt",
@@ -304,12 +359,11 @@ func TestPackageSetInstaller_Install(t *testing.T) {
 			state, err := New(runner).PackageSetInstaller().Install(context.Background(), res, "cli-tools")
 			if tt.wantErr == "" {
 				require.NoError(t, err)
-				require.Len(t, runner.captureCmds, 1)
-				assert.Equal(t, tt.wantCmd, runner.captureCmds[0])
+				assert.Equal(t, tt.wantCmds, runner.captureCmds)
 				require.NotNil(t, state)
 				assert.Equal(t, "apt", state.InstallerRef)
 				assert.Equal(t, tt.packages, state.Packages)
-				assert.NotNil(t, state.InstalledVersions)
+				assert.Equal(t, tt.wantVersions, state.InstalledVersions)
 				assert.False(t, state.UpdatedAt.IsZero(), "UpdatedAt should be set")
 			} else {
 				require.Error(t, err)
@@ -320,9 +374,40 @@ func TestPackageSetInstaller_Install(t *testing.T) {
 	}
 }
 
+func TestPackageSetInstaller_Install_NilGuards(t *testing.T) {
+	t.Parallel()
+	// Defense-in-depth at the apt boundary. Mirrors PackageRepository
+	// installer's `apt: repository %q: nil spec` shape (repository.go:394).
+	cases := []struct {
+		name string
+		res  *resource.SystemPackageSet
+	}{
+		{"nil resource", nil},
+		{"nil spec", &resource.SystemPackageSet{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runner := &mockCommandRunner{}
+			state, err := New(runner).PackageSetInstaller().Install(context.Background(), tc.res, "cli-tools")
+			require.Error(t, err)
+			assert.Nil(t, state)
+			assert.Contains(t, err.Error(), `apt: package set "cli-tools": nil spec`)
+			assert.Empty(t, runner.captureCmds, "apt-get install must not run when spec is missing")
+		})
+	}
+}
+
 func TestPackageSetInstaller_Install_PropagatesRepositoryRef(t *testing.T) {
 	t.Parallel()
-	runner := &mockCommandRunner{}
+	// Sequence:
+	//   index 0 = pre-install IsInstalled probe for "docker-ce" (empty
+	//             output ⇒ not installed).
+	//   index 1 = apt-get install (no output read).
+	//   index 2 = dpkg-query version probe for "docker-ce".
+	runner := &mockCommandRunner{
+		captureOutputs: []string{"", "", "installed 5:24.0.7-1~ubuntu.22.04~jammy\n"},
+	}
 	res := &resource.SystemPackageSet{
 		SystemPackageSetSpec: &resource.SystemPackageSetSpec{
 			InstallerRef:  "apt",
@@ -333,6 +418,314 @@ func TestPackageSetInstaller_Install_PropagatesRepositoryRef(t *testing.T) {
 	state, err := New(runner).PackageSetInstaller().Install(context.Background(), res, "docker")
 	require.NoError(t, err)
 	assert.Equal(t, "docker", state.RepositoryRef)
+}
+
+// TestPackageSetInstaller_Install_PopulatesVersions verifies that Install
+// runs the pre-install IsInstalled probes, then apt-get install, then
+// version probes per package in order, and the per-package versions land
+// in state.InstalledVersions.
+func TestPackageSetInstaller_Install_PopulatesVersions(t *testing.T) {
+	t.Parallel()
+	runner := &mockCommandRunner{
+		// Sequence:
+		//   indices 0..1: pre-install IsInstalled probes for tree, jq
+		//                 (empty output ⇒ not installed).
+		//   index   2   : apt-get install (no output read).
+		//   indices 3..4: dpkg-query version probes per package.
+		captureOutputs: []string{
+			"",
+			"",
+			"",
+			"installed 1.8.0-5build1\n",
+			"installed 1.6-2.1ubuntu3\n",
+		},
+	}
+	res := &resource.SystemPackageSet{
+		SystemPackageSetSpec: &resource.SystemPackageSetSpec{
+			InstallerRef: "apt",
+			Packages:     []string{"tree", "jq"},
+		},
+	}
+	state, err := New(runner).PackageSetInstaller().Install(context.Background(), res, "cli-tools")
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t,
+		map[string]string{"tree": "1.8.0-5build1", "jq": "1.6-2.1ubuntu3"},
+		state.InstalledVersions,
+	)
+	// Verify the full call sequence: pre-install probes, then install,
+	// then version probes — all in spec order.
+	require.Len(t, runner.captureCmds, 5)
+	assert.Equal(t, `dpkg-query -W -f='${db:Status-Status}\n' -- tree`, runner.captureCmds[0])
+	assert.Equal(t, `dpkg-query -W -f='${db:Status-Status}\n' -- jq`, runner.captureCmds[1])
+	assert.Equal(t,
+		"sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get install -y -o DPkg::Lock::Timeout=60 -- tree jq",
+		runner.captureCmds[2],
+	)
+	assert.Equal(t, `dpkg-query -W -f='${db:Status-Status} ${Version}\n' -- tree`, runner.captureCmds[3])
+	assert.Equal(t, `dpkg-query -W -f='${db:Status-Status} ${Version}\n' -- jq`, runner.captureCmds[4])
+}
+
+// TestPackageSetInstaller_Install_Upgrade_DrainsDroppedPackages
+// asserts the upgrade-time package drainage. When the executor invokes
+// Install with executor.WithOldPackages on the ctx (as it does for any
+// ActionUpgrade / ActionReinstall on a state implementing GetPackages),
+// the installer MUST uninstall the diff (old - new) BEFORE running
+// apt-get install for the new spec. Without this, a user shrinking the
+// spec from [tree, jq] to [tree] would leave jq installed on the host
+// with no state tracking — the executor's generic "upgrade = re-run
+// Install" flow has no other place to do this cleanup.
+func TestPackageSetInstaller_Install_Upgrade_DrainsDroppedPackages(t *testing.T) {
+	t.Parallel()
+	runner := &mockCommandRunner{
+		// Sequence (new spec = [tree], old packages = [tree, jq] from
+		// executor ctx):
+		//   index 0: drainage apt-get remove jq.
+		//   index 1: pre-install IsInstalled(tree) → "installed\n".
+		//   index 2: apt-get install tree (no-op, already installed).
+		//   index 3: dpkg-query version(tree).
+		captureOutputs: []string{"", "installed\n", "", "installed 1.8.0-5build1\n"},
+	}
+	res := &resource.SystemPackageSet{
+		SystemPackageSetSpec: &resource.SystemPackageSetSpec{
+			InstallerRef: "apt",
+			Packages:     []string{"tree"},
+		},
+	}
+	ctx := executor.WithOldPackages(context.Background(), []string{"tree", "jq"})
+	state, err := New(runner).PackageSetInstaller().Install(ctx, res, "cli-tools")
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, []string{"tree"}, state.Packages, "state reflects the new spec only")
+	require.Len(t, runner.captureCmds, 4)
+	assert.Equal(t,
+		"sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get remove -y -o DPkg::Lock::Timeout=60 -- jq",
+		runner.captureCmds[0],
+		"drainage must remove jq (in old state, not in new spec) BEFORE the install",
+	)
+	assert.Equal(t, `dpkg-query -W -f='${db:Status-Status}\n' -- tree`, runner.captureCmds[1])
+	assert.Equal(t,
+		"sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get install -y -o DPkg::Lock::Timeout=60 -- tree",
+		runner.captureCmds[2],
+	)
+}
+
+// TestPackageSetInstaller_Install_Upgrade_NoDrainWhenSpecGrows asserts
+// that when the new spec is a superset of the old (no packages dropped),
+// no drainage apt-get remove fires — only the install + version probes.
+func TestPackageSetInstaller_Install_Upgrade_NoDrainWhenSpecGrows(t *testing.T) {
+	t.Parallel()
+	runner := &mockCommandRunner{
+		captureOutputs: []string{
+			"installed\n", // pre-install IsInstalled(tree) → already installed
+			"",            // pre-install IsInstalled(jq)   → not installed
+			"",            // apt-get install (no output read)
+			"installed 1.8.0-5build1\n",
+			"installed 1.6-2.1ubuntu3\n",
+		},
+	}
+	res := &resource.SystemPackageSet{
+		SystemPackageSetSpec: &resource.SystemPackageSetSpec{
+			InstallerRef: "apt",
+			Packages:     []string{"tree", "jq"},
+		},
+	}
+	ctx := executor.WithOldPackages(context.Background(), []string{"tree"})
+	state, err := New(runner).PackageSetInstaller().Install(ctx, res, "cli-tools")
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	require.Len(t, runner.captureCmds, 5,
+		"superset upgrade ⇒ no drainage; sequence is 2 IsInstalled + 1 install + 2 version probes")
+	// First command must be a dpkg-query (pre-install IsInstalled probe),
+	// NOT an apt-get remove. This pins the "no drainage" claim.
+	assert.Contains(t, runner.captureCmds[0], "dpkg-query",
+		"superset upgrade must NOT run apt-get remove first")
+}
+
+// TestPackageSetInstaller_Install_Upgrade_DrainFailureAborts asserts
+// that a drainage failure (apt-get remove returning an error) aborts the
+// Install before any apt-get install runs. The host stays in its
+// pre-Install state if apt-get remove fails on the dropped packages.
+func TestPackageSetInstaller_Install_Upgrade_DrainFailureAborts(t *testing.T) {
+	t.Parallel()
+	drainErr := errors.New("apt-get remove: exit status 100")
+	runner := &mockCommandRunner{
+		// Drainage (index 0) fails. The pre-install probes and
+		// apt-get install MUST NOT run.
+		captureErrs: []error{drainErr},
+	}
+	res := &resource.SystemPackageSet{
+		SystemPackageSetSpec: &resource.SystemPackageSetSpec{
+			InstallerRef: "apt",
+			Packages:     []string{"tree"},
+		},
+	}
+	ctx := executor.WithOldPackages(context.Background(), []string{"tree", "jq"})
+	state, err := New(runner).PackageSetInstaller().Install(ctx, res, "cli-tools")
+	require.Error(t, err)
+	assert.Nil(t, state)
+	assert.Contains(t, err.Error(), `apt: package set "cli-tools": upgrade drain`)
+	require.Len(t, runner.captureCmds, 1, "drainage failure must abort BEFORE the install step")
+}
+
+// TestPackageSetInstaller_Install_VersionProbeError verifies that a
+// failure in any post-install dpkg-query probe aborts the Install and
+// returns the wrapped error — a successful apt-get install for which we
+// cannot read versions is a state-store consistency bug, so the helper
+// surfaces it rather than degrading to an empty map.
+//
+// Beyond surfacing the error, Install must also roll back the apt-get
+// install (best-effort) so the host returns to its pre-Install state —
+// but ONLY for packages that this Install action newly placed. Packages
+// already on the host before Install must NOT be uninstalled, even if
+// they appear in spec.Packages (apt-get install no-ops on preexisting
+// packages; the rollback diff is based on the pre-install IsInstalled
+// snapshot). This mirrors PackageRepositoryInstaller.bestEffortRollback's
+// snapshot-restore semantics for repository files.
+func TestPackageSetInstaller_Install_VersionProbeError(t *testing.T) {
+	t.Parallel()
+	probeErr := errors.New("dpkg-query: connection lost")
+	runner := &mockCommandRunner{
+		// Sequence:
+		//   index 0: pre-install IsInstalled(tree) → nil err, "" out → not installed.
+		//   index 1: pre-install IsInstalled(jq)   → nil err, "" out → not installed.
+		//   index 2: apt-get install               → nil err.
+		//   index 3: dpkg-query version(tree)      → probeErr.
+		//   index 4: best-effort rollback apt-get remove → nil err.
+		captureErrs: []error{nil, nil, nil, probeErr, nil},
+	}
+	res := &resource.SystemPackageSet{
+		SystemPackageSetSpec: &resource.SystemPackageSetSpec{
+			InstallerRef: "apt",
+			Packages:     []string{"tree", "jq"},
+		},
+	}
+	state, err := New(runner).PackageSetInstaller().Install(context.Background(), res, "cli-tools")
+	require.Error(t, err)
+	assert.Nil(t, state, "no state when version probe fails — state-store consistency")
+	assert.Contains(t, err.Error(), `apt: package set "cli-tools": probe version of "tree"`)
+	// Probe for "jq" must NOT fire after "tree"'s probe failed, but the
+	// best-effort rollback must remove BOTH packages (both were absent
+	// before Install — the snapshot recorded them as not-installed, so
+	// both are in the rollback set).
+	require.Len(t, runner.captureCmds, 5)
+	assert.Equal(t, `dpkg-query -W -f='${db:Status-Status}\n' -- tree`, runner.captureCmds[0])
+	assert.Equal(t, `dpkg-query -W -f='${db:Status-Status}\n' -- jq`, runner.captureCmds[1])
+	assert.Equal(t,
+		"sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get install -y -o DPkg::Lock::Timeout=60 -- tree jq",
+		runner.captureCmds[2],
+	)
+	assert.Equal(t, `dpkg-query -W -f='${db:Status-Status} ${Version}\n' -- tree`, runner.captureCmds[3])
+	assert.Equal(t,
+		"sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get remove -y -o DPkg::Lock::Timeout=60 -- tree jq",
+		runner.captureCmds[4],
+	)
+}
+
+// TestPackageSetInstaller_Install_VersionProbeError_PreinstalledNotRolledBack
+// asserts the rollback differential: a package that was already installed
+// before Install must NOT be removed during the post-probe-failure rollback.
+// Without the pre-install snapshot, the rollback would uninstall a user-
+// managed (or other SystemPackageSet's) package, violating the "do not
+// touch what we did not place" contract.
+func TestPackageSetInstaller_Install_VersionProbeError_PreinstalledNotRolledBack(t *testing.T) {
+	t.Parallel()
+	probeErr := errors.New("dpkg-query: connection lost")
+	runner := &mockCommandRunner{
+		// Sequence:
+		//   index 0: pre-install IsInstalled(tree) → "installed\n" ⇒ already on host.
+		//   index 1: pre-install IsInstalled(jq)   → "" ⇒ not installed.
+		//   index 2: apt-get install (no-ops tree, installs jq).
+		//   index 3: dpkg-query version(tree) → probeErr.
+		//   index 4: best-effort rollback apt-get remove → nil. Must only
+		//            target jq because tree predated this Install action.
+		captureOutputs: []string{"installed\n", "", "", "", ""},
+		captureErrs:    []error{nil, nil, nil, probeErr, nil},
+	}
+	res := &resource.SystemPackageSet{
+		SystemPackageSetSpec: &resource.SystemPackageSetSpec{
+			InstallerRef: "apt",
+			Packages:     []string{"tree", "jq"},
+		},
+	}
+	state, err := New(runner).PackageSetInstaller().Install(context.Background(), res, "cli-tools")
+	require.Error(t, err)
+	assert.Nil(t, state)
+	assert.Contains(t, err.Error(), `apt: package set "cli-tools": probe version of "tree"`)
+	require.Len(t, runner.captureCmds, 5)
+	// Critical assertion: the rollback removes ONLY jq, not tree.
+	assert.Equal(t,
+		"sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get remove -y -o DPkg::Lock::Timeout=60 -- jq",
+		runner.captureCmds[4],
+		"rollback must not uninstall packages that predated this Install action",
+	)
+}
+
+// TestPackageSetInstaller_Install_VersionProbeError_AllPreinstalledNoRollback
+// asserts that when every package was already on the host, a probe
+// failure skips rollback entirely (no apt-get remove call). The Install
+// action did not change the host's installed-package set, so there is
+// nothing to undo.
+func TestPackageSetInstaller_Install_VersionProbeError_AllPreinstalledNoRollback(t *testing.T) {
+	t.Parallel()
+	probeErr := errors.New("dpkg-query: connection lost")
+	runner := &mockCommandRunner{
+		// Both pre-install probes report "installed". Install no-ops.
+		// The version probe fails on tree → no rollback (nothing newly placed).
+		captureOutputs: []string{"installed\n", "installed\n", "", "", ""},
+		captureErrs:    []error{nil, nil, nil, probeErr},
+	}
+	res := &resource.SystemPackageSet{
+		SystemPackageSetSpec: &resource.SystemPackageSetSpec{
+			InstallerRef: "apt",
+			Packages:     []string{"tree", "jq"},
+		},
+	}
+	state, err := New(runner).PackageSetInstaller().Install(context.Background(), res, "cli-tools")
+	require.Error(t, err)
+	assert.Nil(t, state)
+	// No rollback command: sequence stops at the failing version probe.
+	require.Len(t, runner.captureCmds, 4,
+		"all packages preinstalled ⇒ no rollback fires; sequence is 2 IsInstalled + 1 install + 1 failing probe")
+}
+
+// TestPackageSetInstaller_Install_VersionProbeError_RollbackFailure
+// verifies that a rollback failure does NOT mask the probe error in the
+// returned wrap — the trigger cause (probe failure) stays at the head of
+// the chain; the rollback failure goes to slog at Warn. The host may end
+// up with orphaned packages in this rare path, but the apply still fails
+// loudly with the right root cause.
+func TestPackageSetInstaller_Install_VersionProbeError_RollbackFailure(t *testing.T) {
+	t.Parallel()
+	probeErr := errors.New("dpkg-query: connection lost")
+	rollbackErr := errors.New("apt-get remove: exit status 100")
+	runner := &mockCommandRunner{
+		// Sequence:
+		//   index 0: pre-install IsInstalled(tree) → not installed.
+		//   index 1: apt-get install → nil.
+		//   index 2: dpkg-query version(tree) → probeErr.
+		//   index 3: rollback apt-get remove → rollbackErr.
+		captureErrs: []error{nil, nil, probeErr, rollbackErr},
+	}
+	res := &resource.SystemPackageSet{
+		SystemPackageSetSpec: &resource.SystemPackageSetSpec{
+			InstallerRef: "apt",
+			Packages:     []string{"tree"},
+		},
+	}
+	state, err := New(runner).PackageSetInstaller().Install(context.Background(), res, "cli-tools")
+	require.Error(t, err)
+	assert.Nil(t, state)
+	// The trigger error must be the head of the chain; the rollback
+	// failure goes to slog (asserted by other tests via capture pattern).
+	assert.Contains(t, err.Error(), "probe version of")
+	assert.Contains(t, err.Error(), "dpkg-query: connection lost")
+	// The rollback attempt still fired even though it failed.
+	require.Len(t, runner.captureCmds, 4)
+	assert.Equal(t,
+		"sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get remove -y -o DPkg::Lock::Timeout=60 -- tree",
+		runner.captureCmds[3],
+	)
 }
 
 func TestPackageSetInstaller_Remove(t *testing.T) {

--- a/internal/installer/executor/context.go
+++ b/internal/installer/executor/context.go
@@ -35,3 +35,24 @@ func OldBinPathFromContext(ctx context.Context) string {
 	}
 	return ""
 }
+
+type oldPackagesKey struct{}
+
+// WithOldPackages returns a context carrying the package list recorded in
+// the prior state. Used by SystemPackageSet upgrade so the installer can
+// uninstall packages that were dropped from the new spec — without this
+// signal, the generic executor's "upgrade = install" flow leaves dropped
+// packages on the host with no state tracking.
+func WithOldPackages(ctx context.Context, packages []string) context.Context {
+	return context.WithValue(ctx, oldPackagesKey{}, packages)
+}
+
+// OldPackagesFromContext returns the prior-state package list, or nil if
+// the context does not carry one (i.e., this is a first-time Install, or
+// the state type does not expose GetPackages).
+func OldPackagesFromContext(ctx context.Context) []string {
+	if v, ok := ctx.Value(oldPackagesKey{}).([]string); ok {
+		return v
+	}
+	return nil
+}

--- a/internal/installer/executor/executor.go
+++ b/internal/installer/executor/executor.go
@@ -71,6 +71,15 @@ func (e *Executor[R, S]) install(ctx context.Context, action reconciler.Action[R
 				ctx = WithOldBinPath(ctx, oldPath)
 			}
 		}
+		// Pass old Packages for SystemPackageSet upgrade-time drainage.
+		// The generic install flow only re-runs Install with the new
+		// spec; without the old package list the installer has no way
+		// to detect (and uninstall) packages dropped from the spec.
+		if pg, ok := any(action.State).(interface{ GetPackages() []string }); ok {
+			if oldPkgs := pg.GetPackages(); len(oldPkgs) > 0 {
+				ctx = WithOldPackages(ctx, oldPkgs)
+			}
+		}
 	}
 
 	// Install the resource

--- a/internal/resource/system_package.go
+++ b/internal/resource/system_package.go
@@ -399,6 +399,19 @@ type SystemPackageSetState struct {
 
 func (*SystemPackageSetState) isState() {}
 
+// GetPackages returns the package list recorded by Install. The executor
+// type-asserts this method on the state to surface the prior packages
+// through context.WithOldPackages on upgrade/reinstall actions — the apt
+// installer uses that signal to uninstall packages dropped from the new
+// spec, which the generic "upgrade = install" executor flow would
+// otherwise leave orphaned on the host.
+func (s *SystemPackageSetState) GetPackages() []string {
+	if s == nil {
+		return nil
+	}
+	return s.Packages
+}
+
 // SystemPackageSpec defines a single system package; sugar for a 1-element SystemPackageSet.
 type SystemPackageSpec struct {
 	InstallerRef  string `json:"installerRef"`

--- a/internal/resource/system_package.go
+++ b/internal/resource/system_package.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"regexp"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -398,6 +399,51 @@ type SystemPackageSetState struct {
 }
 
 func (*SystemPackageSetState) isState() {}
+
+// ValidateSystemPackageSetOverlap rejects manifests where the same OS
+// package name is declared by more than one SystemPackageSet. Without
+// this check, dropping or shrinking one overlapping set would trigger
+// PackageSetInstaller.Remove (or the Install-time upgrade drain) on a
+// package that another set still relies on; the other set's state would
+// continue to record the package as installed while it had been
+// uninstalled from the host, and subsequent applies would observe no
+// drift to repair.
+//
+// Operates on the post-ExpandSets resource list (SystemPackage → 1-
+// element SystemPackageSet, so it catches overlap regardless of which
+// sugar a manifest used). Callers should invoke this from the same
+// place they invoke ExpandSets (validate / plan / apply).
+//
+// Two SystemPackageSet resources with disjoint Packages are fine. A
+// future refcount-aware Remove/Drain could relax this constraint, but
+// until that lands the only safe model is "one package, one owner."
+func ValidateSystemPackageSetOverlap(resources []Resource) error {
+	owners := make(map[string][]string)
+	for _, r := range resources {
+		ps, ok := r.(*SystemPackageSet)
+		if !ok {
+			continue
+		}
+		if ps.SystemPackageSetSpec == nil {
+			continue
+		}
+		for _, pkg := range ps.SystemPackageSetSpec.Packages {
+			owners[pkg] = append(owners[pkg], r.Name())
+		}
+	}
+	var dupes []string
+	for pkg, names := range owners {
+		if len(names) > 1 {
+			sort.Strings(names)
+			dupes = append(dupes, fmt.Sprintf("package %q declared by SystemPackageSet %v", pkg, names))
+		}
+	}
+	if len(dupes) == 0 {
+		return nil
+	}
+	sort.Strings(dupes)
+	return fmt.Errorf("system package overlap: %s", strings.Join(dupes, "; "))
+}
 
 // GetPackages returns the package list recorded by Install. The executor
 // type-asserts this method on the state to surface the prior packages

--- a/internal/resource/system_package.go
+++ b/internal/resource/system_package.go
@@ -400,41 +400,6 @@ type SystemPackageSetState struct {
 
 func (*SystemPackageSetState) isState() {}
 
-// ValidateSystemPackageSetOverlap rejects manifests where the same OS
-// package name is declared by more than one SystemPackageSet. Without
-// this check, dropping or shrinking one overlapping set would trigger
-// PackageSetInstaller.Remove (or the Install-time upgrade drain) on a
-// package that another set still relies on; the other set's state would
-// continue to record the package as installed while it had been
-// uninstalled from the host, and subsequent applies would observe no
-// drift to repair.
-//
-// Operates on the post-ExpandSets resource list (SystemPackage → 1-
-// element SystemPackageSet, so it catches overlap regardless of which
-// sugar a manifest used). Callers should invoke this from the same
-// place they invoke ExpandSets (validate / plan / apply).
-//
-// Two SystemPackageSet resources with disjoint Packages are fine. A
-// future refcount-aware Remove/Drain could relax this constraint, but
-// until that lands the only safe model is "one package, one owner."
-//
-// Known limitation — cross-set removal cascade: this check rejects
-// only DIRECT name overlap. apt's reverse-dependency handling can
-// still cascade a Remove on one set's package into a package owned by
-// another set (e.g., set A owns `perl`, set B owns `cowsay`; removing
-// set A cascades cowsay out from under set B because cowsay depends on
-// perl). The within-set variant of this hazard is caught at runtime
-// via apt-get -s simulation in PackageSetInstaller.Install's upgrade
-// drain. Cross-set cascade protection requires plumbing all-set state
-// into Install/Remove (so simulation can compare cascades against the
-// union of every other set's packages), which is tracked as a separate
-// follow-up. Until that lands, manifest authors splitting a dependency
-// chain across multiple SystemPackageSets carry the risk.
-//
-// See also ValidateSystemPackageSetStateOverlap for the companion
-// check that catches legacy state drift (state.json contains
-// overlapping entries from an older tomei version where the desired-
-// state validation did not yet exist).
 // ValidateSystemPackageSetStateOverlap is the companion to
 // ValidateSystemPackageSetOverlap for the legacy-drift case: even when
 // the *desired* resource list has no overlap, state.json may already
@@ -489,6 +454,41 @@ func ValidateSystemPackageSetStateOverlap(states map[string]*SystemPackageSetSta
 	return fmt.Errorf("system package state overlap (resolve state.json manually before re-applying): %s", strings.Join(dupes, "; "))
 }
 
+// ValidateSystemPackageSetOverlap rejects manifests where the same OS
+// package name is declared by more than one SystemPackageSet. Without
+// this check, dropping or shrinking one overlapping set would trigger
+// PackageSetInstaller.Remove (or the Install-time upgrade drain) on a
+// package that another set still relies on; the other set's state would
+// continue to record the package as installed while it had been
+// uninstalled from the host, and subsequent applies would observe no
+// drift to repair.
+//
+// Operates on the post-ExpandSets resource list (SystemPackage → 1-
+// element SystemPackageSet, so it catches overlap regardless of which
+// sugar a manifest used). Callers should invoke this from the same
+// place they invoke ExpandSets (validate / plan / apply).
+//
+// Two SystemPackageSet resources with disjoint Packages are fine. A
+// future refcount-aware Remove/Drain could relax this constraint, but
+// until that lands the only safe model is "one package, one owner."
+//
+// Known limitation — cross-set removal cascade: this check rejects
+// only DIRECT name overlap. apt's reverse-dependency handling can
+// still cascade a Remove on one set's package into a package owned by
+// another set (e.g., set A owns `perl`, set B owns `cowsay`; removing
+// set A cascades cowsay out from under set B because cowsay depends on
+// perl). The within-set variant of this hazard is caught at runtime
+// via apt-get -s simulation in PackageSetInstaller.Install's upgrade
+// drain. Cross-set cascade protection requires plumbing all-set state
+// into Install/Remove (so simulation can compare cascades against the
+// union of every other set's packages), which is tracked as a separate
+// follow-up. Until that lands, manifest authors splitting a dependency
+// chain across multiple SystemPackageSets carry the risk.
+//
+// See also ValidateSystemPackageSetStateOverlap for the companion
+// check that catches legacy state drift (state.json contains
+// overlapping entries from an older tomei version where the desired-
+// state validation did not yet exist).
 func ValidateSystemPackageSetOverlap(resources []Resource) error {
 	// owners is pkg → set-of-distinct-owner-names. Set semantics avoid
 	// a false overlap when a single SystemPackageSet's Packages list

--- a/internal/resource/system_package.go
+++ b/internal/resource/system_package.go
@@ -430,6 +430,52 @@ func (*SystemPackageSetState) isState() {}
 // union of every other set's packages), which is tracked as a separate
 // follow-up. Until that lands, manifest authors splitting a dependency
 // chain across multiple SystemPackageSets carry the risk.
+//
+// See also ValidateSystemPackageSetStateOverlap for the companion
+// check that catches legacy state drift (state.json contains
+// overlapping entries from an older tomei version where the desired-
+// state validation did not yet exist).
+// ValidateSystemPackageSetStateOverlap is the companion to
+// ValidateSystemPackageSetOverlap for the legacy-drift case: even when
+// the *desired* resource list has no overlap, state.json may already
+// contain overlapping SystemPackageSet entries written by an older
+// tomei version (before the desired-state validation existed) or by
+// manual edits. Removing or shrinking one of those legacy-overlapping
+// sets would then run apt-get remove on a package the other set's
+// state still claims to own, with no manifest-side gate to catch it.
+//
+// Detect the drift early — at the same boundary createSystemEngine
+// loads the SystemState store — and refuse to build the engine. The
+// user must resolve the drift manually (e.g., by editing state.json
+// so only one set claims each package) before subsequent applies.
+//
+// The signature takes the raw map rather than *state.SystemState to
+// keep the resource package free of an inverse dependency on the
+// state package (state already imports resource).
+func ValidateSystemPackageSetStateOverlap(states map[string]*SystemPackageSetState) error {
+	owners := make(map[string][]string)
+	for name, st := range states {
+		if st == nil {
+			continue
+		}
+		for _, pkg := range st.Packages {
+			owners[pkg] = append(owners[pkg], name)
+		}
+	}
+	var dupes []string
+	for pkg, names := range owners {
+		if len(names) > 1 {
+			sort.Strings(names)
+			dupes = append(dupes, fmt.Sprintf("package %q recorded as installed by SystemPackageSet %v", pkg, names))
+		}
+	}
+	if len(dupes) == 0 {
+		return nil
+	}
+	sort.Strings(dupes)
+	return fmt.Errorf("system package state overlap (resolve state.json manually before re-applying): %s", strings.Join(dupes, "; "))
+}
+
 func ValidateSystemPackageSetOverlap(resources []Resource) error {
 	owners := make(map[string][]string)
 	for _, r := range resources {

--- a/internal/resource/system_package.go
+++ b/internal/resource/system_package.go
@@ -417,6 +417,19 @@ func (*SystemPackageSetState) isState() {}
 // Two SystemPackageSet resources with disjoint Packages are fine. A
 // future refcount-aware Remove/Drain could relax this constraint, but
 // until that lands the only safe model is "one package, one owner."
+//
+// Known limitation — cross-set removal cascade: this check rejects
+// only DIRECT name overlap. apt's reverse-dependency handling can
+// still cascade a Remove on one set's package into a package owned by
+// another set (e.g., set A owns `perl`, set B owns `cowsay`; removing
+// set A cascades cowsay out from under set B because cowsay depends on
+// perl). The within-set variant of this hazard is caught at runtime
+// via apt-get -s simulation in PackageSetInstaller.Install's upgrade
+// drain. Cross-set cascade protection requires plumbing all-set state
+// into Install/Remove (so simulation can compare cascades against the
+// union of every other set's packages), which is tracked as a separate
+// follow-up. Until that lands, manifest authors splitting a dependency
+// chain across multiple SystemPackageSets carry the risk.
 func ValidateSystemPackageSetOverlap(resources []Resource) error {
 	owners := make(map[string][]string)
 	for _, r := range resources {

--- a/internal/resource/system_package.go
+++ b/internal/resource/system_package.go
@@ -453,21 +453,34 @@ func (*SystemPackageSetState) isState() {}
 // keep the resource package free of an inverse dependency on the
 // state package (state already imports resource).
 func ValidateSystemPackageSetStateOverlap(states map[string]*SystemPackageSetState) error {
-	owners := make(map[string][]string)
+	// owners is pkg → set-of-distinct-owner-names. Using a set rather
+	// than a slice deduplicates the case where a single state entry's
+	// Packages list contains the same package name more than once
+	// (legitimate "noisy" state but only one owner) — without this,
+	// appending the owner name twice would surface a false overlap.
+	owners := make(map[string]map[string]struct{})
 	for name, st := range states {
 		if st == nil {
 			continue
 		}
 		for _, pkg := range st.Packages {
-			owners[pkg] = append(owners[pkg], name)
+			if owners[pkg] == nil {
+				owners[pkg] = make(map[string]struct{})
+			}
+			owners[pkg][name] = struct{}{}
 		}
 	}
 	var dupes []string
-	for pkg, names := range owners {
-		if len(names) > 1 {
-			sort.Strings(names)
-			dupes = append(dupes, fmt.Sprintf("package %q recorded as installed by SystemPackageSet %v", pkg, names))
+	for pkg, ownerSet := range owners {
+		if len(ownerSet) <= 1 {
+			continue
 		}
+		names := make([]string, 0, len(ownerSet))
+		for n := range ownerSet {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		dupes = append(dupes, fmt.Sprintf("package %q recorded as installed by SystemPackageSet %v", pkg, names))
 	}
 	if len(dupes) == 0 {
 		return nil
@@ -477,7 +490,13 @@ func ValidateSystemPackageSetStateOverlap(states map[string]*SystemPackageSetSta
 }
 
 func ValidateSystemPackageSetOverlap(resources []Resource) error {
-	owners := make(map[string][]string)
+	// owners is pkg → set-of-distinct-owner-names. Set semantics avoid
+	// a false overlap when a single SystemPackageSet's Packages list
+	// repeats the same package name (e.g., a copy-paste mistake in the
+	// manifest — apt-get install handles duplicates without complaint,
+	// so this is not its own validation error; we just don't want it
+	// to look like an overlap across two sets).
+	owners := make(map[string]map[string]struct{})
 	for _, r := range resources {
 		ps, ok := r.(*SystemPackageSet)
 		if !ok {
@@ -487,15 +506,23 @@ func ValidateSystemPackageSetOverlap(resources []Resource) error {
 			continue
 		}
 		for _, pkg := range ps.SystemPackageSetSpec.Packages {
-			owners[pkg] = append(owners[pkg], r.Name())
+			if owners[pkg] == nil {
+				owners[pkg] = make(map[string]struct{})
+			}
+			owners[pkg][r.Name()] = struct{}{}
 		}
 	}
 	var dupes []string
-	for pkg, names := range owners {
-		if len(names) > 1 {
-			sort.Strings(names)
-			dupes = append(dupes, fmt.Sprintf("package %q declared by SystemPackageSet %v", pkg, names))
+	for pkg, ownerSet := range owners {
+		if len(ownerSet) <= 1 {
+			continue
 		}
+		names := make([]string, 0, len(ownerSet))
+		for n := range ownerSet {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		dupes = append(dupes, fmt.Sprintf("package %q declared by SystemPackageSet %v", pkg, names))
 	}
 	if len(dupes) == 0 {
 		return nil

--- a/internal/resource/system_package_test.go
+++ b/internal/resource/system_package_test.go
@@ -5,7 +5,96 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestValidateSystemPackageSetOverlap(t *testing.T) {
+	t.Parallel()
+	mkSet := func(name string, pkgs ...string) *SystemPackageSet {
+		return &SystemPackageSet{
+			BaseResource:         BaseResource{Metadata: Metadata{Name: name}},
+			SystemPackageSetSpec: &SystemPackageSetSpec{InstallerRef: "apt", Packages: pkgs},
+		}
+	}
+	tests := []struct {
+		name      string
+		resources []Resource
+		wantErr   string
+	}{
+		{
+			name:      "empty",
+			resources: nil,
+		},
+		{
+			name: "single set",
+			resources: []Resource{
+				mkSet("dev", "curl", "jq"),
+			},
+		},
+		{
+			name: "disjoint sets",
+			resources: []Resource{
+				mkSet("dev", "curl", "jq"),
+				mkSet("ops", "htop", "iotop"),
+			},
+		},
+		{
+			name: "same package in two sets",
+			resources: []Resource{
+				mkSet("dev", "curl"),
+				mkSet("ops", "curl"),
+			},
+			wantErr: `system package overlap: package "curl" declared by SystemPackageSet [dev ops]`,
+		},
+		{
+			name: "multiple overlapping packages — error names them in stable order",
+			resources: []Resource{
+				mkSet("dev", "curl", "jq"),
+				mkSet("ops", "curl", "jq"),
+			},
+			// Both "curl" and "jq" appear twice; deterministic sort
+			// (package-name then owners) means "curl" precedes "jq".
+			wantErr: `package "curl" declared by SystemPackageSet [dev ops]; package "jq" declared by SystemPackageSet [dev ops]`,
+		},
+		{
+			name: "three-way overlap surfaces all owners sorted",
+			resources: []Resource{
+				mkSet("zeta", "curl"),
+				mkSet("alpha", "curl"),
+				mkSet("middle", "curl"),
+			},
+			wantErr: `package "curl" declared by SystemPackageSet [alpha middle zeta]`,
+		},
+		{
+			name: "nil spec is skipped (defensive)",
+			resources: []Resource{
+				&SystemPackageSet{BaseResource: BaseResource{Metadata: Metadata{Name: "broken"}}},
+				mkSet("dev", "curl"),
+			},
+		},
+		{
+			name: "non-SystemPackageSet resources are ignored",
+			resources: []Resource{
+				mkSet("dev", "curl"),
+				&Tool{BaseResource: BaseResource{Metadata: Metadata{Name: "rg"}}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateSystemPackageSetOverlap(tt.resources)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
 
 func TestSystemPackageSetSpec_Validate(t *testing.T) {
 	t.Parallel()

--- a/internal/resource/system_package_test.go
+++ b/internal/resource/system_package_test.go
@@ -10,6 +10,60 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestValidateSystemPackageSetStateOverlap(t *testing.T) {
+	t.Parallel()
+	mkState := func(pkgs ...string) *SystemPackageSetState {
+		return &SystemPackageSetState{InstallerRef: "apt", Packages: pkgs}
+	}
+	tests := []struct {
+		name    string
+		states  map[string]*SystemPackageSetState
+		wantErr string
+	}{
+		{name: "empty map", states: nil},
+		{
+			name: "single state entry",
+			states: map[string]*SystemPackageSetState{
+				"dev": mkState("curl"),
+			},
+		},
+		{
+			name: "disjoint states",
+			states: map[string]*SystemPackageSetState{
+				"dev": mkState("curl", "jq"),
+				"ops": mkState("htop"),
+			},
+		},
+		{
+			name: "legacy overlap (drift from older tomei version)",
+			states: map[string]*SystemPackageSetState{
+				"dev": mkState("curl"),
+				"ops": mkState("curl"),
+			},
+			wantErr: `system package state overlap (resolve state.json manually before re-applying): package "curl" recorded as installed by SystemPackageSet [dev ops]`,
+		},
+		{
+			name: "nil state entry skipped",
+			states: map[string]*SystemPackageSetState{
+				"broken": nil,
+				"dev":    mkState("curl"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateSystemPackageSetStateOverlap(tt.states)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
 func TestValidateSystemPackageSetOverlap(t *testing.T) {
 	t.Parallel()
 	mkSet := func(name string, pkgs ...string) *SystemPackageSet {

--- a/internal/resource/system_package_test.go
+++ b/internal/resource/system_package_test.go
@@ -49,6 +49,17 @@ func TestValidateSystemPackageSetStateOverlap(t *testing.T) {
 				"dev":    mkState("curl"),
 			},
 		},
+		{
+			// Defense against false positive: a single state entry
+			// listing the same package twice (e.g., from a noisy
+			// migration or a future bug elsewhere) must NOT surface
+			// as an overlap. Only DISTINCT owner names trip the
+			// guard.
+			name: "duplicate package inside one state entry is not overlap",
+			states: map[string]*SystemPackageSetState{
+				"dev": mkState("curl", "curl", "jq"),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -133,6 +144,17 @@ func TestValidateSystemPackageSetOverlap(t *testing.T) {
 			resources: []Resource{
 				mkSet("dev", "curl"),
 				&Tool{BaseResource: BaseResource{Metadata: Metadata{Name: "rg"}}},
+			},
+		},
+		{
+			// Defense against false positive: a single
+			// SystemPackageSet listing the same package twice (a
+			// copy-paste mistake — apt handles dupes silently) must
+			// NOT surface as an overlap. Only DISTINCT owner names
+			// trip the guard.
+			name: "duplicate package inside one set is not overlap",
+			resources: []Resource{
+				mkSet("dev", "curl", "curl", "jq"),
 			},
 		},
 	}

--- a/tests/apt_package_set_integration_test.go
+++ b/tests/apt_package_set_integration_test.go
@@ -18,23 +18,32 @@ import (
 )
 
 // TestPackageSetInstaller_RealSystem_InstallAndRemove exercises Install
-// end-to-end with a multi-package set against the real apt-get / dpkg
-// stack, then exercises Remove. The key additional surface beyond
+// end-to-end against the real apt-get / dpkg stack, then exercises
+// Remove. The headline additional surface beyond
 // TestPackageSetInstaller_RealSystem (single-package, in
-// apt_install_integration_test.go) is the post-install per-package
-// dpkg-query probe wired in #198: state.InstalledVersions must be
-// populated with a non-empty version string for every package.
+// apt_install_integration_test.go) is the post-install dpkg-query probe
+// wired in #198: state.InstalledVersions must be populated with a
+// non-empty version string for every package.
 //
 // Requires Linux + apt-get + dpkg + passwordless sudo (CI: ubuntu-latest).
 //
-// Package choice: hello + cowsay. The previous canonical "safe test"
-// pair (tree + jq) is unsafe on the GitHub `ubuntu-latest` runner image
-// where `tree` is preinstalled — installing it would no-op and the test
-// would not exercise the install path. hello and cowsay are both small,
-// have no significant runtime dependencies, and are not preinstalled on
-// the runner image. A per-package preinstall guard skips the whole test
-// if either is already present on a developer machine, so we never
-// mutate a host that already depends on these binaries.
+// Package choice: `hello` (single package, zero new transitive deps).
+// The earlier draft used `hello + cowsay`, but cowsay pulls in perl /
+// perl-modules / etc.; the cleanup either had to use `--auto-remove`
+// (over-broad — it can sweep any orphaned auto-installed packages a
+// developer already had on the host) or leave those deps behind
+// (under-broad — mutates the developer's machine). `hello` depends
+// only on libc6 (always preinstalled), so plain `apt-get remove`
+// restores the host fully without disturbing anything else.
+//
+// Multi-package install logic (loop over spec.Packages, command-line
+// composition, per-package version probe) is independently covered by
+// the table-driven mock tests in apt_test.go's TestPackageSetInstaller_Install
+// "multiple packages" subtest — the integration test's job is to verify
+// the real apt-get / dpkg shell path, not to re-test the loop body.
+//
+// A preinstall guard skips the whole test if `hello` is already present
+// on a developer machine, so we never mutate a host that depends on it.
 func TestPackageSetInstaller_RealSystem_InstallAndRemove(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("apt-get integration test requires Linux")
@@ -48,7 +57,7 @@ func TestPackageSetInstaller_RealSystem_InstallAndRemove(t *testing.T) {
 		t.Skip("passwordless sudo not available")
 	}
 
-	pkgs := []string{"hello", "cowsay"}
+	pkgs := []string{"hello"}
 	for _, pkg := range pkgs {
 		if err := exec.Command("dpkg", "-s", pkg).Run(); err == nil {
 			t.Skipf("%s is already installed; skipping to avoid mutating the host environment", pkg)
@@ -67,21 +76,17 @@ func TestPackageSetInstaller_RealSystem_InstallAndRemove(t *testing.T) {
 		// strand the placed ones. Per-package isolates the failure to a
 		// single binary so the others still get drained.
 		//
-		// --auto-remove diverges from the production Remove path on
-		// purpose: the test packages (e.g. cowsay) can pull in
-		// transitive deps that the preinstall guard at the top of this
-		// test will already have classified as "not preinstalled by the
-		// developer." Without --auto-remove, apt-get remove would leave
-		// those deps lingering and the test would mutate a developer's
-		// host beyond the preinstall-guard contract. Production Remove
-		// omits --auto-remove because tomei does not own the deps; here
-		// the test transactionally owns everything new that landed.
+		// Plain `apt-get remove` (no --auto-remove): the chosen test
+		// package(s) have zero new transitive deps, so there is nothing
+		// to sweep. --auto-remove would be over-broad — it can pick up
+		// any orphaned auto-installed packages a developer already had
+		// on the host, mutating state beyond what this test touched.
 		for _, pkg := range pkgs {
 			cleanup := exec.Command("sudo",
 				"-n", "env", "DEBIAN_FRONTEND=noninteractive",
-				"apt-get", "remove", "-y", "--auto-remove", "-o", "DPkg::Lock::Timeout=60", "--", pkg)
+				"apt-get", "remove", "-y", "-o", "DPkg::Lock::Timeout=60", "--", pkg)
 			if err := cleanup.Run(); err != nil {
-				t.Logf("cleanup: apt-get remove --auto-remove %s: %v", pkg, err)
+				t.Logf("cleanup: apt-get remove %s: %v", pkg, err)
 			}
 		}
 	})

--- a/tests/apt_package_set_integration_test.go
+++ b/tests/apt_package_set_integration_test.go
@@ -66,12 +66,22 @@ func TestPackageSetInstaller_RealSystem_InstallAndRemove(t *testing.T) {
 		// "Unable to locate package" / exit-100 on the missing ones and
 		// strand the placed ones. Per-package isolates the failure to a
 		// single binary so the others still get drained.
+		//
+		// --auto-remove diverges from the production Remove path on
+		// purpose: the test packages (e.g. cowsay) can pull in
+		// transitive deps that the preinstall guard at the top of this
+		// test will already have classified as "not preinstalled by the
+		// developer." Without --auto-remove, apt-get remove would leave
+		// those deps lingering and the test would mutate a developer's
+		// host beyond the preinstall-guard contract. Production Remove
+		// omits --auto-remove because tomei does not own the deps; here
+		// the test transactionally owns everything new that landed.
 		for _, pkg := range pkgs {
 			cleanup := exec.Command("sudo",
 				"-n", "env", "DEBIAN_FRONTEND=noninteractive",
-				"apt-get", "remove", "-y", "-o", "DPkg::Lock::Timeout=60", "--", pkg)
+				"apt-get", "remove", "-y", "--auto-remove", "-o", "DPkg::Lock::Timeout=60", "--", pkg)
 			if err := cleanup.Run(); err != nil {
-				t.Logf("cleanup: apt-get remove %s: %v", pkg, err)
+				t.Logf("cleanup: apt-get remove --auto-remove %s: %v", pkg, err)
 			}
 		}
 	})

--- a/tests/apt_package_set_integration_test.go
+++ b/tests/apt_package_set_integration_test.go
@@ -1,0 +1,140 @@
+//go:build integration
+
+package tests
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/terassyi/tomei/internal/installer/apt"
+	"github.com/terassyi/tomei/internal/installer/command"
+	"github.com/terassyi/tomei/internal/resource"
+)
+
+// TestPackageSetInstaller_RealSystem_InstallAndRemove exercises Install
+// end-to-end with a multi-package set against the real apt-get / dpkg
+// stack, then exercises Remove. The key additional surface beyond
+// TestPackageSetInstaller_RealSystem (single-package, in
+// apt_install_integration_test.go) is the post-install per-package
+// dpkg-query probe wired in #198: state.InstalledVersions must be
+// populated with a non-empty version string for every package.
+//
+// Requires Linux + apt-get + dpkg + passwordless sudo (CI: ubuntu-latest).
+//
+// Package choice: hello + cowsay. The previous canonical "safe test"
+// pair (tree + jq) is unsafe on the GitHub `ubuntu-latest` runner image
+// where `tree` is preinstalled — installing it would no-op and the test
+// would not exercise the install path. hello and cowsay are both small,
+// have no significant runtime dependencies, and are not preinstalled on
+// the runner image. A per-package preinstall guard skips the whole test
+// if either is already present on a developer machine, so we never
+// mutate a host that already depends on these binaries.
+func TestPackageSetInstaller_RealSystem_InstallAndRemove(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("apt-get integration test requires Linux")
+	}
+	for _, bin := range []string{"apt-get", "dpkg", "sudo"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not found in PATH", bin)
+		}
+	}
+	if err := exec.Command("sudo", "-n", "true").Run(); err != nil {
+		t.Skip("passwordless sudo not available")
+	}
+
+	pkgs := []string{"hello", "cowsay"}
+	for _, pkg := range pkgs {
+		if err := exec.Command("dpkg", "-s", pkg).Run(); err == nil {
+			t.Skipf("%s is already installed; skipping to avoid mutating the host environment", pkg)
+		}
+	}
+
+	t.Cleanup(func() {
+		// Belt-and-suspenders cleanup: raw exec so we don't rely on the
+		// SUT's Remove path. Mirror the production invocation hardening
+		// (DEBIAN_FRONTEND, lock-timeout, `--` operand separator).
+		//
+		// Per-package invocations rather than one batch call: if the
+		// install left the host in a partial state (one of N packages
+		// somehow placed, the rest not), batching could surface an
+		// "Unable to locate package" / exit-100 on the missing ones and
+		// strand the placed ones. Per-package isolates the failure to a
+		// single binary so the others still get drained.
+		for _, pkg := range pkgs {
+			cleanup := exec.Command("sudo",
+				"-n", "env", "DEBIAN_FRONTEND=noninteractive",
+				"apt-get", "remove", "-y", "-o", "DPkg::Lock::Timeout=60", "--", pkg)
+			if err := cleanup.Run(); err != nil {
+				t.Logf("cleanup: apt-get remove %s: %v", pkg, err)
+			}
+		}
+	})
+
+	client := apt.New(command.NewExecutor(""))
+
+	// Refresh the index first: minimal images / stale runner caches can
+	// surface "Unable to locate package" or 404 errors that mask the
+	// real subject under test. If Update itself fails (no network), skip.
+	if err := client.Update(context.Background()); err != nil {
+		t.Skipf("apt-get update failed (cannot run integration test): %v", err)
+	}
+
+	res := &resource.SystemPackageSet{
+		SystemPackageSetSpec: &resource.SystemPackageSetSpec{
+			InstallerRef: "apt",
+			Packages:     pkgs,
+		},
+	}
+	installer := client.PackageSetInstaller()
+
+	state, err := installer.Install(context.Background(), res, "integration-set")
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, pkgs, state.Packages)
+
+	// Per-package version probe: the headline behavior wired in #198.
+	// We assert non-empty rather than a specific version because the
+	// archive shipping versions varies across Debian/Ubuntu releases.
+	require.NotNil(t, state.InstalledVersions, "InstalledVersions must be populated after Install (#198)")
+	for _, pkg := range pkgs {
+		assert.NotEmpty(t, state.InstalledVersions[pkg],
+			"InstalledVersions[%q] must be a non-empty version string", pkg)
+	}
+
+	// Cross-check against dpkg -l for each package; this is the
+	// independent oracle that proves apt-get install actually ran.
+	for _, pkg := range pkgs {
+		out, dpkgErr := exec.Command("dpkg", "-l", pkg).CombinedOutput()
+		require.NoError(t, dpkgErr, "dpkg -l %s output: %s", pkg, out)
+		assert.Contains(t, string(out), "ii  "+pkg,
+			"%s should be installed (status ii); got: %s", pkg, out)
+	}
+
+	require.NoError(t, installer.Remove(context.Background(), state, "integration-set"))
+
+	// After Remove, dpkg -l should no longer show "ii  <pkg>" for any of
+	// the packages. `dpkg -l` exits 0 on success, 1 when no matching
+	// package exists (purged path), and 2+ on real errors. Exit 1 is an
+	// acceptable non-zero status; anything else (or a non-ExitError such
+	// as the dpkg binary missing / permission denied) is a genuine test
+	// failure that must not be swallowed.
+	for _, pkg := range pkgs {
+		out, dpkgErr := exec.Command("dpkg", "-l", pkg).CombinedOutput()
+		if dpkgErr != nil {
+			var exitErr *exec.ExitError
+			if !errors.As(dpkgErr, &exitErr) {
+				require.NoError(t, dpkgErr, "dpkg -l invocation failed: %s", out)
+			}
+			require.Equal(t, 1, exitErr.ExitCode(),
+				"dpkg -l %s returned unexpected exit %d: %s", pkg, exitErr.ExitCode(), out)
+		}
+		assert.NotContains(t, string(out), "ii  "+pkg,
+			"%s should not be installed (status ii) after Remove; got: %s", pkg, out)
+	}
+}


### PR DESCRIPTION
apt.PackageSetInstaller.Install now probes each package's installed
version via Client.PackageVersion (dpkg-query) after the apt-get install
succeeds, and stores the result in state.InstalledVersions. A probe
failure aborts the Install — surfacing a state-store consistency bug
rather than silently degrading to an empty map.

Wires SystemPackageSet through cmd/tomei the same way #196 wired
SystemPackageRepository:
- Rename skipPackageInstaller -> unsupportedHostPackageInstaller; reword
  Install error to "system: package %q: requires a supported Linux
  package manager (apt) on this host"; Remove returns nil + slog.Warn
  surfacing the orphaned packages list for cross-host audit.
- Add selectPackageInstaller(validator, aptClient) mirroring
  selectRepoInstaller — gates on slices.Contains(SupportedInstallers(),
  PackageManagerAPT) so non-apt Linux distros (Fedora/Arch/Alpine) fall
  through to the placeholder.
- Drop the skip-downgrade for KindSystemPackageSet in plan.go
  (addSystemResourceInfo / markAllSystemAsInstall). Plan output now
  shows real reconciler actions for SystemPackageSet.

Tests:
- internal/installer/apt/apt_test.go: TestPackageSetInstaller_Install_
  PopulatesVersions sequences install + per-package dpkg-query probe;
  _VersionProbeError asserts wrapped error from probe failure aborts.
- cmd/tomei/system_engine_test.go: TestUnsupportedHostPackageInstaller_*
  + TestSelectPackageInstaller (apt/dnf/nil branches) mirror the #196
  Repository test shape.
- cmd/tomei/plan_test.go: flip SystemPackageSet assertions from
  ActionSkip to ActionInstall in TestMarkAllSystemAsInstall and
  TestAddSystemResourceInfo (plus a regression test that the package set
  is no longer downgraded).
- tests/apt_package_set_integration_test.go (new, //go:build integration):
  exercises Install + Remove end-to-end with hello + cowsay (tree is
  preinstalled on ubuntu-latest runners and would not exercise the
  install path); asserts state.InstalledVersions is populated for every
  package; preinstall-guard skip protects developer machines.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
