### PR TITLE
test(e2e): add SystemPackageSet apply coverage (#200)

### DIFF
--- a/e2e/config/system-package-test/manifest.cue
+++ b/e2e/config/system-package-test/manifest.cue
@@ -52,10 +52,12 @@ tree: {
 //   - small, daemon-free, deterministic;
 //   - NOT in e2e/containers/ubuntu/Dockerfile preinstall list.
 //
-// cowsay and sl satisfy all four. bc was the first attempt and broke
-// the CI native legs (`fixture invariant violated: bc is preinstalled
-// on the runner`) — see the GitHub runner image inventory at
-// actions/runner-images.
+// cowsay, sl, and tree all satisfy the four criteria. bc was the
+// first attempt and broke the CI native legs (`fixture invariant
+// violated: bc is preinstalled on the runner`) — see the GitHub
+// runner image inventory at actions/runner-images. tree is carried
+// by the SystemPackage sugar resource generated alongside cliTools
+// (see fixtureSugarPkg in system_package_test.go).
 cliTools: {
 	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "SystemPackageSet"

--- a/e2e/config/system-package-test/manifest.cue
+++ b/e2e/config/system-package-test/manifest.cue
@@ -26,23 +26,33 @@ tree: {
 }
 
 // cliTools is the multi-package SystemPackageSet fixture. Packages here
-// MUST NOT be preinstalled in e2e/containers/ubuntu/Dockerfile — a
-// dpkg-query check that passes because of preinstall would hide any
-// silent no-op regression in the installer. bc (main) and cowsay
-// (universe) are small, daemon-free, and not in the Dockerfile preinstall
-// list. cowsay's runtime Depends are libtext-charwidth-perl and perl:any
-// (both already part of the Ubuntu base via essential dependencies);
-// cowsay-off is Suggests, not Recommends, and is therefore NOT pulled by
-// apt's default install. The apply-time Context in
-// e2e/system_package_test.go re-checks the preinstall invariant in
-// BeforeAll as defence-in-depth against future Dockerfile drift.
+// are chosen so that the real-apply E2E in system_package_test.go can
+// verify that tomei actually mutated the host. Selection criteria:
+//
+//   - leaf packages with no reverse dependencies (so a post-suite
+//     apt-get remove cannot cascade into uninstalling unrelated host
+//     packages on the runner);
+//   - in the `universe` pocket (NOT `main`), so the GitHub-hosted
+//     ubuntu-24.04 runner image — which preinstalls essentially every
+//     `main` utility, including bc and other obvious candidates — does
+//     NOT ship them by default;
+//   - small, daemon-free, deterministic;
+//   - NOT in e2e/containers/ubuntu/Dockerfile preinstall list.
+//
+// cowsay and sl satisfy all four. bc was the first attempt and broke
+// the CI native legs (`fixture invariant violated: bc is preinstalled
+// on the runner`) — see the GitHub runner image inventory at
+// actions/runner-images. The real-apply Context in
+// e2e/system_package_test.go also runs `apt-get remove` for these
+// packages in BeforeAll as a defence-in-depth against a future
+// preinstall regression on either side.
 cliTools: {
 	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "SystemPackageSet"
 	metadata: name: "cli-tools"
 	spec: {
 		installerRef: "apt"
-		packages: ["bc", "cowsay"]
+		packages: ["cowsay", "sl"]
 	}
 }
 

--- a/e2e/config/system-package-test/manifest.cue
+++ b/e2e/config/system-package-test/manifest.cue
@@ -31,13 +31,19 @@ tree: {
 // IMPORTANT — the real-apply E2E does NOT read this fixture. The
 // apply Contexts generate their own /tmp manifests with
 // hard-coded package lists at runtime; this file is only consumed
-// by `tomei validate ~/system-package-test/` and `tomei plan
-// ~/system-package-test/`. The duplication is intentional (the
-// apply path needs to mutate /tmp without touching the canonical
-// fixture used by other Contexts), but it means that adding a
-// fourth package here does NOT automatically extend the apply
-// coverage — you also need to update fixtureSetInstall /
-// fixtureSetRemoval / fixtureSugarPkg in system_package_test.go.
+// by the validate + plan E2E coverage:
+//
+//   - `tomei validate ~/system-package-test/`
+//   - `tomei plan ~/system-package-test/`           (skip-downgrade)
+//   - `tomei plan --system ~/system-package-test/`  (with installer)
+//
+// (Both plan modes read the same canonical fixture; only the apply
+// path forks to /tmp.) The duplication is intentional — the apply
+// path needs to mutate /tmp without touching the canonical fixture
+// used by other Contexts — but it means that adding a fourth
+// package here does NOT automatically extend the apply coverage:
+// you also need to update fixtureSetInstall / fixtureSetRemoval /
+// fixtureSugarPkg in system_package_test.go.
 //
 // Package selection criteria (applied to BOTH this fixture and the
 // apply-side list):

--- a/e2e/config/system-package-test/manifest.cue
+++ b/e2e/config/system-package-test/manifest.cue
@@ -9,8 +9,8 @@ apt: {
 		privileged: true
 		commands: {
 			install: {command: "sudo apt-get install -y"}
-			remove:  {command: "sudo apt-get remove -y"}
-			check:   {command: "dpkg -s"}
+			remove: {command: "sudo apt-get remove -y"}
+			check: {command: "dpkg -s"}
 		}
 	}
 }
@@ -25,13 +25,24 @@ tree: {
 	}
 }
 
+// cliTools is the multi-package SystemPackageSet fixture. Packages here
+// MUST NOT be preinstalled in e2e/containers/ubuntu/Dockerfile — a
+// dpkg-query check that passes because of preinstall would hide any
+// silent no-op regression in the installer. bc (main) and cowsay
+// (universe) are small, daemon-free, and not in the Dockerfile preinstall
+// list. cowsay's runtime Depends are libtext-charwidth-perl and perl:any
+// (both already part of the Ubuntu base via essential dependencies);
+// cowsay-off is Suggests, not Recommends, and is therefore NOT pulled by
+// apt's default install. The apply-time Context in
+// e2e/system_package_test.go re-checks the preinstall invariant in
+// BeforeAll as defence-in-depth against future Dockerfile drift.
 cliTools: {
 	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "SystemPackageSet"
 	metadata: name: "cli-tools"
 	spec: {
 		installerRef: "apt"
-		packages: ["jq", "curl"]
+		packages: ["bc", "cowsay"]
 	}
 }
 

--- a/e2e/config/system-package-test/manifest.cue
+++ b/e2e/config/system-package-test/manifest.cue
@@ -44,7 +44,7 @@ tree: {
 // on the runner`) — see the GitHub runner image inventory at
 // actions/runner-images. The real-apply Context in
 // e2e/system_package_test.go also runs `apt-get remove` for these
-// packages in BeforeAll as a defence-in-depth against a future
+// packages in BeforeAll as a defense-in-depth against a future
 // preinstall regression on either side.
 cliTools: {
 	apiVersion: "tomei.terassyi.net/v1beta1"

--- a/e2e/config/system-package-test/manifest.cue
+++ b/e2e/config/system-package-test/manifest.cue
@@ -25,9 +25,22 @@ tree: {
 	}
 }
 
-// cliTools is the multi-package SystemPackageSet fixture. Packages here
-// are chosen so that the real-apply E2E in system_package_test.go can
-// verify that tomei actually mutated the host. Selection criteria:
+// cliTools is the multi-package SystemPackageSet fixture used by the
+// validate / plan E2E coverage in e2e/system_package_test.go.
+//
+// IMPORTANT — the real-apply E2E does NOT read this fixture. The
+// apply Contexts generate their own /tmp manifests with
+// hard-coded package lists at runtime; this file is only consumed
+// by `tomei validate ~/system-package-test/` and `tomei plan
+// ~/system-package-test/`. The duplication is intentional (the
+// apply path needs to mutate /tmp without touching the canonical
+// fixture used by other Contexts), but it means that adding a
+// fourth package here does NOT automatically extend the apply
+// coverage — you also need to update fixtureSetInstall /
+// fixtureSetRemoval / fixtureSugarPkg in system_package_test.go.
+//
+// Package selection criteria (applied to BOTH this fixture and the
+// apply-side list):
 //
 //   - leaf packages with no reverse dependencies (so a post-suite
 //     apt-get remove cannot cascade into uninstalling unrelated host
@@ -42,10 +55,7 @@ tree: {
 // cowsay and sl satisfy all four. bc was the first attempt and broke
 // the CI native legs (`fixture invariant violated: bc is preinstalled
 // on the runner`) — see the GitHub runner image inventory at
-// actions/runner-images. The real-apply Context in
-// e2e/system_package_test.go also runs `apt-get remove` for these
-// packages in BeforeAll as a defense-in-depth against a future
-// preinstall regression on either side.
+// actions/runner-images.
 cliTools: {
 	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "SystemPackageSet"

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -343,13 +343,37 @@ func systemPackageTests() {
 	// (`installed`, `not-installed`, `config-files`, `half-installed`,
 	// etc.) so the assertion is exact regardless of the desired-state
 	// dimension.
-	pkgCurrentState := func(pkg string) (string, error) {
+	// pkgCurrentState returns the dpkg current-state for pkg ("installed",
+	// "not-installed", "config-files", "half-installed", etc.) or "" when
+	// the package is not in the dpkg database at all.
+	//
+	// testExec.Exec captures via CombinedOutput, so stderr is mixed into
+	// the output buffer. When dpkg-query can't find a package (the
+	// never-installed / purged case), it writes "dpkg-query: no packages
+	// found matching <pkg>" to stderr and exits 1 with EMPTY stdout.
+	// Returning the raw combined output here would surface that
+	// diagnostic string as the "state", which is NOT in the removedStates
+	// allowlist — the preflight on a clean runner would fail before any
+	// apply spec ran. Detect the not-found case via err != nil (dpkg-
+	// query's documented exit-1 contract for unknown packages) and
+	// collapse it to the empty-string "never installed in DB" token that
+	// removedStates explicitly admits.
+	pkgCurrentState := func(pkg string) string {
 		out, err := testExec.Exec("dpkg-query", "-W", "-f=${db:Status-Status}\n", "--", pkg)
-		return strings.TrimSpace(out), err
+		if err != nil {
+			return ""
+		}
+		return strings.TrimSpace(out)
 	}
 	assertInstalled := func(pkg string) {
-		state, err := pkgCurrentState(pkg)
-		Expect(err).NotTo(HaveOccurred(), "dpkg-query failed for %s: %s", pkg, state)
+		// pkgCurrentState now collapses dpkg-query's documented exit-1
+		// not-found case to "" (rather than surfacing the stderr
+		// diagnostic string CombinedOutput would otherwise yield), so
+		// the state-equality check is the single source of truth: any
+		// failure to find the package — not-found, dpkg DB error,
+		// transient — fails this Expect rather than slipping past via
+		// a non-error path.
+		state := pkgCurrentState(pkg)
 		Expect(state).To(Equal("installed"),
 			"package %s should be installed; dpkg-query current-state: %q", pkg, state)
 	}
@@ -377,7 +401,7 @@ func systemPackageTests() {
 		"config-files":  true,
 	}
 	assertNotInstalled := func(pkg string) {
-		state, _ := pkgCurrentState(pkg)
+		state := pkgCurrentState(pkg)
 		Expect(removedStates).To(HaveKey(state),
 			"package %s must be in a known-removed dpkg state (one of %v), got current-state: %q", pkg, removedStates, state)
 	}
@@ -588,17 +612,22 @@ EOF`, dir, strings.Join(quoted, ", "))
 				fmt.Fprintln(GinkgoWriter, "TOMEI_E2E_NATIVE_SKIP_CLEANUP=true: skipping host package + /tmp cleanup")
 				return
 			}
-			// Preflight gate: only apt-get remove the fixture packages
-			// if Context A's BeforeAll preflight succeeded. The
-			// preflight uninstalled any pre-existing copy, so removing
-			// them again here is at worst a no-op rather than a
-			// destructive uninstall of state that predates this
-			// Context. If the preflight aborted, preflightComplete
-			// stays false and we MUST NOT touch host packages — that
-			// was the concrete risk Copilot flagged on the earlier
-			// version. /tmp scratch dirs are always safe to remove
-			// (regex-allowlisted single-segment paths created by this
-			// suite only).
+			// Preflight gate: only act if Context A's BeforeAll
+			// preflight succeeded. Two reasons:
+			//   - apt-get remove: the preflight uninstalled any
+			//     pre-existing copy, so re-removing here is at worst
+			//     a no-op rather than a destructive uninstall of
+			//     state that predates this Context. With
+			//     preflightComplete=false, we MUST NOT touch host
+			//     packages — that was the concrete risk Copilot
+			//     flagged on the earlier version.
+			//   - rm -rf /tmp/...: when skipIfNotLinux skips the
+			//     inner specs (macOS native CI, or non-Debian Linux
+			//     with TOMEI_E2E_NATIVE=true), Context A's BeforeAll
+			//     never runs and these scratch dirs are never
+			//     created by this suite. An unconditional rm -rf
+			//     would otherwise delete a pre-existing host
+			//     directory that happens to share the path.
 			if preflightComplete {
 				// apt-get remove targets only the fixture packages, by
 				// explicit name — no chance of broadening the blast
@@ -623,8 +652,8 @@ EOF`, dir, strings.Join(quoted, ", "))
 				if os.Getenv("TOMEI_E2E_CONTAINER") != "" {
 					_, _ = testExec.ExecBash("sudo -n apt-get autoremove -y 2>&1 || true")
 				}
+				_, _ = testExec.ExecBash("rm -rf /tmp/tomei-system-package-install /tmp/tomei-system-package-removal")
 			}
-			_, _ = testExec.ExecBash("rm -rf /tmp/tomei-system-package-install /tmp/tomei-system-package-removal")
 		})
 
 		Context("Apply --system (real install)", func() {
@@ -698,7 +727,7 @@ EOF`, dir, strings.Join(quoted, ", "))
 					// installed`) or a broken half-installed state both fail
 					// here, so neither can slip past the preflight and make
 					// the install spec a no-op.
-					state, _ := pkgCurrentState(pkg)
+					state := pkgCurrentState(pkg)
 					Expect(removedStates).To(HaveKey(state),
 						"preflight failed: %s is not in a known-removed dpkg state after apt-get remove (current-state: %q, expected one of %v) — the apply spec below would not be exercising a real install", pkg, state, removedStates)
 				}

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -562,15 +562,31 @@ func systemPackageTests() {
 	installCfgPath := "/tmp/tomei-system-package-install-" + scratchSuffix + "/"
 	removalCfgPath := "/tmp/tomei-system-package-removal-" + scratchSuffix + "/"
 
-	// fixturePackages enumerates every package the apply specs may
-	// install on the host (via `tomei apply --system` against the
-	// generated install manifest). BeforeAll itself does NOT install
-	// these — it only snapshots their pre-test state and runs the
-	// preflight remove. The apply spec is the install site; this list
-	// is what BeforeAll snapshots, what the outer AfterAll cleans up,
-	// and what any future drift detector for the fixture set should
-	// stay in lockstep with.
-	fixturePackages := []string{"cowsay", "sl", "tree"}
+	// Source-of-truth constants for the fixture set. The earlier
+	// design had three separate hand-maintained lists (fixturePackages
+	// for cleanup, the install manifest's hard-coded packages, the
+	// removal manifest's hard-coded packages) — those could drift
+	// from each other and silently let the preflight/cleanup operate
+	// on a different set than the apply specs install. Routing every
+	// list through these constants makes drift impossible.
+	//
+	//   fixtureSetInstall — cli-tools SystemPackageSet members at
+	//     install time. Passed to writeSystemPackageManifest for the
+	//     install manifest, used by the apply install spec.
+	//   fixtureSetRemoval — cli-tools members after the shrink (the
+	//     "remove sl, keep cowsay" Context).
+	//   fixtureSugarPkg — the SystemPackage sugar entry (a single
+	//     package, currently `tree`). Embedded into the generated
+	//     manifest's SystemPackage stanza.
+	//
+	// fixturePackages is the derived union of all packages the apply
+	// specs may install — what BeforeAll snapshots, what the outer
+	// AfterAll cleans up, and what the cascade-removal simulator
+	// passes to apt-get -s remove.
+	fixtureSetInstall := []string{"cowsay", "sl"}
+	fixtureSetRemoval := []string{"cowsay"}
+	const fixtureSugarPkg = "tree"
+	fixturePackages := append(append([]string{}, fixtureSetInstall...), fixtureSugarPkg)
 
 	// preflightComplete is set to true at the very end of Context A's
 	// BeforeAll, after the remove-first preflight has succeeded. It is
@@ -779,13 +795,13 @@ apt: {
 	}
 }
 
-tree: {
+%[3]s: {
 	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "SystemPackage"
-	metadata: name: "tree"
+	metadata: name: "%[3]s"
 	spec: {
 		installerRef: "apt"
-		package:      "tree"
+		package:      "%[3]s"
 	}
 }
 
@@ -798,7 +814,7 @@ cliTools: {
 		packages: [%[2]s]
 	}
 }
-EOF`, dir, strings.Join(quoted, ", "))
+EOF`, dir, strings.Join(quoted, ", "), fixtureSugarPkg)
 		_, err = testExec.ExecBash(content)
 		Expect(err).NotTo(HaveOccurred(), "writing manifest content for %s failed", dir)
 	}
@@ -1061,7 +1077,7 @@ EOF`, dir, strings.Join(quoted, ", "))
 				// with no record of what to restore.
 
 				// (1) Non-mutating: write the generated /tmp manifest.
-				writeSystemPackageManifest(strings.TrimRight(installCfgPath, "/"), []string{"cowsay", "sl"})
+				writeSystemPackageManifest(strings.TrimRight(installCfgPath, "/"), fixtureSetInstall)
 
 				// (2) Non-mutating from the host-package perspective: refresh
 				// the apt index. PackageSetInstaller.Install does not refresh
@@ -1374,7 +1390,7 @@ EOF`, dir, strings.Join(quoted, ", "))
 				// byte-stable manifest. (Context A applies its own
 				// generated /tmp/tomei-system-package-install/, not the
 				// canonical fixture, so it doesn't appear in this list.)
-				writeSystemPackageManifest(strings.TrimRight(removalCfgPath, "/"), []string{"cowsay"})
+				writeSystemPackageManifest(strings.TrimRight(removalCfgPath, "/"), fixtureSetRemoval)
 			})
 
 			// Host cleanup is registered at the outer Context scope (see

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -353,17 +353,31 @@ func systemPackageTests() {
 	// found matching <pkg>" to stderr and exits 1 with EMPTY stdout.
 	// Returning the raw combined output here would surface that
 	// diagnostic string as the "state", which is NOT in the removedStates
-	// allowlist — the preflight on a clean runner would fail before any
-	// apply spec ran. Detect the not-found case via err != nil (dpkg-
-	// query's documented exit-1 contract for unknown packages) and
-	// collapse it to the empty-string "never installed in DB" token that
-	// removedStates explicitly admits.
+	// allowlist.
+	//
+	// CRITICAL: we MUST distinguish the documented exit-1 "no packages
+	// found" case from any other dpkg-query failure (DB lock, corruption,
+	// dpkg-query binary missing, etc.). Earlier code collapsed every
+	// err != nil to "" — which meant a real dpkg failure looked
+	// identical to "package absent" and would silently let a pre-test
+	// snapshot record the wrong state OR let assertNotInstalled pass for
+	// the wrong reason. We now match the specific stderr message format
+	// dpkg-query uses for the not-found case and Fail() on anything else.
 	pkgCurrentState := func(pkg string) string {
 		out, err := testExec.Exec("dpkg-query", "-W", "-f=${db:Status-Status}\n", "--", pkg)
-		if err != nil {
+		if err == nil {
+			return strings.TrimSpace(out)
+		}
+		// dpkg-query's stable format for the never-installed /
+		// purged case: `dpkg-query: no packages found matching <pkg>`
+		// (with exit 1). Any other err+output combination indicates
+		// a real failure that must surface — fail the spec rather
+		// than silently treating it as "not installed".
+		if strings.Contains(out, "no packages found matching") {
 			return ""
 		}
-		return strings.TrimSpace(out)
+		Fail(fmt.Sprintf("dpkg-query failed unexpectedly for %s (not the documented 'no packages found' case): err=%v, output=%q", pkg, err, out))
+		return "" // unreachable: Fail() panics
 	}
 	assertInstalled := func(pkg string) {
 		// pkgCurrentState now collapses dpkg-query's documented exit-1
@@ -574,14 +588,24 @@ func systemPackageTests() {
 		// allowlist above restricts dir to a flat single-segment
 		// /tmp/<name> path — no risk of clobbering anything outside
 		// the scratch area.
-		// `set -euo pipefail` so any setup failure (rm -rf refusal, mkdir
-		// failure, heredoc write failure) aborts the script. Without it,
-		// the implicit `; cat > manifest.cue ...` between heredocs would
-		// run even if the earlier rm or module.cue write failed,
-		// returning success while stale `.cue` files remain in place.
+		// Refuse to rm -rf an existing dir that doesn't carry our
+		// ownership marker. The fixed /tmp paths used here are
+		// predictable across runs, so a concurrent process or another
+		// user could theoretically own a directory at the same path
+		// — without this check, a bare `rm -rf` would silently clobber
+		// it. The marker file `.tomei-e2e-system-package-test` lives
+		// at the dir root; on a previous suite run we wrote it
+		// ourselves, so re-running the suite is still idempotent.
+		// `set -euo pipefail` so any setup failure (rm -rf refusal,
+		// mkdir failure, heredoc write failure) aborts the script.
 		script := fmt.Sprintf(`set -euo pipefail
+if [ -e %[1]s ] && [ ! -f %[1]s/.tomei-e2e-system-package-test ]; then
+	echo "refusing to remove %[1]s: directory exists but lacks the .tomei-e2e-system-package-test ownership marker — another process may own this path" >&2
+	exit 1
+fi
 rm -rf %[1]s
 mkdir -p %[1]s/cue.mod
+touch %[1]s/.tomei-e2e-system-package-test
 cat > %[1]s/cue.mod/module.cue <<'EOF'
 module: "tomei.local@v0"
 language: version: "v0.9.0"
@@ -659,22 +683,28 @@ EOF`, dir, strings.Join(quoted, ", "))
 				fmt.Fprintln(GinkgoWriter, "TOMEI_E2E_NATIVE_SKIP_CLEANUP=true: skipping host package + /tmp cleanup")
 				return
 			}
-			// Preflight gate: only act if Context A's BeforeAll
-			// preflight succeeded. Two reasons:
-			//   - apt-get remove: the preflight uninstalled any
-			//     pre-existing copy, so re-removing here is at worst
-			//     a no-op rather than a destructive uninstall of
-			//     state that predates this Context. With
-			//     preflightComplete=false, we MUST NOT touch host
-			//     packages — that was the concrete risk Copilot
-			//     flagged on the earlier version.
-			//   - rm -rf /tmp/...: when skipIfNotLinux skips the
-			//     inner specs (macOS native CI, or non-Debian Linux
-			//     with TOMEI_E2E_NATIVE=true), Context A's BeforeAll
-			//     never runs and these scratch dirs are never
-			//     created by this suite. An unconditional rm -rf
-			//     would otherwise delete a pre-existing host
-			//     directory that happens to share the path.
+			// Three independent cleanup paths follow, each with its
+			// own ownership-tracking flag:
+			//
+			//   1. preflightComplete → fixture-package remove +
+			//      optional autoremove. Acts only when the apply
+			//      specs may have run install.
+			//   2. preflightMutationStarted → restore preTestInstalled.
+			//      Acts whenever the mutating preflight was attempted
+			//      (even if the post-remove assertions failed), so a
+			//      partial remove still re-installs pre-existing
+			//      fixture packages.
+			//   3. scratchDirs (per-dir ledger) → rm -rf the scratch
+			//      directories. Acts only on paths the suite wrote, so
+			//      a pre-existing /tmp dir owned by another process is
+			//      never touched.
+			//
+			// Splitting the gates was Copilot's repeated ask: the
+			// earlier single-flag design either leaked dirs (when the
+			// preflight failed after the manifest was written) or
+			// failed to restore pre-test host packages (when the
+			// preflight removed some but not all, then assertion-
+			// failed).
 			if preflightComplete {
 				// Full cleanup path: the preflight succeeded AND specs
 				// may have run apply, so tomei may have installed the
@@ -1078,6 +1108,14 @@ EOF`, dir, strings.Join(quoted, ", "))
 				Expect(installed).To(HaveKey("tree"),
 					"sugar entry tree must survive a sibling set's shrink; got keys: %v", installed)
 				Expect(installed["tree"]).To(HaveKey("tree"))
+				// Parity with the install-path coverage: a sibling
+				// SystemPackageSet shrink must not corrupt the
+				// surviving SystemPackage sugar entry's recorded
+				// version. An empty version here would indicate the
+				// shrink path rewrote tree.installedVersions["tree"]
+				// to "" instead of leaving it byte-stable.
+				Expect(installed["tree"]["tree"]).NotTo(BeEmpty(),
+					"tree.installedVersions.tree must remain a non-empty version string across a sibling set's shrink")
 			})
 
 			It("re-apply removal manifest WITH --system is idempotent", func() {

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -304,10 +304,12 @@ func systemPackageTests() {
 	// or TOMEI_E2E_NATIVE — see skipIfNotLinux). The two inner Contexts
 	// below are Ordered (inherited from the suite-level `Describe(...,
 	// Ordered, ...)` in suite_test.go): Context A applies a generated
-	// /tmp/tomei-system-package-install/ manifest and asserts install +
-	// state-record + no-op + idempotency; Context B applies a reduced
-	// /tmp/tomei-system-package-removal/ manifest and asserts remove +
-	// state-shrink + idempotency.
+	// /tmp/tomei-system-package-install-<pid>-<ns>/ manifest and
+	// asserts install + state-record + no-op + idempotency; Context B
+	// applies a reduced /tmp/tomei-system-package-removal-<pid>-<ns>/
+	// manifest and asserts remove + state-shrink + idempotency. The
+	// <pid>-<ns> suffix is the per-process scratch suffix described
+	// in the scratchSuffix block below.
 	//
 	// Wrapped in an outer Context so that the host-cleanup AfterAll
 	// (apt-get remove + rm -rf /tmp) lives at a scope that covers BOTH
@@ -1417,8 +1419,9 @@ EOF`, dir, strings.Join(quoted, ", "), fixtureSugarPkg)
 				// the prior validate / plan Contexts that read
 				// ~/system-package-test/manifest.cue keep seeing a
 				// byte-stable manifest. (Context A applies its own
-				// generated /tmp/tomei-system-package-install/, not the
-				// canonical fixture, so it doesn't appear in this list.)
+				// generated /tmp/tomei-system-package-install-<pid>-<ns>/
+				// path, not the canonical fixture, so it doesn't appear
+				// in this list.)
 				writeSystemPackageManifest(strings.TrimRight(removalCfgPath, "/"), fixtureSetRemoval)
 			})
 

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -586,7 +586,27 @@ func systemPackageTests() {
 	fixtureSetInstall := []string{"cowsay", "sl"}
 	fixtureSetRemoval := []string{"cowsay"}
 	const fixtureSugarPkg = "tree"
-	fixturePackages := append(append([]string{}, fixtureSetInstall...), fixtureSugarPkg)
+	// Build fixturePackages as a deduplicated union. A naive
+	// `append(..., fixtureSugarPkg)` would emit duplicates if a future
+	// change makes the sugar package name overlap with fixtureSet
+	// Install (e.g. someone renames the sugar to "cowsay"). Duplicates
+	// in the cleanup/preflight command line would not cause incorrect
+	// behaviour with apt-get (it tolerates them), but would violate
+	// the documented "union" contract and could surprise log readers.
+	fixturePackages := func() []string {
+		seen := map[string]bool{}
+		var out []string
+		for _, p := range fixtureSetInstall {
+			if !seen[p] {
+				seen[p] = true
+				out = append(out, p)
+			}
+		}
+		if !seen[fixtureSugarPkg] {
+			out = append(out, fixtureSugarPkg)
+		}
+		return out
+	}()
 
 	// preflightComplete is set to true at the very end of Context A's
 	// BeforeAll, after the remove-first preflight has succeeded. It is
@@ -607,8 +627,9 @@ func systemPackageTests() {
 	// — so they are deliberately not in the list of preflight aborts.)
 	var preflightComplete bool
 
-	// scratchDirs is a per-directory ownership ledger. writeSystemPackage
-	// Manifest records each scratch path it has successfully written;
+	// scratchDirs is a per-directory ownership ledger.
+	// writeSystemPackageManifest records each scratch path it has
+	// successfully written;
 	// the outer AfterAll iterates the recorded keys and rm -rf's only
 	// those — never the other suite's path nor a pre-existing /tmp
 	// directory the suite did not create. Earlier code used a single

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -742,14 +742,14 @@ func systemPackageTests() {
 		// it up rather than leaking the partial scratch dir.
 		//
 		// Phase 1 — claim. Refuse to rm -rf an existing dir that
-		// doesn't carry our ownership marker. The fixed /tmp paths
-		// used here are predictable across runs, so a concurrent
-		// process or another user could theoretically own a
-		// directory at the same path — without this check, a bare
-		// `rm -rf` would silently clobber it. The marker file
-		// `.tomei-e2e-system-package-test` lives at the dir root;
-		// on a previous suite run we wrote it ourselves, so re-
-		// running the suite is still idempotent.
+		// doesn't carry our ownership marker. With the PID/timestamp
+		// suffix on installCfgPath/removalCfgPath, a fresh suite run
+		// computes an unguessable path so no other process can race
+		// for it; the marker check stays as defense-in-depth against
+		// (a) a future refactor that drops the suffix and reverts to
+		// fixed names, and (b) the edge case of two suite runs from
+		// the same PID with the same nanosecond timestamp (effectively
+		// impossible, but the marker keeps the safety net cheap).
 		// `set -euo pipefail` so any setup failure (rm -rf refusal,
 		// mkdir failure, marker touch failure) aborts the script.
 		claim := fmt.Sprintf(`set -euo pipefail

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -503,15 +503,30 @@ func systemPackageTests() {
 	// deliberately not in the list of preflight aborts.)
 	var preflightComplete bool
 
-	// scratchDirsCreated tracks /tmp scratch-dir ownership independently
-	// from package-preflight ownership. Set to true as soon as
-	// writeSystemPackageManifest writes the install dir, so even if a
-	// later BeforeAll step fails (and preflightComplete stays false),
-	// the outer AfterAll can still rm -rf the dirs the suite created.
-	// Earlier code gated both cleanups on preflightComplete, which left
-	// the scratch dir leaked when the preflight remove or assertion
-	// failed between manifest-write and flag-set.
-	var scratchDirsCreated bool
+	// scratchDirs is a per-directory ownership ledger. writeSystemPackage
+	// Manifest records each scratch path it has successfully written;
+	// the outer AfterAll iterates the recorded keys and rm -rf's only
+	// those — never the other suite's path nor a pre-existing /tmp
+	// directory the suite did not create. Earlier code used a single
+	// boolean flag covering both fixed paths, so a Context A failure
+	// before Context B's manifest was written could still trigger an
+	// rm -rf of /tmp/tomei-system-package-removal even though this
+	// suite never touched it.
+	scratchDirs := map[string]bool{}
+
+	// preflightMutationStarted is set RIGHT BEFORE the host-mutating
+	// `apt-get remove` runs in Context A's BeforeAll, and stays true
+	// even if the subsequent assertions fail. This is the gate for
+	// the restore path in the outer AfterAll: we MUST restore any
+	// pre-test installed fixture package if the preflight remove was
+	// attempted, regardless of whether the assertion loop later passed.
+	//
+	// Earlier code gated restore on preflightComplete (set only after
+	// the assertion loop succeeded), which meant a partial remove
+	// followed by a failing assertion would leave pre-existing fixture
+	// packages uninstalled with no restore — exactly the host-pollution
+	// path the snapshot-and-restore design is meant to close.
+	var preflightMutationStarted bool
 
 	// preTestInstalled records which fixture packages were ALREADY
 	// installed on the host at BeforeAll time, before the preflight
@@ -559,7 +574,15 @@ func systemPackageTests() {
 		// allowlist above restricts dir to a flat single-segment
 		// /tmp/<name> path — no risk of clobbering anything outside
 		// the scratch area.
-		script := fmt.Sprintf(`rm -rf %[1]s && mkdir -p %[1]s/cue.mod && cat > %[1]s/cue.mod/module.cue <<'EOF'
+		// `set -euo pipefail` so any setup failure (rm -rf refusal, mkdir
+		// failure, heredoc write failure) aborts the script. Without it,
+		// the implicit `; cat > manifest.cue ...` between heredocs would
+		// run even if the earlier rm or module.cue write failed,
+		// returning success while stale `.cue` files remain in place.
+		script := fmt.Sprintf(`set -euo pipefail
+rm -rf %[1]s
+mkdir -p %[1]s/cue.mod
+cat > %[1]s/cue.mod/module.cue <<'EOF'
 module: "tomei.local@v0"
 language: version: "v0.9.0"
 EOF
@@ -603,11 +626,12 @@ cliTools: {
 EOF`, dir, strings.Join(quoted, ", "))
 		_, err := testExec.ExecBash(script)
 		Expect(err).NotTo(HaveOccurred(), "writing manifest for %s failed", dir)
-		// Flip ownership for /tmp cleanup. The outer AfterAll's rm -rf
-		// is gated on this flag, so once we've successfully written
-		// the manifest dir we promise to clean it up regardless of
-		// what happens later in BeforeAll.
-		scratchDirsCreated = true
+		// Record this specific dir for AfterAll cleanup. The outer
+		// AfterAll iterates the ledger so it only removes paths this
+		// suite actually wrote — never a pre-existing /tmp directory
+		// nor the OTHER fixture's dir if this BeforeAll didn't write
+		// it (e.g. Context B's removal dir if Context A aborted).
+		scratchDirs[strings.TrimRight(dir, "/")] = true
 	}
 
 	Context("Apply --system mutates host packages (#200)", func() {
@@ -652,9 +676,11 @@ EOF`, dir, strings.Join(quoted, ", "))
 			//     would otherwise delete a pre-existing host
 			//     directory that happens to share the path.
 			if preflightComplete {
-				// apt-get remove targets only the fixture packages, by
-				// explicit name — no chance of broadening the blast
-				// radius.
+				// Full cleanup path: the preflight succeeded AND specs
+				// may have run apply, so tomei may have installed the
+				// fixture packages. Remove them by explicit name (no
+				// blast-radius broadening) before the restore step
+				// re-installs the host's pre-test set.
 				_, _ = testExec.ExecBash("sudo -n apt-get remove -y " + strings.Join(fixturePackages, " ") + " 2>&1 || true")
 				// autoremove is scoped to TOMEI_E2E_CONTAINER ONLY.
 				// `apt-get autoremove` is a host-global operation: it
@@ -668,11 +694,13 @@ EOF`, dir, strings.Join(quoted, ", "))
 				if os.Getenv("TOMEI_E2E_CONTAINER") != "" {
 					_, _ = testExec.ExecBash("sudo -n apt-get autoremove -y 2>&1 || true")
 				}
-				// Restore packages that were already installed on the
-				// host BEFORE the preflight remove ran. Without this,
-				// a native opt-in run that started with cowsay/sl/tree
-				// already installed would have them uninstalled after
-				// the suite. Iterate in fixturePackages order (rather
+			}
+			if preflightMutationStarted {
+				// Restore path runs whenever the preflight remove was
+				// ATTEMPTED — not only when the full preflight succeeded.
+				// A partial remove + failed assertion would otherwise
+				// leave pre-existing fixture packages uninstalled with
+				// no restore. Iterate in fixturePackages order (rather
 				// than map iteration order) so the apt-get install
 				// command line is deterministic across runs.
 				var toRestore []string
@@ -694,13 +722,22 @@ EOF`, dir, strings.Join(quoted, ", "))
 					}
 				}
 			}
-			if scratchDirsCreated {
-				// Scratch-dir cleanup is gated independently from
-				// host-package cleanup. If writeSystemPackageManifest
-				// succeeded but a later BeforeAll step failed, the
-				// scratch dir exists but preflightComplete is false —
-				// we still need to clean up the dir this suite wrote.
-				_, _ = testExec.ExecBash("rm -rf /tmp/tomei-system-package-install /tmp/tomei-system-package-removal")
+			// Scratch-dir cleanup iterates the per-dir ownership ledger
+			// (scratchDirs) rather than blindly removing both fixed
+			// paths. So if Context A wrote its dir and aborted before
+			// Context B wrote its own, only Context A's dir is removed
+			// — a pre-existing /tmp/tomei-system-package-removal owned
+			// by something else is not touched.
+			for dir := range scratchDirs {
+				// Defense-in-depth: re-validate the recorded dir against
+				// the helper's regex before rm -rf. scratchDirs is only
+				// ever populated by writeSystemPackageManifest after the
+				// regex check passes, but a future refactor could route
+				// a different writer to this map; the re-check makes the
+				// rm safe regardless.
+				if systemPackageTestDirRE.MatchString(dir) {
+					_, _ = testExec.ExecBash("rm -rf " + dir)
+				}
 			}
 		})
 
@@ -795,6 +832,17 @@ EOF`, dir, strings.Join(quoted, ", "))
 				// use NOT-purge so /etc/cowsay (none exist, but futureproof)
 				// is preserved; the outer AfterAll handles final removal.
 				//
+				// Mark mutation-started BEFORE the remove runs. This
+				// authorizes the AfterAll restore path independently of
+				// whether the post-remove assertions pass — if apt
+				// removes one pre-existing fixture package and then
+				// fails on another, preflightComplete stays false but
+				// preflightMutationStarted is true, so the restore loop
+				// still re-installs whatever preTestInstalled recorded.
+				// Without this split, a partially-failed preflight could
+				// leave the host with a permanently uninstalled package
+				// that was there before the suite ran.
+				preflightMutationStarted = true
 				// `2>&1 || true` swallows the failure for packages that are
 				// not installed (apt-get remove exits non-zero); the
 				// pkgCurrentState assertions below are the real assertion.

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -548,14 +549,27 @@ func systemPackageTests() {
 	// with the canonical fixture (add pgdgRepo) and either promote the
 	// existing PIts to It or fold the SystemPackageRepository apply
 	// coverage into this Context.
-	const installCfgPath = "/tmp/tomei-system-package-install/"
-	const removalCfgPath = "/tmp/tomei-system-package-removal/"
+	// Scratch paths carry a per-process unguessable suffix
+	// (PID + ns timestamp). The earlier fixed paths
+	// (`/tmp/tomei-system-package-install/`, etc.) were predictable
+	// across runs and across users on the same host, so a same-user
+	// process could race between the marker check and the rm -rf in
+	// writeSystemPackageManifest. With the suffix, no other process
+	// can guess the path before this BeforeAll runs, so the TOCTOU
+	// window between marker validation and removal collapses — the
+	// path is suite-private from the moment of computation.
+	scratchSuffix := fmt.Sprintf("%d-%d", os.Getpid(), time.Now().UnixNano())
+	installCfgPath := "/tmp/tomei-system-package-install-" + scratchSuffix + "/"
+	removalCfgPath := "/tmp/tomei-system-package-removal-" + scratchSuffix + "/"
 
-	// fixturePackages enumerates every package this Context's BeforeAll
-	// may install on the host. Centralized so the BeforeAll remove-first
-	// step, the outer AfterAll cleanup, and any future drift detector
-	// stay in lockstep — adding a fourth package in the manifest without
-	// touching this list would silently leak host state.
+	// fixturePackages enumerates every package the apply specs may
+	// install on the host (via `tomei apply --system` against the
+	// generated install manifest). BeforeAll itself does NOT install
+	// these — it only snapshots their pre-test state and runs the
+	// preflight remove. The apply spec is the install site; this list
+	// is what BeforeAll snapshots, what the outer AfterAll cleans up,
+	// and what any future drift detector for the fixture set should
+	// stay in lockstep with.
 	fixturePackages := []string{"cowsay", "sl", "tree"}
 
 	// preflightComplete is set to true at the very end of Context A's
@@ -563,13 +577,18 @@ func systemPackageTests() {
 	// the gate that authorizes the outer AfterAll to apt-get remove the
 	// fixture packages from the host.
 	//
-	// Outer AfterAll consults it: if BeforeAll aborted before the
-	// preflight completed (e.g. the remove-first step left a package
-	// installed and the Expect surfaced the failure), the flag stays
-	// false and host-package cleanup is a no-op. (`apt-get update`
-	// failures are logged via GinkgoWriter and do NOT abort BeforeAll —
-	// a stale index is usually still functional — so they are
-	// deliberately not in the list of preflight aborts.)
+	// Outer AfterAll consults it: with preflightComplete=false, the
+	// fixture-package remove path is skipped (no `apt-get remove`
+	// against the fixture set). However, the RESTORE path is gated
+	// independently on preflightMutationStarted (set before the
+	// remove-first), so a partial-remove + failed-assertion case
+	// still re-installs anything preTestInstalled recorded. So the
+	// host-package cleanup is not a wholesale no-op when
+	// preflightComplete is false — only the bulk-remove leg is.
+	//
+	// (`apt-get update` failures are logged via GinkgoWriter and do
+	// NOT abort BeforeAll — a stale index is usually still functional
+	// — so they are deliberately not in the list of preflight aborts.)
 	var preflightComplete bool
 
 	// scratchDirs is a per-directory ownership ledger. writeSystemPackage
@@ -644,6 +663,19 @@ func systemPackageTests() {
 	// than silently letting the suite uninstall a package the user
 	// expected to keep.
 	preTestInstalled := map[string]bool{}
+
+	// preTestAutoMarked records which preTestInstalled packages were
+	// in apt's "auto-installed" set at BeforeAll time (i.e. apt-mark
+	// showauto would list them — these are packages apt brought in
+	// as transitive Depends rather than ones the user installed
+	// directly). The outer AfterAll's restore path runs `apt-get
+	// install`, which marks restored packages as MANUALLY installed
+	// by default; without this snapshot, a native opt-in host that
+	// originally had cowsay auto-marked would come back with cowsay
+	// flagged manual, eligible for the user's next `apt autoremove`
+	// to keep when it shouldn't be. Restore therefore also runs
+	// `apt-mark auto <pkg>` for the packages recorded here.
+	preTestAutoMarked := map[string]bool{}
 
 	// preTestPackageSet is a snapshot of EVERY package installed on
 	// the host at BeforeAll time (not just the fixture set). In
@@ -905,6 +937,14 @@ EOF`, dir, strings.Join(quoted, ", "))
 					// reliably reconstructed. The flag goes inside the
 					// verb so it lands BEFORE the `--` end-of-options
 					// separator added by aptCmd.
+					//
+					// After reinstall, re-apply apt's "auto" mark for
+					// packages that were auto-installed pre-test
+					// (apt-get install marks restored packages as
+					// MANUAL by default, which would otherwise change
+					// the host's apt-mark state on net even though the
+					// installed set is restored). Determined from
+					// preTestAutoMarked captured at BeforeAll.
 					out, err := testExec.ExecBash(aptCmd("install --no-install-recommends", toRestore) + " 2>&1")
 					if err != nil {
 						// Best-effort: log and continue. A reinstall
@@ -914,6 +954,25 @@ EOF`, dir, strings.Join(quoted, ", "))
 						// suite at cleanup time; the developer can
 						// re-run apt-get install manually if needed.
 						fmt.Fprintf(GinkgoWriter, "WARNING: failed to restore pre-test packages %v (err=%v):\n%s\n", toRestore, err, out)
+					}
+					// Re-apply auto marks for packages that were
+					// auto-installed pre-test. apt-mark auto is
+					// idempotent and unprivileged-friendly under sudo
+					// (no -n needed because apt-mark itself doesn't
+					// touch the dpkg lock the way apt-get does, but we
+					// keep -n for parity). Iterate in fixturePackages
+					// order for deterministic output.
+					var toAutoMark []string
+					for _, pkg := range fixturePackages {
+						if preTestAutoMarked[pkg] {
+							toAutoMark = append(toAutoMark, pkg)
+						}
+					}
+					if len(toAutoMark) > 0 {
+						mOut, mErr := testExec.ExecBash("sudo -n apt-mark auto -- " + strings.Join(toAutoMark, " ") + " 2>&1")
+						if mErr != nil {
+							fmt.Fprintf(GinkgoWriter, "WARNING: failed to re-apply auto marks for %v (err=%v):\n%s\n", toAutoMark, mErr, mOut)
+						}
 					}
 				}
 			}
@@ -1002,7 +1061,7 @@ EOF`, dir, strings.Join(quoted, ", "))
 				// with no record of what to restore.
 
 				// (1) Non-mutating: write the generated /tmp manifest.
-				writeSystemPackageManifest("/tmp/tomei-system-package-install", []string{"cowsay", "sl"})
+				writeSystemPackageManifest(strings.TrimRight(installCfgPath, "/"), []string{"cowsay", "sl"})
 
 				// (2) Non-mutating from the host-package perspective: refresh
 				// the apt index. PackageSetInstaller.Install does not refresh
@@ -1027,6 +1086,31 @@ EOF`, dir, strings.Join(quoted, ", "))
 				for _, pkg := range fixturePackages {
 					if pkgCurrentState(pkg) == "installed" {
 						preTestInstalled[pkg] = true
+					}
+				}
+
+				// (3a*) Also snapshot apt-mark auto state for the
+				// pre-installed packages, so the AfterAll restore can
+				// re-apply auto-marks. apt-mark showauto is unprivileged
+				// and never prompts; failures here are non-fatal (no
+				// auto-marks captured → restore re-installs as manual,
+				// closer to but not exactly the pre-test state). C
+				// locale not strictly needed (output is package-name
+				// list with no localized phrases) but kept for parity.
+				autoOut, autoErr := testExec.ExecBash("LC_ALL=C LANGUAGE=C apt-mark showauto 2>&1")
+				if autoErr != nil {
+					fmt.Fprintf(GinkgoWriter, "WARNING: apt-mark showauto failed (auto-marks will not be restored): %v\n%s\n", autoErr, autoOut)
+				} else {
+					autoSet := map[string]bool{}
+					for line := range strings.SplitSeq(autoOut, "\n") {
+						if name := strings.TrimSpace(line); name != "" {
+							autoSet[name] = true
+						}
+					}
+					for _, pkg := range fixturePackages {
+						if preTestInstalled[pkg] && autoSet[pkg] {
+							preTestAutoMarked[pkg] = true
+						}
 					}
 				}
 
@@ -1290,7 +1374,7 @@ EOF`, dir, strings.Join(quoted, ", "))
 				// byte-stable manifest. (Context A applies its own
 				// generated /tmp/tomei-system-package-install/, not the
 				// canonical fixture, so it doesn't appear in this list.)
-				writeSystemPackageManifest("/tmp/tomei-system-package-removal", []string{"cowsay"})
+				writeSystemPackageManifest(strings.TrimRight(removalCfgPath, "/"), []string{"cowsay"})
 			})
 
 			// Host cleanup is registered at the outer Context scope (see

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -389,6 +389,19 @@ func systemPackageTests() {
 		if os.Getenv("TOMEI_E2E_CONTAINER") == "" && os.Getenv("TOMEI_E2E_NATIVE") == "" {
 			Skip("real-apply SystemPackageSet mutates host apt state; set TOMEI_E2E_CONTAINER or TOMEI_E2E_NATIVE to opt in (both are set automatically by `make test-e2e` / CI; a bare `go test ./e2e/...` skips by design)")
 		}
+		// Toolchain probe: "Linux" alone is not enough — the specs
+		// below invoke `apt-get install/remove` and `dpkg-query`, which
+		// only exist on Debian-family distros. A TOMEI_E2E_NATIVE=true
+		// run on Fedora/Arch/Alpine/etc. would otherwise hit
+		// command-not-found mid-spec and surface as a misleading test
+		// failure. We probe via `command -v` (POSIX-portable, no
+		// dependency on bash specifics) so the skip message is precise
+		// about which tool is missing.
+		_, errApt := testExec.ExecBash("command -v apt-get >/dev/null 2>&1")
+		_, errDpkg := testExec.ExecBash("command -v dpkg-query >/dev/null 2>&1")
+		if errApt != nil || errDpkg != nil {
+			Skip("real-apply SystemPackageSet requires apt-get and dpkg-query (Debian-family); not available on this Linux host")
+		}
 	}
 
 	// installCfgPath / removalCfgPath are sibling manifests under /tmp/
@@ -415,14 +428,21 @@ func systemPackageTests() {
 	// touching this list would silently leak host state.
 	fixturePackages := []string{"cowsay", "sl", "tree"}
 
-	// fixtureManaged is set to true at the very end of Context A's
-	// BeforeAll, after tomei has had a chance to take ownership of the
-	// fixture packages. Outer AfterAll consults it: if BeforeAll aborted
-	// midway (e.g. the preflight remove-first step failed and the spec
-	// short-circuited), we MUST NOT then unconditionally apt-get remove
-	// the user's pre-existing packages. The flag is the explicit
-	// "we own these now" signal that gates destructive cleanup.
-	var fixtureManaged bool
+	// preflightComplete is set to true at the very end of Context A's
+	// BeforeAll, after the remove-first preflight has succeeded and
+	// `apt-get update` has run. It does NOT mean tomei has installed
+	// anything yet — the first It block is what drives `apply --system`
+	// — but it DOES mean Context A's preflight removed any
+	// pre-existing fixture package from the host, so the outer AfterAll
+	// is free to apt-get remove the same set without risk of clobbering
+	// state that was on the host before this Context ran.
+	//
+	// Outer AfterAll consults it: if BeforeAll aborted before the
+	// preflight completed (e.g. apt-get update failed, or the
+	// remove-first step left a package installed), the flag stays false
+	// and cleanup is a no-op so the user's pre-existing packages are
+	// preserved exactly as they were.
+	var preflightComplete bool
 
 	// writeSystemPackageManifest writes a minimal CUE manifest under dir:
 	// SystemInstaller/apt + SystemPackage/tree sugar + SystemPackageSet
@@ -432,10 +452,11 @@ func systemPackageTests() {
 	// reserved for future CUE template syntax) are inert.
 	//
 	// pkgs is rendered as a CUE list literal; callers MUST pass safe
-	// values (the only call sites are static literals "bc"/"cowsay"). We
-	// validate each entry against a conservative regex so a future caller
-	// with dynamic input cannot break the heredoc terminator or inject
-	// CUE syntax.
+	// values (the only call sites are static literals "cowsay"/"sl",
+	// with "tree" carried by the SystemPackage sugar resource). We
+	// validate each entry against a conservative regex so a future
+	// caller with dynamic input cannot break the heredoc terminator or
+	// inject CUE syntax.
 	writeSystemPackageManifest := func(dir string, pkgs []string) {
 		Expect(systemPackageTestDirRE.MatchString(dir)).To(BeTrue(),
 			"dir %q does not match the absolute-path allowlist; only static /tmp paths are accepted by this helper", dir)
@@ -527,29 +548,41 @@ EOF`, dir, strings.Join(quoted, ", "))
 				fmt.Fprintln(GinkgoWriter, "TOMEI_E2E_NATIVE_SKIP_CLEANUP=true: skipping host package + /tmp cleanup")
 				return
 			}
-			// Ownership gate: only apt-get remove the fixture packages
-			// if Context A's BeforeAll completed (and therefore tomei,
-			// not the runner/developer, is the owner of these packages
-			// post-test). If the preflight remove-first step or any
-			// earlier setup aborted, fixtureManaged stays false and we
-			// MUST NOT touch packages we did not install — that was the
-			// concrete risk Copilot flagged: a failed preinstall
-			// invariant followed by an unconditional apt-get remove of
-			// the user's pre-existing package. /tmp scratch dirs are
-			// always safe to remove (regex-allowlisted single-segment
-			// paths created by this suite only).
-			if fixtureManaged {
-				// `apt-get autoremove` is intentionally included after
-				// the remove step. cowsay's runtime Depends pulled in
-				// libtext-charwidth-perl (and similar transitive
-				// auto-installed packages); without --autoremove,
-				// `apt-get remove` leaves those orphaned on the runner
-				// across suite invocations, which is exactly the
-				// "still leave host package state changed after the
-				// suite" concern Copilot raised. Best-effort: ignore
-				// non-zero exit so a failure in cleanup never masks a
-				// real spec failure.
-				_, _ = testExec.ExecBash("sudo -n apt-get remove -y " + strings.Join(fixturePackages, " ") + " 2>&1; sudo -n apt-get autoremove -y 2>&1; true")
+			// Preflight gate: only apt-get remove the fixture packages
+			// if Context A's BeforeAll preflight succeeded. The
+			// preflight uninstalled any pre-existing copy, so removing
+			// them again here is at worst a no-op rather than a
+			// destructive uninstall of state that predates this
+			// Context. If the preflight aborted, preflightComplete
+			// stays false and we MUST NOT touch host packages — that
+			// was the concrete risk Copilot flagged on the earlier
+			// version. /tmp scratch dirs are always safe to remove
+			// (regex-allowlisted single-segment paths created by this
+			// suite only).
+			if preflightComplete {
+				// apt-get remove targets only the fixture packages, by
+				// explicit name — no chance of broadening the blast
+				// radius.
+				_, _ = testExec.ExecBash("sudo -n apt-get remove -y " + strings.Join(fixturePackages, " ") + " 2>&1 || true")
+				// autoremove is scoped to TOMEI_E2E_CONTAINER ONLY.
+				// `apt-get autoremove` is a host-global operation: it
+				// removes ANY package currently marked auto-removable,
+				// not just transitive Depends introduced by this
+				// suite. On an ephemeral CI container we own the
+				// filesystem and the broader cleanup is desirable; on
+				// a native runner or developer laptop (even with
+				// TOMEI_E2E_NATIVE=true), it could remove unrelated
+				// auto-installed packages the user expects to keep.
+				// The trade-off: native mode may leave cowsay's
+				// transitive Depends (e.g. libtext-charwidth-perl)
+				// orphaned across suite runs. That's acceptable
+				// because the ephemeral CI native runner is wiped
+				// between jobs anyway, and a developer running with
+				// TOMEI_E2E_NATIVE=true has opted in to host mutation
+				// being best-effort rather than perfect.
+				if os.Getenv("TOMEI_E2E_CONTAINER") != "" {
+					_, _ = testExec.ExecBash("sudo -n apt-get autoremove -y 2>&1 || true")
+				}
 			}
 			_, _ = testExec.ExecBash("rm -rf /tmp/tomei-system-package-install /tmp/tomei-system-package-removal")
 		})
@@ -616,13 +649,13 @@ EOF`, dir, strings.Join(quoted, ", "))
 				out, err := testExec.ExecBash("sudo -n apt-get update -qq 2>&1")
 				fmt.Fprintf(GinkgoWriter, "apt-get update (err=%v):\n%s\n", err, out)
 
-				// Take ownership: from this point, the outer AfterAll is
-				// authorized to apt-get remove the fixture packages.
-				// Setting this AFTER all preflight steps complete means a
-				// preflight failure leaves it false and the AfterAll
-				// becomes a no-op — preserving the user/runner's
-				// pre-existing host state in that scenario.
-				fixtureManaged = true
+				// Mark preflight as complete: from this point the outer
+				// AfterAll is allowed to run apt-get remove against the
+				// fixture packages. The preflight already uninstalled any
+				// pre-existing copies, so even if no spec runs to install
+				// them, the AfterAll is a safe no-op rather than a
+				// destructive uninstall.
+				preflightComplete = true
 			})
 
 			It("apply --system installs the manifest packages on the host", func() {

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -401,20 +401,30 @@ func systemPackageTests() {
 	}
 
 	// snapshotInstalledPackages returns the set of currently-installed
-	// package names on the host. Used by the outer AfterAll to detect
-	// any packages added since BeforeAll (typically transitive Depends
-	// pulled in by `apt-get install` for cowsay etc.) so cleanup can
-	// remove them explicitly rather than leaking them onto a native
-	// opt-in runner. Generic + fixture-agnostic: works no matter which
-	// fixture packages we choose or what their Depends graph looks like.
+	// package names on the host. Used by the outer AfterAll (in
+	// TOMEI_E2E_CONTAINER mode only) to detect any packages added
+	// since BeforeAll — typically transitive Depends pulled in by
+	// `apt-get install` for cowsay etc. — so container-mode cleanup
+	// can remove them explicitly. Native mode does not run the diff
+	// (see the gated block in AfterAll) so a native opt-in run may
+	// leak transitive deps; that's an intentional trade-off documented
+	// alongside the diff-cleanup site.
+	//
+	// Returns (set, error) rather than calling Expect so the outer
+	// AfterAll's best-effort cleanup contract is preserved: a
+	// dpkg-query failure during cleanup is logged and the diff step is
+	// skipped, instead of failing the spec (which would mask the
+	// underlying assertion that triggered the cleanup).
 	//
 	// Locale is forced to C so the dpkg-query Status-Status field
 	// always emits the un-translated tokens (`installed`,
 	// `not-installed`, etc.) the Go strings.Fields filter below
 	// matches against.
-	snapshotInstalledPackages := func() map[string]bool {
+	snapshotInstalledPackages := func() (map[string]bool, error) {
 		out, err := testExec.ExecBash(`LC_ALL=C LANGUAGE=C dpkg-query -W -f='${db:Status-Status} ${binary:Package}` + "\n" + `' 2>/dev/null`)
-		Expect(err).NotTo(HaveOccurred(), "dpkg-query enumeration failed: %s", out)
+		if err != nil {
+			return nil, fmt.Errorf("dpkg-query enumeration failed: %s: %w", out, err)
+		}
 		set := map[string]bool{}
 		for line := range strings.SplitSeq(out, "\n") {
 			fields := strings.Fields(line)
@@ -422,7 +432,7 @@ func systemPackageTests() {
 				set[fields[1]] = true
 			}
 		}
-		return set
+		return set, nil
 	}
 	assertInstalled := func(pkg string) {
 		// pkgCurrentState now collapses dpkg-query's documented exit-1
@@ -602,14 +612,20 @@ func systemPackageTests() {
 	preTestInstalled := map[string]bool{}
 
 	// preTestPackageSet is a snapshot of EVERY package installed on
-	// the host at BeforeAll time (not just the fixture set). The
-	// outer AfterAll diffs this against the post-test snapshot to
-	// identify transitive dependencies pulled in by tomei's apt-get
-	// install (e.g. libtext-charwidth-perl for cowsay) and removes
-	// them explicitly. This replaces the earlier blanket
-	// `apt-get autoremove` which Copilot flagged as too broad — the
-	// diff approach only touches packages whose presence is
-	// attributable to this suite's BeforeAll/It path.
+	// the host at BeforeAll time (not just the fixture set). In
+	// TOMEI_E2E_CONTAINER mode the outer AfterAll diffs this against
+	// the post-test snapshot to identify transitive dependencies
+	// pulled in by tomei's apt-get install (e.g. libtext-charwidth-
+	// perl for cowsay) and removes them explicitly. This replaces the
+	// earlier blanket `apt-get autoremove` which Copilot flagged as
+	// too broad.
+	//
+	// In native mode the diff is intentionally NOT run — a user/
+	// system could install packages concurrently during the E2E
+	// window and the diff cannot distinguish those from suite-
+	// introduced deps. Native mode therefore may leak cowsay's
+	// transitive Depends; that's an opt-in trade-off (CI native is
+	// ephemeral, dev laptop signed up for best-effort host mutation).
 	var preTestPackageSet map[string]bool
 
 	// writeSystemPackageManifest writes a minimal CUE manifest under dir:
@@ -792,17 +808,28 @@ EOF`, dir, strings.Join(quoted, ", "))
 				// runner is ephemeral and a developer on
 				// TOMEI_E2E_NATIVE=true has opted in to best-effort
 				// host mutation.
-				currentSet := snapshotInstalledPackages()
-				var leaked []string
-				for pkg := range currentSet {
-					if !preTestPackageSet[pkg] {
-						leaked = append(leaked, pkg)
+				//
+				// snapshotInstalledPackages returns an error here
+				// instead of calling Expect, so a dpkg-query failure
+				// inside cleanup is logged and the diff step is
+				// skipped — never failing the spec from within
+				// AfterAll (which would mask the original assertion
+				// failure that triggered the cleanup).
+				currentSet, snapErr := snapshotInstalledPackages()
+				if snapErr != nil {
+					fmt.Fprintf(GinkgoWriter, "WARNING: diff-based dep cleanup skipped: %v\n", snapErr)
+				} else {
+					var leaked []string
+					for pkg := range currentSet {
+						if !preTestPackageSet[pkg] {
+							leaked = append(leaked, pkg)
+						}
 					}
-				}
-				sort.Strings(leaked)
-				if len(leaked) > 0 {
-					fmt.Fprintf(GinkgoWriter, "removing %d package(s) introduced by the suite: %v\n", len(leaked), leaked)
-					_, _ = testExec.ExecBash("sudo -n apt-get remove -y " + strings.Join(leaked, " ") + " 2>&1 || true")
+					sort.Strings(leaked)
+					if len(leaked) > 0 {
+						fmt.Fprintf(GinkgoWriter, "removing %d package(s) introduced by the suite: %v\n", len(leaked), leaked)
+						_, _ = testExec.ExecBash("sudo -n apt-get remove -y " + strings.Join(leaked, " ") + " 2>&1 || true")
+					}
 				}
 			}
 			if preflightMutationStarted {
@@ -943,10 +970,14 @@ EOF`, dir, strings.Join(quoted, ", "))
 				// snapshot too, for the dep-leak diff in AfterAll.
 				// Captured here (after fixture preflight snapshot but
 				// before remove) so the post-test diff isolates packages
-				// added by tomei's install step — including transitive
-				// Depends like libtext-charwidth-perl that apt-get
-				// remove without autoremove would otherwise leak.
-				preTestPackageSet = snapshotInstalledPackages()
+				// added by tomei's install step. BeforeAll Expects on
+				// the error: a failed baseline snapshot would silently
+				// disable the diff cleanup, defeating the purpose, so
+				// fail fast here rather than at AfterAll time.
+				var snapErr error
+				preTestPackageSet, snapErr = snapshotInstalledPackages()
+				Expect(snapErr).NotTo(HaveOccurred(),
+					"baseline snapshotInstalledPackages failed — cannot establish a pre-test package set for the AfterAll diff cleanup")
 
 				// (3b) Mutating: preflight remove-first. Ensures the fixture
 				// packages are NOT installed before tomei runs, so the
@@ -973,7 +1004,18 @@ EOF`, dir, strings.Join(quoted, ", "))
 				// is defense-in-depth for any future fixture change.
 				// Matches the production PackageSetInstaller's pre-
 				// remove simulation.
-				simOut, _ := testExec.ExecBash("LC_ALL=C LANGUAGE=C sudo -n apt-get -s remove -y " + strings.Join(fixturePackages, " ") + " 2>&1")
+				//
+				// Capture the simulation's exit code: a non-zero exit
+				// means apt failed to even compute the plan (lock held,
+				// broken dependency DB, etc.) and the output cannot be
+				// trusted as "no cascade detected". Abort the spec
+				// before the real mutating remove runs. (apt-get -s
+				// remove returns 0 even when packages are not
+				// installed — that case is benign and produces no Remv
+				// lines, so we don't need to special-case it.)
+				simOut, simErr := testExec.ExecBash("LC_ALL=C LANGUAGE=C sudo -n apt-get -s remove -y " + strings.Join(fixturePackages, " ") + " 2>&1")
+				Expect(simErr).NotTo(HaveOccurred(),
+					"apt-get -s remove simulation failed — cannot verify the real remove will not cascade. Aborting before host mutation. Full output:\n%s", simOut)
 				fixtureSet := map[string]bool{}
 				for _, p := range fixturePackages {
 					fixtureSet[p] = true
@@ -1168,9 +1210,11 @@ EOF`, dir, strings.Join(quoted, ", "))
 				// {cowsay, sl} to {cowsay}, so the removal driven by
 				// `apply --system` is exactly the sl package. We
 				// generate this as a sibling to the canonical fixture so
-				// prior Contexts (validate / plan / Apply A) that read
+				// the prior validate / plan Contexts that read
 				// ~/system-package-test/manifest.cue keep seeing a
-				// byte-stable manifest.
+				// byte-stable manifest. (Context A applies its own
+				// generated /tmp/tomei-system-package-install/, not the
+				// canonical fixture, so it doesn't appear in this list.)
 				writeSystemPackageManifest("/tmp/tomei-system-package-removal", []string{"cowsay"})
 			})
 

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -613,10 +613,20 @@ func systemPackageTests() {
 	//     instead of failing immediately on transient apt contention
 	//   - --: end-of-options so package names that look like flags
 	//     cannot be misinterpreted
-	// Keeping the e2e wrapper byte-identical to production means a
-	// future change to the wrapper (different timeout, additional env
-	// var, etc.) lands in one place and both the suite and the code
-	// under test stay aligned.
+	//
+	// DUPLICATION NOTE: this string is intentionally a copy of the
+	// production wrapper rather than a shared call into internal/
+	// installer/apt. The e2e binary is built with the `e2e` tag and
+	// must not depend on the production installer's runtime types
+	// (Client, executor.Runner, etc.) to avoid pulling in cmd/tomei
+	// engine wiring. A future change to the production wrapper
+	// (different lock timeout, additional env var, etc.) therefore
+	// requires updating BOTH internal/installer/apt/apt.go aptGetEnv
+	// Prefix AND this helper in lockstep — there is no compile-time
+	// check enforcing the link. The drift detector for that contract
+	// is: if production ever stops being NOPASSWD or stops using
+	// LC_ALL=C, the apt invocations in this suite would diverge and
+	// the CI native legs would surface the inconsistency first.
 	aptCmd := func(verb string, pkgs []string) string {
 		return "sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get " + verb + " -y -o DPkg::Lock::Timeout=60 -- " + strings.Join(pkgs, " ")
 	}
@@ -786,7 +796,7 @@ EOF`, dir, strings.Join(quoted, ", "))
 				fmt.Fprintln(GinkgoWriter, "TOMEI_E2E_NATIVE_SKIP_CLEANUP=true: skipping host package + /tmp cleanup")
 				return
 			}
-			// Three independent cleanup paths follow, each with its
+			// Four independent cleanup paths follow, each with its
 			// own ownership-tracking flag:
 			//
 			//   1. preflightComplete → fixture-package remove. Acts
@@ -803,7 +813,7 @@ EOF`, dir, strings.Join(quoted, ", "))
 			//      so a partial remove still re-installs pre-existing
 			//      fixture packages even when post-remove assertions
 			//      failed and preflightComplete stayed false.
-			//   3. scratchDirs (per-dir ledger) → rm -rf the scratch
+			//   4. scratchDirs (per-dir ledger) → rm -rf the scratch
 			//      directories. Acts only on paths the suite wrote, so
 			//      a pre-existing /tmp dir owned by another process is
 			//      never touched.

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -490,23 +490,41 @@ func systemPackageTests() {
 	fixturePackages := []string{"cowsay", "sl", "tree"}
 
 	// preflightComplete is set to true at the very end of Context A's
-	// BeforeAll, after the remove-first preflight has succeeded and
-	// `apt-get update` has run. It does NOT mean tomei has installed
-	// anything yet — the first It block is what drives `apply --system`
-	// — but it DOES mean Context A's preflight removed any
-	// pre-existing fixture package from the host, so the outer AfterAll
-	// is free to apt-get remove the same set without risk of clobbering
-	// state that was on the host before this Context ran.
+	// BeforeAll, after the remove-first preflight has succeeded. It is
+	// the gate that authorizes the outer AfterAll to apt-get remove the
+	// fixture packages from the host.
 	//
 	// Outer AfterAll consults it: if BeforeAll aborted before the
 	// preflight completed (e.g. the remove-first step left a package
 	// installed and the Expect surfaced the failure), the flag stays
-	// false and cleanup is a no-op so the user's pre-existing packages
-	// are preserved exactly as they were. (`apt-get update` failures
-	// are logged via GinkgoWriter and do NOT abort BeforeAll — a stale
-	// index is usually still functional — so they are deliberately not
-	// in the list of preflight aborts.)
+	// false and host-package cleanup is a no-op. (`apt-get update`
+	// failures are logged via GinkgoWriter and do NOT abort BeforeAll —
+	// a stale index is usually still functional — so they are
+	// deliberately not in the list of preflight aborts.)
 	var preflightComplete bool
+
+	// scratchDirsCreated tracks /tmp scratch-dir ownership independently
+	// from package-preflight ownership. Set to true as soon as
+	// writeSystemPackageManifest writes the install dir, so even if a
+	// later BeforeAll step fails (and preflightComplete stays false),
+	// the outer AfterAll can still rm -rf the dirs the suite created.
+	// Earlier code gated both cleanups on preflightComplete, which left
+	// the scratch dir leaked when the preflight remove or assertion
+	// failed between manifest-write and flag-set.
+	var scratchDirsCreated bool
+
+	// preTestInstalled records which fixture packages were ALREADY
+	// installed on the host at BeforeAll time, before the preflight
+	// remove ran. The outer AfterAll uses it to distinguish packages
+	// the test owns (install them; remove on cleanup) from packages
+	// the host owned pre-test (remove then re-install on cleanup, so
+	// the developer's host state survives the suite). Capture-and-
+	// restore is intentionally best-effort: a reinstall after the
+	// suite has run apt-get autoremove may be a no-op if the package
+	// disappeared from the cache, but that failure mode is more
+	// transparent (log + leave-uninstalled) than silently letting the
+	// suite uninstall a package the user expected to keep.
+	preTestInstalled := map[string]bool{}
 
 	// writeSystemPackageManifest writes a minimal CUE manifest under dir:
 	// SystemInstaller/apt + SystemPackage/tree sugar + SystemPackageSet
@@ -585,6 +603,11 @@ cliTools: {
 EOF`, dir, strings.Join(quoted, ", "))
 		_, err := testExec.ExecBash(script)
 		Expect(err).NotTo(HaveOccurred(), "writing manifest for %s failed", dir)
+		// Flip ownership for /tmp cleanup. The outer AfterAll's rm -rf
+		// is gated on this flag, so once we've successfully written
+		// the manifest dir we promise to clean it up regardless of
+		// what happens later in BeforeAll.
+		scratchDirsCreated = true
 	}
 
 	Context("Apply --system mutates host packages (#200)", func() {
@@ -642,16 +665,41 @@ EOF`, dir, strings.Join(quoted, ", "))
 				// a native runner or developer laptop (even with
 				// TOMEI_E2E_NATIVE=true), it could remove unrelated
 				// auto-installed packages the user expects to keep.
-				// The trade-off: native mode may leave cowsay's
-				// transitive Depends (e.g. libtext-charwidth-perl)
-				// orphaned across suite runs. That's acceptable
-				// because the ephemeral CI native runner is wiped
-				// between jobs anyway, and a developer running with
-				// TOMEI_E2E_NATIVE=true has opted in to host mutation
-				// being best-effort rather than perfect.
 				if os.Getenv("TOMEI_E2E_CONTAINER") != "" {
 					_, _ = testExec.ExecBash("sudo -n apt-get autoremove -y 2>&1 || true")
 				}
+				// Restore packages that were already installed on the
+				// host BEFORE the preflight remove ran. Without this,
+				// a native opt-in run that started with cowsay/sl/tree
+				// already installed would have them uninstalled after
+				// the suite. Iterate in fixturePackages order (rather
+				// than map iteration order) so the apt-get install
+				// command line is deterministic across runs.
+				var toRestore []string
+				for _, pkg := range fixturePackages {
+					if preTestInstalled[pkg] {
+						toRestore = append(toRestore, pkg)
+					}
+				}
+				if len(toRestore) > 0 {
+					out, err := testExec.ExecBash("sudo -n apt-get install -y --no-install-recommends " + strings.Join(toRestore, " ") + " 2>&1")
+					if err != nil {
+						// Best-effort: log and continue. A reinstall
+						// failure (e.g. mirror outage, package vanished
+						// from the index between BeforeAll and AfterAll)
+						// is more transparent than failing the whole
+						// suite at cleanup time; the developer can
+						// re-run apt-get install manually if needed.
+						fmt.Fprintf(GinkgoWriter, "WARNING: failed to restore pre-test packages %v (err=%v):\n%s\n", toRestore, err, out)
+					}
+				}
+			}
+			if scratchDirsCreated {
+				// Scratch-dir cleanup is gated independently from
+				// host-package cleanup. If writeSystemPackageManifest
+				// succeeded but a later BeforeAll step failed, the
+				// scratch dir exists but preflightComplete is false —
+				// we still need to clean up the dir this suite wrote.
 				_, _ = testExec.ExecBash("rm -rf /tmp/tomei-system-package-install /tmp/tomei-system-package-removal")
 			}
 		})
@@ -660,11 +708,28 @@ EOF`, dir, strings.Join(quoted, ", "))
 			BeforeAll(func() {
 				skipIfNotLinux()
 
-				// Ensure tomei is initialized — `tomei apply` aborts early with
-				// "tomei is not initialized" otherwise. --force makes the call
-				// idempotent across prior Contexts (some of which may have
-				// already run init). Pattern: e2e/privileged_test.go:16.
-				_, _ = testExec.Exec("tomei", "init", "--yes", "--force")
+				// Probe non-interactive sudo BEFORE touching host state.
+				// Outer AfterAll's apt-get remove uses `sudo -n` and
+				// swallows errors (cleanup is best-effort by design); on
+				// a native opt-in run with interactive-only sudo, that
+				// cleanup would silently no-op and leave cowsay/sl/tree
+				// installed. By failing the spec up-front when sudo is
+				// not passwordless, we trade a clean fail-fast for the
+				// alternative of silent host pollution.
+				_, sudoErr := testExec.ExecBash("sudo -n true 2>&1")
+				Expect(sudoErr).NotTo(HaveOccurred(),
+					"non-interactive sudo (NOPASSWD) is required: the AfterAll cleanup uses `sudo -n` and would silently leave fixture packages installed without it")
+
+				// Ensure tomei is initialized — `tomei apply` aborts early
+				// with "tomei is not initialized" otherwise. --force makes
+				// the call idempotent across prior Contexts. Assert
+				// success here: silently ignoring the error would let the
+				// host-mutating preflight below run even when the
+				// downstream apply spec is guaranteed to fail with
+				// "tomei is not initialized", uninstalling fixture
+				// packages without ever exercising the install path.
+				initOut, initErr := testExec.Exec("tomei", "init", "--yes", "--force")
+				Expect(initErr).NotTo(HaveOccurred(), "tomei init failed before preflight: %s", initOut)
 
 				// Reset SYSTEM state only — user-store belongs to other suites.
 				// Top-level JSON keys match internal/state/state.go SystemState.
@@ -701,7 +766,21 @@ EOF`, dir, strings.Join(quoted, ", "))
 				out, err := testExec.ExecBash("sudo -n apt-get update -qq 2>&1")
 				fmt.Fprintf(GinkgoWriter, "apt-get update (err=%v):\n%s\n", err, out)
 
-				// (3) Mutating: preflight remove-first. Ensures the fixture
+				// (3a) Snapshot which fixture packages are already installed
+				// on the host BEFORE the preflight remove runs. The outer
+				// AfterAll uses this to reinstall any package that was
+				// here pre-test, so a native opt-in run leaves the
+				// developer/runner's host state untouched on net
+				// (uninstall + reinstall = no-op modulo version drift).
+				// Captured before the remove so we can distinguish
+				// "tomei installed this" from "the host had this before".
+				for _, pkg := range fixturePackages {
+					if pkgCurrentState(pkg) == "installed" {
+						preTestInstalled[pkg] = true
+					}
+				}
+
+				// (3b) Mutating: preflight remove-first. Ensures the fixture
 				// packages are NOT installed before tomei runs, so the
 				// subsequent `apply --system` actually exercises the install
 				// path rather than passing because the package happened to

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -410,7 +410,8 @@ func systemPackageTests() {
 	//
 	// Locale is forced to C so the dpkg-query Status-Status field
 	// always emits the un-translated tokens (`installed`,
-	// `not-installed`, etc.) the awk filter below matches against.
+	// `not-installed`, etc.) the Go strings.Fields filter below
+	// matches against.
 	snapshotInstalledPackages := func() map[string]bool {
 		out, err := testExec.ExecBash(`LC_ALL=C LANGUAGE=C dpkg-query -W -f='${db:Status-Status} ${binary:Package}` + "\n" + `' 2>/dev/null`)
 		Expect(err).NotTo(HaveOccurred(), "dpkg-query enumeration failed: %s", out)
@@ -592,11 +593,12 @@ func systemPackageTests() {
 	// the test owns (install them; remove on cleanup) from packages
 	// the host owned pre-test (remove then re-install on cleanup, so
 	// the developer's host state survives the suite). Capture-and-
-	// restore is intentionally best-effort: a reinstall after the
-	// suite has run apt-get autoremove may be a no-op if the package
-	// disappeared from the cache, but that failure mode is more
-	// transparent (log + leave-uninstalled) than silently letting the
-	// suite uninstall a package the user expected to keep.
+	// restore is intentionally best-effort: a reinstall failure (e.g.
+	// mirror outage, package vanished from the apt cache between
+	// BeforeAll and AfterAll) is logged via GinkgoWriter rather than
+	// failing the suite at cleanup time, which is more transparent
+	// than silently letting the suite uninstall a package the user
+	// expected to keep.
 	preTestInstalled := map[string]bool{}
 
 	// preTestPackageSet is a snapshot of EVERY package installed on
@@ -747,14 +749,14 @@ EOF`, dir, strings.Join(quoted, ", "))
 			// Three independent cleanup paths follow, each with its
 			// own ownership-tracking flag:
 			//
-			//   1. preflightComplete → fixture-package remove +
-			//      optional autoremove. Acts only when the apply
-			//      specs may have run install.
-			//   2. preflightMutationStarted → restore preTestInstalled.
-			//      Acts whenever the mutating preflight was attempted
-			//      (even if the post-remove assertions failed), so a
-			//      partial remove still re-installs pre-existing
-			//      fixture packages.
+			//   1. preflightComplete → fixture-package remove. Acts
+			//      only when the apply specs may have run install.
+			//   2. preflightMutationStarted → diff-based dep cleanup
+			//      (snapshotInstalledPackages before/after) + restore
+			//      of preTestInstalled. Acts whenever the mutating
+			//      preflight was attempted, so a partial remove still
+			//      re-installs pre-existing fixture packages and the
+			//      dep diff still removes packages tomei pulled in.
 			//   3. scratchDirs (per-dir ledger) → rm -rf the scratch
 			//      directories. Acts only on paths the suite wrote, so
 			//      a pre-existing /tmp dir owned by another process is
@@ -774,14 +776,22 @@ EOF`, dir, strings.Join(quoted, ", "))
 				// re-installs the host's pre-test set.
 				_, _ = testExec.ExecBash("sudo -n apt-get remove -y " + strings.Join(fixturePackages, " ") + " 2>&1 || true")
 			}
-			if preflightMutationStarted && preTestPackageSet != nil {
-				// Diff-based dep cleanup: any package currently
-				// installed that was NOT in preTestPackageSet was
-				// introduced by tomei's apt-get install (cowsay pulls
-				// libtext-charwidth-perl, etc.). Remove only those —
-				// no host-global autoremove, no risk of clobbering
-				// packages the user opted to keep. Iterate sorted so
-				// the apt-get remove command line is deterministic.
+			if preflightMutationStarted && preTestPackageSet != nil && os.Getenv("TOMEI_E2E_CONTAINER") != "" {
+				// Diff-based dep cleanup, scoped to TOMEI_E2E_CONTAINER
+				// ONLY. In container mode we own the entire FS, so any
+				// package now present that wasn't pre-test is by
+				// definition something tomei installed (cowsay pulled
+				// libtext-charwidth-perl, etc.) — safe to remove.
+				//
+				// In native mode (CI native legs OR developer laptop)
+				// the user/system could install packages concurrently
+				// during the E2E window, and the diff would falsely
+				// attribute those to the suite. The trade-off: native
+				// mode may leak cowsay's transitive Depends across
+				// suite runs. That's acceptable because the CI native
+				// runner is ephemeral and a developer on
+				// TOMEI_E2E_NATIVE=true has opted in to best-effort
+				// host mutation.
 				currentSet := snapshotInstalledPackages()
 				var leaked []string
 				for pkg := range currentSet {
@@ -953,6 +963,41 @@ EOF`, dir, strings.Join(quoted, ", "))
 				// use NOT-purge so /etc/cowsay (none exist, but futureproof)
 				// is preserved; the outer AfterAll handles final removal.
 				//
+				// Cascade-removal probe. Simulate the remove (`apt-get
+				// -s`) BEFORE mutating anything: if apt reports any
+				// non-fixture package would be removed as a reverse-
+				// dependency of cowsay/sl/tree, abort the spec rather
+				// than uninstalling host state the restore path
+				// doesn't track. cowsay/sl/tree are leaf packages today,
+				// so the simulation reports only the fixture set; this
+				// is defense-in-depth for any future fixture change.
+				// Matches the production PackageSetInstaller's pre-
+				// remove simulation.
+				simOut, _ := testExec.ExecBash("LC_ALL=C LANGUAGE=C sudo -n apt-get -s remove -y " + strings.Join(fixturePackages, " ") + " 2>&1")
+				fixtureSet := map[string]bool{}
+				for _, p := range fixturePackages {
+					fixtureSet[p] = true
+				}
+				var cascade []string
+				for line := range strings.SplitSeq(simOut, "\n") {
+					// `apt-get -s remove` prints `Remv <pkg> [<version>]`
+					// for each package that would actually be removed.
+					if !strings.HasPrefix(line, "Remv ") {
+						continue
+					}
+					fields := strings.Fields(line)
+					if len(fields) < 2 {
+						continue
+					}
+					if !fixtureSet[fields[1]] {
+						cascade = append(cascade, fields[1])
+					}
+				}
+				sort.Strings(cascade)
+				Expect(cascade).To(BeEmpty(),
+					"preflight remove would cascade-remove non-fixture package(s) %v — aborting before any host mutation so the restore path (which only knows about fixturePackages) cannot lose unrelated host state. Full apt-get -s remove output:\n%s",
+					cascade, simOut)
+
 				// Mark mutation-started BEFORE the remove runs. This
 				// authorizes the AfterAll restore path independently of
 				// whether the post-remove assertions pass — if apt

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -3,7 +3,11 @@
 package e2e
 
 import (
+	"fmt"
 	"os"
+	"regexp"
+	"runtime"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -47,6 +51,28 @@ var ubuntuReleaseToCodename = map[string]string{
 	"22.04": "jammy",
 	"24.04": "noble",
 }
+
+// systemPackageTestPkgNameRE is a conservative allowlist for package
+// names appearing in the writeSystemPackageManifest helper. It rejects
+// any name that could break the single-quoted heredoc body or inject CUE
+// syntax (quotes, whitespace, control chars, slashes). Production
+// validation in internal/installer/apt/apt.go uses a blacklist of
+// disallowed characters which accepts a wider set of Debian-legal names
+// (e.g., uppercase, longer punctuation); this test-helper allowlist is
+// intentionally narrower — it only needs to admit the small fixture set
+// ("bc", "cowsay", "tree") and refuses anything riskier even if that
+// rejects names production would happily accept. Compiled once at
+// package init to avoid re-parsing per call.
+var systemPackageTestPkgNameRE = regexp.MustCompile(`^[a-z0-9][a-z0-9+\-.]*$`)
+
+// systemPackageTestDirRE is a path allowlist for writeSystemPackageManifest's
+// dir argument. Callers currently pass only static literals under /tmp/,
+// but Sprintf-into-shell-heredoc semantics mean any future caller passing
+// a path with shell metacharacters (`$`, backticks, `;`) would break out
+// of the heredoc. Defense-in-depth: refuse anything that isn't an
+// alphanumeric/`/`/`-`/`_`/`.` path so the failure mode is a loud
+// Expect rather than silent code execution.
+var systemPackageTestDirRE = regexp.MustCompile(`^/[A-Za-z0-9._/\-]+$`)
 
 // pgdgKeyHashSHA256 is the pinned SHA256 of the PostgreSQL APT signing
 // key referenced from e2e/config/system-package-test/manifest.cue. The
@@ -264,5 +290,335 @@ func systemPackageTests() {
 				//   - /etc/apt/sources.list.d/pgdg.list is gone, and
 				//   - state.json no longer mentions pgdg.
 			})
+	})
+
+	// SystemPackageSet apply coverage (#200). Mutates host packages, so
+	// gated to linux (apt). The two Contexts below are Ordered: Context A
+	// installs from the canonical fixture; Context B reduces the manifest
+	// to drive an apt-get remove. Context B's AfterAll cleans up the host.
+	//
+	// dpkg-query -W -f='${Status}' is preferred over dpkg -l because
+	// `dpkg -l` exits 0 for the `rc` ("removed but config present") state
+	// after `apt-get remove` without --purge — a false-positive trap for
+	// post-remove assertions. `install ok installed` is the only state
+	// that counts as "installed"; `deinstall ok config-files` (the
+	// post-remove state) is correctly excluded by NotTo ContainSubstring.
+
+	// dpkg-query is invoked via argv form (testExec.Exec) rather than
+	// shell-string concatenation: the package name lives in its own argv
+	// slot, eliminating the shell-injection footgun even if a future
+	// caller passes a dynamic pkg string. `--` defends against pkg names
+	// that could look like options. dpkg-query exits non-zero when no
+	// matching package is in the dpkg DB (the post-purge state); for
+	// assertInstalled this is a failure, for assertNotInstalled it counts
+	// as "removed".
+	assertInstalled := func(pkg string) {
+		out, err := testExec.Exec("dpkg-query", "-W", "-f=${Status}\n", "--", pkg)
+		Expect(err).NotTo(HaveOccurred(), "dpkg-query failed for %s: %s", pkg, out)
+		Expect(strings.TrimSpace(out)).To(Equal("install ok installed"),
+			"package %s should be installed; dpkg-query Status: %q", pkg, out)
+	}
+	assertNotInstalled := func(pkg string) {
+		// apt-get remove (NOT --purge) leaves dpkg in
+		// "deinstall ok config-files"; a never-installed or purged package
+		// produces an exit-1 with empty stdout from dpkg-query. Both count
+		// as "removed"; only "install ok installed" is forbidden.
+		out, _ := testExec.Exec("dpkg-query", "-W", "-f=${Status}\n", "--", pkg)
+		Expect(out).NotTo(ContainSubstring("install ok installed"),
+			"package %s must not be in installed state; dpkg-query: %q", pkg, out)
+	}
+
+	// stateHash returns sha256 of the system state.json. Used over mtime
+	// equality because ext4 mtime granularity is 1 second — a touch within
+	// the same second as the prior write would silently pass an mtime
+	// check. sha256sum exits non-zero if the file is missing, which the
+	// Expect surfaces as a clear failure.
+	stateHash := func() string {
+		out, err := testExec.ExecBash("sha256sum ~/.local/share/tomei/system/state.json | awk '{print $1}'")
+		Expect(err).NotTo(HaveOccurred(), "sha256sum on system state.json failed: %s", out)
+		return strings.TrimSpace(out)
+	}
+
+	skipIfNotLinux := func() {
+		targetOS := runtime.GOOS
+		if os.Getenv("TOMEI_E2E_CONTAINER") != "" {
+			targetOS = "linux"
+		}
+		if targetOS != "linux" {
+			Skip("real-apply SystemPackageSet requires apt; current OS is " + targetOS)
+		}
+	}
+
+	// installCfgPath / removalCfgPath are sibling manifests under /tmp/
+	// that exercise the SystemPackageSet apply path WITHOUT pgdgRepo.
+	// pgdg's installer needs `gpg --dearmor` and `gnupg` is intentionally
+	// not in the runner image (#197 follow-up will add it together with a
+	// network mock). The canonical fixture at ~/system-package-test/ keeps
+	// pgdgRepo so the prior validate/plan/PIt Contexts continue to assert
+	// against it; the apply Contexts here use their own sibling manifests
+	// to isolate the SystemPackageSet apply path.
+	//
+	// TODO(#197-followup): once gnupg lands in the runner image and PGDG
+	// network access can be mocked, re-align the install/removal heredocs
+	// with the canonical fixture (add pgdgRepo) and either promote the
+	// existing PIts to It or fold the SystemPackageRepository apply
+	// coverage into this Context.
+	const installCfgPath = "/tmp/tomei-system-package-install/"
+	const removalCfgPath = "/tmp/tomei-system-package-removal/"
+
+	// writeSystemPackageManifest writes a minimal CUE manifest under dir:
+	// SystemInstaller/apt + SystemPackage/tree sugar + SystemPackageSet
+	// cli-tools with the given package list. The single-quoted heredoc
+	// terminator (<<'EOF') prevents any shell expansion inside the
+	// manifest body, so the embedded `$` and `${...}` (none today, but
+	// reserved for future CUE template syntax) are inert.
+	//
+	// pkgs is rendered as a CUE list literal; callers MUST pass safe
+	// values (the only call sites are static literals "bc"/"cowsay"). We
+	// validate each entry against a conservative regex so a future caller
+	// with dynamic input cannot break the heredoc terminator or inject
+	// CUE syntax.
+	writeSystemPackageManifest := func(dir string, pkgs []string) {
+		Expect(systemPackageTestDirRE.MatchString(dir)).To(BeTrue(),
+			"dir %q does not match the absolute-path allowlist; only static /tmp paths are accepted by this helper", dir)
+		for _, p := range pkgs {
+			Expect(systemPackageTestPkgNameRE.MatchString(p)).To(BeTrue(),
+				"pkg %q does not match the conservative test-helper allowlist; the production allowlist is in internal/installer/apt/apt.go", p)
+		}
+		quoted := make([]string, len(pkgs))
+		for i, p := range pkgs {
+			quoted[i] = `"` + p + `"`
+		}
+		script := fmt.Sprintf(`mkdir -p %[1]s/cue.mod && cat > %[1]s/cue.mod/module.cue <<'EOF'
+module: "tomei.local@v0"
+language: version: "v0.9.0"
+EOF
+cat > %[1]s/manifest.cue <<'EOF'
+package tomei
+
+apt: {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "SystemInstaller"
+	metadata: name: "apt"
+	spec: {
+		pattern:    "delegation"
+		privileged: true
+		commands: {
+			install: {command: "sudo apt-get install -y"}
+			remove:  {command: "sudo apt-get remove -y"}
+			check:   {command: "dpkg -s"}
+		}
+	}
+}
+
+tree: {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "SystemPackage"
+	metadata: name: "tree"
+	spec: {
+		installerRef: "apt"
+		package:      "tree"
+	}
+}
+
+cliTools: {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "SystemPackageSet"
+	metadata: name: "cli-tools"
+	spec: {
+		installerRef: "apt"
+		packages: [%[2]s]
+	}
+}
+EOF`, dir, strings.Join(quoted, ", "))
+		_, err := testExec.ExecBash(script)
+		Expect(err).NotTo(HaveOccurred(), "writing manifest for %s failed", dir)
+	}
+
+	Context("Apply --system (real install)", func() {
+		BeforeAll(func() {
+			skipIfNotLinux()
+
+			// Ensure tomei is initialized — `tomei apply` aborts early with
+			// "tomei is not initialized" otherwise. --force makes the call
+			// idempotent across prior Contexts (some of which may have
+			// already run init). Pattern: e2e/privileged_test.go:16.
+			_, _ = testExec.Exec("tomei", "init", "--yes", "--force")
+
+			// Reset SYSTEM state only — user-store belongs to other suites.
+			// Top-level JSON keys match internal/state/state.go SystemState.
+			// Failure here means the home directory is misconfigured and
+			// every downstream spec would surface a misleading error, so
+			// fail loudly instead of swallowing the error.
+			_, err := testExec.ExecBash(`mkdir -p ~/.local/share/tomei/system && echo '{"version":"1","systemInstallers":{},"systemPackageRepositories":{},"systemPackages":{}}' > ~/.local/share/tomei/system/state.json`)
+			Expect(err).NotTo(HaveOccurred(), "failed to reset system state.json")
+
+			// Defense-in-depth: if a future Dockerfile change adds any
+			// fixture pkg to the preinstall list, a post-apply dpkg-query
+			// check would pass even if tomei did nothing. Detect that drift
+			// at BeforeAll time with a precise error message.
+			for _, pkg := range []string{"bc", "cowsay", "tree"} {
+				out, _ := testExec.ExecBash("dpkg-query -W -f='${Status}\\n' " + pkg + " 2>&1 || true")
+				Expect(out).NotTo(ContainSubstring("install ok installed"),
+					"fixture invariant violated: %s is preinstalled on the runner — pick a different package", pkg)
+			}
+
+			writeSystemPackageManifest("/tmp/tomei-system-package-install", []string{"bc", "cowsay"})
+
+			// PackageSetInstaller.Install does not refresh the apt index
+			// (PackageRepositoryInstaller does, but only that one). CI
+			// images carry stale indexes; refresh once. Tolerate non-zero
+			// exit — apt exits non-zero on any mirror failure, but a
+			// partial refresh is usually enough for the apply step to
+			// produce a clearer downstream error than `update` would.
+			// The err is captured (not silently dropped) so a complete
+			// mirror outage surfaces in GinkgoWriter alongside the output.
+			out, err := testExec.ExecBash("sudo -n apt-get update -qq 2>&1")
+			fmt.Fprintf(GinkgoWriter, "apt-get update (err=%v):\n%s\n", err, out)
+		})
+
+		It("apply --system installs the manifest packages on the host", func() {
+			out, err := ExecApply(testExec, "--system", installCfgPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).To(ContainSubstring("SystemPackageSet/cli-tools"))
+			Expect(out).To(ContainSubstring("SystemPackageSet/tree"))
+			assertInstalled("bc")
+			assertInstalled("cowsay")
+			assertInstalled("tree")
+		})
+
+		It("records InstalledVersions for the sugar and the set in state.json", func() {
+			raw, err := testExec.ExecBash("cat ~/.local/share/tomei/system/state.json")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(raw).To(ContainSubstring(`"cli-tools"`))
+			Expect(raw).To(ContainSubstring(`"tree"`))
+			Expect(raw).To(ContainSubstring(`"installedVersions"`))
+			Expect(raw).To(ContainSubstring(`"bc"`))
+			Expect(raw).To(ContainSubstring(`"cowsay"`))
+		})
+
+		It("apply WITHOUT --system is a no-op (system resources skip-downgraded)", func() {
+			// Anchor the prior install: if the previous It silently failed,
+			// the state would be empty and "no rewrite" would trivially
+			// pass. MatchRegexp pins the structural shape — systemPackages
+			// is a non-empty map with cli-tools as a top-level key — so a
+			// stray "cli-tools" substring elsewhere in the JSON (e.g. in a
+			// later nested ref) can't satisfy the assertion.
+			rawBefore, _ := testExec.ExecBash("cat ~/.local/share/tomei/system/state.json")
+			Expect(rawBefore).To(MatchRegexp(`"systemPackages"\s*:\s*\{[^}]*"cli-tools"`),
+				"prerequisite: prior --system apply must have populated systemPackages.cli-tools in state.json before testing no-op semantics; got:\n%s", rawBefore)
+
+			hashBefore := stateHash()
+			out, err := ExecApply(testExec, installCfgPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).To(ContainSubstring("SystemPackageSet/cli-tools"))
+			assertInstalled("bc")
+			assertInstalled("cowsay")
+			assertInstalled("tree")
+			Expect(stateHash()).To(Equal(hashBefore),
+				"apply without --system must not rewrite system state.json")
+		})
+
+		It("re-apply --system is idempotent (plan shows zero work)", func() {
+			// Plan summary is matched by regex so harmless cosmetic
+			// changes to the tree.go printer (color codes, spacing) do not
+			// break the assertion; the four-counter structure is the
+			// invariant. The trailing `, N disabled` segment only renders
+			// when ActionSkip > 0, which is not the case here post-#216
+			// (SystemPackageSet is no longer skip-downgraded with --system).
+			out, err := testExec.Exec("tomei", "plan", "--system", installCfgPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).To(MatchRegexp(`Summary:\s+0 to install,\s+0 to upgrade,\s+0 to reinstall,\s+0 to remove\b`))
+
+			hashBefore := stateHash()
+			_, err = ExecApply(testExec, "--system", installCfgPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stateHash()).To(Equal(hashBefore),
+				"idempotent re-apply must not rewrite state.json")
+		})
+	})
+
+	Context("Apply --system removal and idempotency", func() {
+		BeforeAll(func() {
+			skipIfNotLinux()
+
+			// Pre-flight: anchor Context A's post-install state. If
+			// Context A succeeded, bc/cowsay/tree are installed and the
+			// system state.json holds entries for cli-tools/tree. Without
+			// this guard, a silent failure upstream would let Context B's
+			// "WITH --system runs apt-get remove" spec pass trivially
+			// (nothing to remove → state already matches removal target).
+			assertInstalled("bc")
+			assertInstalled("cowsay")
+			assertInstalled("tree")
+
+			// Reduced manifest under /tmp/ — do NOT edit the canonical
+			// fixture at ~/system-package-test/manifest.cue in place; the
+			// prior Contexts (validate / plan / Apply A) depend on it
+			// being byte-stable.
+			writeSystemPackageManifest("/tmp/tomei-system-package-removal", []string{"bc"})
+		})
+
+		AfterAll(func() {
+			// Native-mode safety: on a developer laptop (TOMEI_E2E_NATIVE)
+			// the AfterAll would otherwise apt-get remove packages the
+			// developer might use day-to-day, and rm -rf predictable /tmp/
+			// paths that a parallel suite or other tooling could be
+			// writing to. In containerised CI we own the entire FS, so
+			// cleanup is safe and beneficial (run-to-run isolation).
+			if os.Getenv("TOMEI_E2E_NATIVE") == "true" {
+				fmt.Fprintln(GinkgoWriter, "TOMEI_E2E_NATIVE=true: skipping host package + /tmp cleanup")
+				return
+			}
+			// Best-effort cleanup. Tolerate non-zero exit so a failure
+			// inside cleanup never masks the spec failure that surfaced
+			// the real bug. apt-get remove (NOT --purge) is enough — we
+			// don't care about lingering config files on an ephemeral CI
+			// runner.
+			_, _ = testExec.ExecBash("sudo -n apt-get remove -y bc cowsay tree 2>&1 || true")
+			_, _ = testExec.ExecBash("rm -rf /tmp/tomei-system-package-install /tmp/tomei-system-package-removal")
+		})
+
+		It("apply removal manifest WITHOUT --system retains cowsay in state (no-op)", func() {
+			hashBefore := stateHash()
+			_, err := ExecApply(testExec, removalCfgPath)
+			Expect(err).NotTo(HaveOccurred())
+			raw, _ := testExec.ExecBash("cat ~/.local/share/tomei/system/state.json")
+			Expect(raw).To(ContainSubstring(`"cowsay"`))
+			assertInstalled("cowsay")
+			Expect(stateHash()).To(Equal(hashBefore),
+				"removal manifest applied without --system must not rewrite state.json")
+		})
+
+		It("apply removal manifest WITH --system runs apt-get remove and updates state.json", func() {
+			out, err := ExecApply(testExec, "--system", removalCfgPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).To(ContainSubstring("SystemPackageSet/cli-tools"))
+			assertNotInstalled("cowsay")
+			assertInstalled("bc")
+			assertInstalled("tree")
+			raw, _ := testExec.ExecBash("cat ~/.local/share/tomei/system/state.json")
+			Expect(raw).To(ContainSubstring(`"cli-tools"`))
+			Expect(raw).To(ContainSubstring(`"bc"`))
+			// The SystemPackage sugar entry must survive a sibling set's
+			// shrink — confirms removal scope is per-resource, not global.
+			Expect(raw).To(ContainSubstring(`"tree"`))
+			Expect(raw).NotTo(ContainSubstring(`"cowsay"`))
+		})
+
+		It("re-apply removal manifest WITH --system is idempotent", func() {
+			// Mirrors Context A's idempotency: once the removal has
+			// converged, a second --system apply against the same reduced
+			// manifest must be a plan-zero / state-byte-stable no-op.
+			out, err := testExec.Exec("tomei", "plan", "--system", removalCfgPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).To(MatchRegexp(`Summary:\s+0 to install,\s+0 to upgrade,\s+0 to reinstall,\s+0 to remove\b`))
+
+			hashBefore := stateHash()
+			_, err = ExecApply(testExec, "--system", removalCfgPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stateHash()).To(Equal(hashBefore),
+				"idempotent re-apply of the removal manifest must not rewrite state.json")
+		})
 	})
 }

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -325,14 +325,18 @@ func systemPackageTests() {
 	// (`hold ok installed` in the full Status triple) also collapse to
 	// `installed` here and are correctly classified as installed.
 
-	// dpkg-query is invoked via argv form (testExec.Exec) rather than
-	// shell-string concatenation: the package name lives in its own argv
-	// slot, eliminating the shell-injection footgun even if a future
-	// caller passes a dynamic pkg string. `--` defends against pkg names
-	// that could look like options. dpkg-query exits non-zero when no
-	// matching package is in the dpkg DB (the post-purge state); for
-	// assertInstalled this is a failure, for assertNotInstalled it counts
-	// as "removed".
+	// pkgCurrentState below uses ExecBash (not argv-form Exec) because
+	// it needs to set LC_ALL=C / LANGUAGE=C on the dpkg-query
+	// invocation — the not-found stderr message is localized otherwise.
+	// Shell-injection safety relies on a regex allowlist enforced
+	// inside the helper itself (`systemPackageTestPkgNameRE`, the same
+	// pattern used by writeSystemPackageManifest): the regex rejects
+	// every shell-meaningful character so embedding pkg into the script
+	// is safe. The earlier argv-form invocation lost the locale lever
+	// and was replaced by the ExecBash + regex pattern documented here.
+	// dpkg-query exits non-zero when no matching package is in the
+	// dpkg DB (the post-purge state); for assertInstalled this is a
+	// failure, for assertNotInstalled it counts as "removed".
 	//
 	// Format string uses `${db:Status-Status}` (the third sub-field of
 	// Status — the *current* state) rather than the full `${Status}`

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -353,16 +353,33 @@ func systemPackageTests() {
 		Expect(state).To(Equal("installed"),
 			"package %s should be installed; dpkg-query current-state: %q", pkg, state)
 	}
+	// removedStates is the explicit allowlist of dpkg current-states that
+	// count as "removed" for the purposes of this suite:
+	//
+	//   - `""`             — dpkg-query exit-1 with empty stdout, meaning
+	//                        the package is not in the dpkg DB at all
+	//                        (never installed, or purged).
+	//   - `not-installed`  — known to dpkg but not currently installed.
+	//   - `config-files`   — apt-get remove (without --purge) leaves
+	//                        config files behind; binaries are gone.
+	//
+	// Other current-states (`installed`, `half-installed`, `unpacked`,
+	// `half-configured`, `triggers-awaited`, `triggers-pending`) all
+	// indicate the package is in a transitional or broken-but-present
+	// state on the host — none of those should count as "removed", and
+	// the earlier `NotTo(Equal("installed"))` predicate would have let
+	// `half-installed` / `unpacked` slip through and mask a failed
+	// removal. The explicit allowlist makes the contract one-way:
+	// anything not on the list is a failure.
+	removedStates := map[string]bool{
+		"":              true,
+		"not-installed": true,
+		"config-files":  true,
+	}
 	assertNotInstalled := func(pkg string) {
-		// apt-get remove (NOT --purge) leaves dpkg current-state
-		// as `config-files`; a never-installed or purged package
-		// returns an exit-1 with empty current-state. Both count as
-		// "removed"; `installed` and the half-installed transitional
-		// states are the only values forbidden — anything else means
-		// the package is not currently runnable on the host.
 		state, _ := pkgCurrentState(pkg)
-		Expect(state).NotTo(Equal("installed"),
-			"package %s must not be in installed state; dpkg-query current-state: %q", pkg, state)
+		Expect(removedStates).To(HaveKey(state),
+			"package %s must be in a known-removed dpkg state (one of %v), got current-state: %q", pkg, removedStates, state)
 	}
 
 	// stateHash returns sha256 of the system state.json. Used over mtime
@@ -628,59 +645,67 @@ EOF`, dir, strings.Join(quoted, ", "))
 				_, err := testExec.ExecBash(`mkdir -p ~/.local/share/tomei/system && echo '{"version":"1","systemInstallers":{},"systemPackageRepositories":{},"systemPackages":{}}' > ~/.local/share/tomei/system/state.json`)
 				Expect(err).NotTo(HaveOccurred(), "failed to reset system state.json")
 
-				// Preflight remove-first: ensure the fixture packages are
-				// NOT installed before tomei runs, so the subsequent
-				// `apply --system` actually exercises the install path
-				// rather than passing because the package happened to
-				// already be on the runner.
-				//
-				// History: an earlier version of this Context used a hard
-				// fail-on-preinstalled invariant ("pick a different
-				// package") which broke the linux/arm64 native CI leg
-				// because GitHub-hosted ubuntu-24.04 runners preinstall
-				// `bc`. Switching to cowsay/sl (universe, leaf, NOT in
-				// any known runner-image preinstall list) plus this
-				// remove-first step makes the spec robust against future
-				// preinstall drift on either side — if a future runner
-				// image starts shipping cowsay or sl, the remove step
-				// uninstalls it cleanly and the test still validates a
-				// fresh install. We use NOT-purge here so /etc/cowsay
-				// (none exist, but futureproof) is preserved; the outer
-				// AfterAll handles the final removal.
-				//
-				// `2>&1 || true` swallows the failure for packages that
-				// are not installed (apt-get remove exits non-zero) so
-				// the BeforeAll proceeds; the assertNotInstalled checks
-				// below are the real assertion that the host is clean.
-				_, _ = testExec.ExecBash("sudo -n apt-get remove -y " + strings.Join(fixturePackages, " ") + " 2>&1 || true")
-				for _, pkg := range fixturePackages {
-					// Mirror the assertNotInstalled helper above: query the
-					// current-state sub-field so a held installed package
-					// (Status `hold ok installed`) cannot pass the
-					// not-installed assertion. Without this, `apt-mark
-					// hold cowsay` on a runner image would slip past the
-					// preflight and make the install spec a no-op.
-					state, _ := pkgCurrentState(pkg)
-					Expect(state).NotTo(Equal("installed"),
-						"preflight failed: %s is still installed after apt-get remove (dpkg-query current-state: %q) — the apply spec below would not be exercising a real install", pkg, state)
-				}
+				// Ordering matters: do every non-mutating setup step FIRST,
+				// THEN the host-mutating preflight remove, THEN set
+				// preflightComplete. If a non-mutating step fails it does so
+				// before any host package has been touched, so
+				// preflightComplete stays false, the outer AfterAll skips
+				// cleanup, and a pre-existing host install of cowsay/sl/tree
+				// survives. The earlier ordering performed the remove BEFORE
+				// writing the manifest and running apt-get update — a write
+				// or update failure between those two steps would have left
+				// a developer's previously-installed package uninstalled
+				// with no record of what to restore.
 
+				// (1) Non-mutating: write the generated /tmp manifest.
 				writeSystemPackageManifest("/tmp/tomei-system-package-install", []string{"cowsay", "sl"})
 
-				// PackageSetInstaller.Install does not refresh the apt index
-				// (PackageRepositoryInstaller does, but only that one). CI
-				// images carry stale indexes; refresh once. Tolerate non-zero
-				// exit — apt exits non-zero on any mirror failure, but a
-				// partial refresh is usually enough for the apply step to
-				// produce a clearer downstream error than `update` would.
+				// (2) Non-mutating from the host-package perspective: refresh
+				// the apt index. PackageSetInstaller.Install does not refresh
+				// it itself (PackageRepositoryInstaller does, but only that
+				// one). CI images carry stale indexes; refresh once. Tolerate
+				// non-zero exit — apt exits non-zero on any mirror failure,
+				// but a partial refresh is usually enough for the apply step
+				// to produce a clearer downstream error than `update` would.
 				// The err is captured (not silently dropped) so a complete
 				// mirror outage surfaces in GinkgoWriter alongside the output.
 				out, err := testExec.ExecBash("sudo -n apt-get update -qq 2>&1")
 				fmt.Fprintf(GinkgoWriter, "apt-get update (err=%v):\n%s\n", err, out)
 
-				// Mark preflight as complete: from this point the outer
+				// (3) Mutating: preflight remove-first. Ensures the fixture
+				// packages are NOT installed before tomei runs, so the
+				// subsequent `apply --system` actually exercises the install
+				// path rather than passing because the package happened to
+				// already be on the runner.
+				//
+				// History: an earlier version used a hard fail-on-preinstalled
+				// invariant which broke the linux/arm64 native CI leg because
+				// GH-hosted ubuntu-24.04 runners preinstall `bc`. Switching
+				// to cowsay/sl (universe, leaf, NOT in any known runner-image
+				// preinstall list) plus this remove-first step makes the spec
+				// robust against future preinstall drift on either side. We
+				// use NOT-purge so /etc/cowsay (none exist, but futureproof)
+				// is preserved; the outer AfterAll handles final removal.
+				//
+				// `2>&1 || true` swallows the failure for packages that are
+				// not installed (apt-get remove exits non-zero); the
+				// pkgCurrentState assertions below are the real assertion.
+				_, _ = testExec.ExecBash("sudo -n apt-get remove -y " + strings.Join(fixturePackages, " ") + " 2>&1 || true")
+				for _, pkg := range fixturePackages {
+					// Query the current-state sub-field and check it against
+					// the same removedStates allowlist assertNotInstalled
+					// uses — a held installed package (Status `hold ok
+					// installed`) or a broken half-installed state both fail
+					// here, so neither can slip past the preflight and make
+					// the install spec a no-op.
+					state, _ := pkgCurrentState(pkg)
+					Expect(removedStates).To(HaveKey(state),
+						"preflight failed: %s is not in a known-removed dpkg state after apt-get remove (current-state: %q, expected one of %v) — the apply spec below would not be exercising a real install", pkg, state, removedStates)
+				}
+
+				// (4) Mark preflight complete. From this point the outer
 				// AfterAll is allowed to run apt-get remove against the
-				// fixture packages. The preflight already uninstalled any
+				// fixture packages — the preflight already uninstalled any
 				// pre-existing copies, so even if no spec runs to install
 				// them, the AfterAll is a safe no-op rather than a
 				// destructive uninstall.
@@ -781,7 +806,19 @@ EOF`, dir, strings.Join(quoted, ", "))
 				// (SystemPackageSet is no longer skip-downgraded with --system).
 				out, err := testExec.Exec("tomei", "plan", "--system", installCfgPath)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(out).To(MatchRegexp(`Summary:\s+0 to install,\s+0 to upgrade,\s+0 to reinstall,\s+0 to remove\b`))
+				// Anchor to end-of-line with `(?m)$`. The earlier
+				// `\b` form matched at the comma boundary, so a
+				// trailing `, N disabled` segment (rendered only when
+				// ActionSkip > 0) would have satisfied the regex —
+				// meaning a regression where SystemPackageSet starts
+				// being skip-downgraded again with --system would pass
+				// silently. Adding a separate ContainSubstring
+				// negation on "disabled" closes the loop in case the
+				// printer rephrases the suffix.
+				Expect(out).To(MatchRegexp(`(?m)^Summary:\s+0 to install,\s+0 to upgrade,\s+0 to reinstall,\s+0 to remove\s*$`),
+					"plan summary must end at '0 to remove' with no trailing ', N disabled' counter; got:\n%s", out)
+				Expect(out).NotTo(ContainSubstring("disabled"),
+					"plan output must not contain 'disabled' (SystemPackageSet must not be skip-downgraded with --system); got:\n%s", out)
 
 				hashBefore := stateHash()
 				_, err = ExecApply(testExec, "--system", installCfgPath)
@@ -893,7 +930,19 @@ EOF`, dir, strings.Join(quoted, ", "))
 				// manifest must be a plan-zero / state-byte-stable no-op.
 				out, err := testExec.Exec("tomei", "plan", "--system", removalCfgPath)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(out).To(MatchRegexp(`Summary:\s+0 to install,\s+0 to upgrade,\s+0 to reinstall,\s+0 to remove\b`))
+				// Anchor to end-of-line with `(?m)$`. The earlier
+				// `\b` form matched at the comma boundary, so a
+				// trailing `, N disabled` segment (rendered only when
+				// ActionSkip > 0) would have satisfied the regex —
+				// meaning a regression where SystemPackageSet starts
+				// being skip-downgraded again with --system would pass
+				// silently. Adding a separate ContainSubstring
+				// negation on "disabled" closes the loop in case the
+				// printer rephrases the suffix.
+				Expect(out).To(MatchRegexp(`(?m)^Summary:\s+0 to install,\s+0 to upgrade,\s+0 to reinstall,\s+0 to remove\s*$`),
+					"plan summary must end at '0 to remove' with no trailing ', N disabled' counter; got:\n%s", out)
+				Expect(out).NotTo(ContainSubstring("disabled"),
+					"plan output must not contain 'disabled' (SystemPackageSet must not be skip-downgraded with --system); got:\n%s", out)
 
 				hashBefore := stateHash()
 				_, err = ExecApply(testExec, "--system", removalCfgPath)

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -816,7 +816,7 @@ apt: {
 	}
 }
 
-%[3]s: {
+"%[3]s": {
 	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "SystemPackage"
 	metadata: name: "%[3]s"
@@ -1135,19 +1135,27 @@ EOF`, dir, strings.Join(quoted, ", "), fixtureSugarPkg)
 				// locale not strictly needed (output is package-name
 				// list with no localized phrases) but kept for parity.
 				autoOut, autoErr := testExec.ExecBash("LC_ALL=C LANGUAGE=C apt-mark showauto 2>&1")
-				if autoErr != nil {
-					fmt.Fprintf(GinkgoWriter, "WARNING: apt-mark showauto failed (auto-marks will not be restored): %v\n%s\n", autoErr, autoOut)
-				} else {
-					autoSet := map[string]bool{}
-					for line := range strings.SplitSeq(autoOut, "\n") {
-						if name := strings.TrimSpace(line); name != "" {
-							autoSet[name] = true
-						}
+				// Fail fast (rather than log-and-continue) if the
+				// auto-mark snapshot can't be taken: continuing with
+				// an empty preTestAutoMarked would let the AfterAll
+				// restore re-install pre-existing fixture packages as
+				// MANUAL, silently changing apt's auto/manual metadata
+				// on a native opt-in host that had them auto-marked.
+				// Aborting BeforeAll here happens BEFORE the preflight
+				// remove runs, so no host package state has been
+				// touched yet — preflightMutationStarted stays false
+				// and AfterAll is a no-op.
+				Expect(autoErr).NotTo(HaveOccurred(),
+					"apt-mark showauto failed before preflight remove: %s\nrefusing to mutate host packages without a complete auto-mark snapshot for restore", autoOut)
+				autoSet := map[string]bool{}
+				for line := range strings.SplitSeq(autoOut, "\n") {
+					if name := strings.TrimSpace(line); name != "" {
+						autoSet[name] = true
 					}
-					for _, pkg := range fixturePackages {
-						if preTestInstalled[pkg] && autoSet[pkg] {
-							preTestAutoMarked[pkg] = true
-						}
+				}
+				for _, pkg := range fixturePackages {
+					if preTestInstalled[pkg] && autoSet[pkg] {
+						preTestAutoMarked[pkg] = true
 					}
 				}
 

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -597,6 +597,30 @@ func systemPackageTests() {
 	// path the snapshot-and-restore design is meant to close.
 	var preflightMutationStarted bool
 
+	// aptCmd wraps an apt-get verb in the same shell prefix the
+	// production apt installer uses (see internal/installer/apt/apt.go
+	// aptGetEnvPrefix + Client.Install/Remove/SimulateRemoveCascade).
+	// The wrapper:
+	//   - sudo -n: non-interactive (same NOPASSWD requirement the
+	//     SystemInstaller spec commands carry)
+	//   - env DEBIAN_FRONTEND=noninteractive: no interactive prompts
+	//     from configuration packages (matters for installs that
+	//     replace conffiles)
+	//   - env LC_ALL=C LANGUAGE=C: stable English output; sudoers with
+	//     reset_env would otherwise lose these if set as shell env
+	//     vars rather than via `env`
+	//   - DPkg::Lock::Timeout=60: wait up to 60s for the dpkg lock
+	//     instead of failing immediately on transient apt contention
+	//   - --: end-of-options so package names that look like flags
+	//     cannot be misinterpreted
+	// Keeping the e2e wrapper byte-identical to production means a
+	// future change to the wrapper (different timeout, additional env
+	// var, etc.) lands in one place and both the suite and the code
+	// under test stay aligned.
+	aptCmd := func(verb string, pkgs []string) string {
+		return "sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get " + verb + " -y -o DPkg::Lock::Timeout=60 -- " + strings.Join(pkgs, " ")
+	}
+
 	// preTestInstalled records which fixture packages were ALREADY
 	// installed on the host at BeforeAll time, before the preflight
 	// remove ran. The outer AfterAll uses it to distinguish packages
@@ -767,12 +791,18 @@ EOF`, dir, strings.Join(quoted, ", "))
 			//
 			//   1. preflightComplete → fixture-package remove. Acts
 			//      only when the apply specs may have run install.
-			//   2. preflightMutationStarted → diff-based dep cleanup
-			//      (snapshotInstalledPackages before/after) + restore
-			//      of preTestInstalled. Acts whenever the mutating
-			//      preflight was attempted, so a partial remove still
-			//      re-installs pre-existing fixture packages and the
-			//      dep diff still removes packages tomei pulled in.
+			//   2. preflightMutationStarted + TOMEI_E2E_CONTAINER →
+			//      diff-based dep cleanup (snapshotInstalledPackages
+			//      before/after). Acts only in container mode where
+			//      newly-installed packages are unambiguously tomei's.
+			//      Native mode intentionally skips this step (concurrent
+			//      installs during the E2E window cannot be distinguished
+			//      from suite-introduced deps).
+			//   3. preflightMutationStarted → restore preTestInstalled.
+			//      Acts whenever the mutating preflight was attempted,
+			//      so a partial remove still re-installs pre-existing
+			//      fixture packages even when post-remove assertions
+			//      failed and preflightComplete stayed false.
 			//   3. scratchDirs (per-dir ledger) → rm -rf the scratch
 			//      directories. Acts only on paths the suite wrote, so
 			//      a pre-existing /tmp dir owned by another process is
@@ -789,8 +819,15 @@ EOF`, dir, strings.Join(quoted, ", "))
 				// may have run apply, so tomei may have installed the
 				// fixture packages. Remove them by explicit name (no
 				// blast-radius broadening) before the restore step
-				// re-installs the host's pre-test set.
-				_, _ = testExec.ExecBash("sudo -n apt-get remove -y " + strings.Join(fixturePackages, " ") + " 2>&1 || true")
+				// re-installs the host's pre-test set. Capture stdout
+				// + err so a remove failure (apt lock, sudo timestamp
+				// expired between specs and AfterAll, etc.) is logged
+				// to GinkgoWriter rather than silently leaving fixture
+				// packages installed.
+				out, err := testExec.ExecBash(aptCmd("remove", fixturePackages) + " 2>&1")
+				if err != nil {
+					fmt.Fprintf(GinkgoWriter, "WARNING: fixture-package cleanup failed (err=%v):\n%s\n", err, out)
+				}
 			}
 			if preflightMutationStarted && preTestPackageSet != nil && os.Getenv("TOMEI_E2E_CONTAINER") != "" {
 				// Diff-based dep cleanup, scoped to TOMEI_E2E_CONTAINER
@@ -828,7 +865,10 @@ EOF`, dir, strings.Join(quoted, ", "))
 					sort.Strings(leaked)
 					if len(leaked) > 0 {
 						fmt.Fprintf(GinkgoWriter, "removing %d package(s) introduced by the suite: %v\n", len(leaked), leaked)
-						_, _ = testExec.ExecBash("sudo -n apt-get remove -y " + strings.Join(leaked, " ") + " 2>&1 || true")
+						out, err := testExec.ExecBash(aptCmd("remove", leaked) + " 2>&1")
+						if err != nil {
+							fmt.Fprintf(GinkgoWriter, "WARNING: diff-based dep cleanup remove failed (err=%v):\n%s\n", err, out)
+						}
 					}
 				}
 			}
@@ -847,7 +887,15 @@ EOF`, dir, strings.Join(quoted, ", "))
 					}
 				}
 				if len(toRestore) > 0 {
-					out, err := testExec.ExecBash("sudo -n apt-get install -y --no-install-recommends " + strings.Join(toRestore, " ") + " 2>&1")
+					// Restore uses the production wrapper too (same env,
+					// same lock timeout). --no-install-recommends keeps
+					// reinstall scope narrow: we restore exactly what
+					// was on the host pre-test, not Recommends that
+					// might also have been there but cannot be
+					// reliably reconstructed. The flag goes inside the
+					// verb so it lands BEFORE the `--` end-of-options
+					// separator added by aptCmd.
+					out, err := testExec.ExecBash(aptCmd("install --no-install-recommends", toRestore) + " 2>&1")
 					if err != nil {
 						// Best-effort: log and continue. A reinstall
 						// failure (e.g. mirror outage, package vanished
@@ -895,16 +943,22 @@ EOF`, dir, strings.Join(quoted, ", "))
 				skipIfNotLinux()
 
 				// Probe non-interactive sudo BEFORE touching host state.
-				// Outer AfterAll's apt-get remove uses `sudo -n` and
-				// swallows errors (cleanup is best-effort by design); on
-				// a native opt-in run with interactive-only sudo, that
-				// cleanup would silently no-op and leave cowsay/sl/tree
-				// installed. By failing the spec up-front when sudo is
-				// not passwordless, we trade a clean fail-fast for the
-				// alternative of silent host pollution.
-				_, sudoErr := testExec.ExecBash("sudo -n true 2>&1")
+				// Outer AfterAll's apt-get remove uses `sudo -n`; on a
+				// native opt-in run with interactive-only sudo, that
+				// cleanup would no-op and leave cowsay/sl/tree
+				// installed. Fail fast here instead.
+				//
+				// `sudo -k && sudo -n true` is the correct probe: a
+				// bare `sudo -n true` succeeds when the user has a
+				// cached sudo timestamp from earlier in the session,
+				// which would falsely pass on a host that actually
+				// requires a password. -k invalidates the cache first,
+				// so the subsequent -n true exercises the NOPASSWD
+				// policy that the apply specs (which themselves call
+				// `sudo -k` between runs) actually depend on.
+				_, sudoErr := testExec.ExecBash("sudo -k && sudo -n true 2>&1")
 				Expect(sudoErr).NotTo(HaveOccurred(),
-					"non-interactive sudo (NOPASSWD) is required: the AfterAll cleanup uses `sudo -n` and would silently leave fixture packages installed without it")
+					"non-interactive sudo (NOPASSWD) is required: the AfterAll cleanup uses `sudo -n` and would silently leave fixture packages installed without it. The probe ran `sudo -k && sudo -n true` to invalidate any cached timestamp first.")
 
 				// Ensure tomei is initialized — `tomei apply` aborts early
 				// with "tomei is not initialized" otherwise. --force makes
@@ -949,7 +1003,7 @@ EOF`, dir, strings.Join(quoted, ", "))
 				// to produce a clearer downstream error than `update` would.
 				// The err is captured (not silently dropped) so a complete
 				// mirror outage surfaces in GinkgoWriter alongside the output.
-				out, err := testExec.ExecBash("sudo -n apt-get update -qq 2>&1")
+				out, err := testExec.ExecBash("sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get update -qq -o DPkg::Lock::Timeout=60 2>&1")
 				fmt.Fprintf(GinkgoWriter, "apt-get update (err=%v):\n%s\n", err, out)
 
 				// (3a) Snapshot which fixture packages are already installed
@@ -1013,7 +1067,7 @@ EOF`, dir, strings.Join(quoted, ", "))
 				// remove returns 0 even when packages are not
 				// installed — that case is benign and produces no Remv
 				// lines, so we don't need to special-case it.)
-				simOut, simErr := testExec.ExecBash("LC_ALL=C LANGUAGE=C sudo -n apt-get -s remove -y " + strings.Join(fixturePackages, " ") + " 2>&1")
+				simOut, simErr := testExec.ExecBash(aptCmd("-s remove", fixturePackages) + " 2>&1")
 				Expect(simErr).NotTo(HaveOccurred(),
 					"apt-get -s remove simulation failed — cannot verify the real remove will not cascade. Aborting before host mutation. Full output:\n%s", simOut)
 				fixtureSet := map[string]bool{}
@@ -1054,7 +1108,7 @@ EOF`, dir, strings.Join(quoted, ", "))
 				// `2>&1 || true` swallows the failure for packages that are
 				// not installed (apt-get remove exits non-zero); the
 				// pkgCurrentState assertions below are the real assertion.
-				_, _ = testExec.ExecBash("sudo -n apt-get remove -y " + strings.Join(fixturePackages, " ") + " 2>&1 || true")
+				_, _ = testExec.ExecBash(aptCmd("remove", fixturePackages) + " 2>&1 || true")
 				for _, pkg := range fixturePackages {
 					// Query the current-state sub-field and check it against
 					// the same removedStates allowlist assertNotInstalled
@@ -1185,8 +1239,19 @@ EOF`, dir, strings.Join(quoted, ", "))
 					"plan output must not contain 'disabled' (SystemPackageSet must not be skip-downgraded with --system); got:\n%s", out)
 
 				hashBefore := stateHash()
-				_, err = ExecApply(testExec, "--system", installCfgPath)
+				idempOut, err := ExecApply(testExec, "--system", installCfgPath)
 				Expect(err).NotTo(HaveOccurred())
+				// runApplyWithProgressManager (cmd/tomei/apply.go) logs
+				// system-engine errors as `Warning: system resource
+				// apply failed: ...` and returns the user-engine
+				// result. So err == nil does NOT prove the system
+				// engine succeeded; a silent system-apply regression
+				// would otherwise sail through this idempotency check
+				// because state.json would also remain unchanged on
+				// failure. Anchoring on the absence of the warning
+				// substring closes that gap.
+				Expect(idempOut).NotTo(ContainSubstring("system resource apply failed"),
+					"idempotent re-apply must not surface a system-engine warning; got:\n%s", idempOut)
 				Expect(stateHash()).To(Equal(hashBefore),
 					"idempotent re-apply must not rewrite state.json")
 			})
@@ -1319,8 +1384,15 @@ EOF`, dir, strings.Join(quoted, ", "))
 					"plan output must not contain 'disabled' (SystemPackageSet must not be skip-downgraded with --system); got:\n%s", out)
 
 				hashBefore := stateHash()
-				_, err = ExecApply(testExec, "--system", removalCfgPath)
+				idempOut, err := ExecApply(testExec, "--system", removalCfgPath)
 				Expect(err).NotTo(HaveOccurred())
+				// Same system-engine warning check as the install
+				// idempotency spec above — runApplyWithProgressManager
+				// returns the user-engine result, so a silent system
+				// apply failure would also leave state.json unchanged
+				// and falsely pass the byte-stability assertion.
+				Expect(idempOut).NotTo(ContainSubstring("system resource apply failed"),
+					"idempotent re-apply of the removal manifest must not surface a system-engine warning; got:\n%s", idempOut)
 				Expect(stateHash()).To(Equal(hashBefore),
 					"idempotent re-apply of the removal manifest must not rewrite state.json")
 			})

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -590,11 +590,12 @@ func systemPackageTests() {
 	const fixtureSugarPkg = "tree"
 	// Build fixturePackages as a deduplicated union. A naive
 	// `append(..., fixtureSugarPkg)` would emit duplicates if a future
-	// change makes the sugar package name overlap with fixtureSet
-	// Install (e.g. someone renames the sugar to "cowsay"). Duplicates
-	// in the cleanup/preflight command line would not cause incorrect
-	// behaviour with apt-get (it tolerates them), but would violate
-	// the documented "union" contract and could surprise log readers.
+	// change makes the sugar package name overlap with
+	// fixtureSetInstall (e.g. someone renames the sugar to "cowsay").
+	// Duplicates in the cleanup/preflight command line would not
+	// cause incorrect behaviour with apt-get (it tolerates them), but
+	// would violate the documented "union" contract and could
+	// surprise log readers.
 	fixturePackages := func() []string {
 		seen := map[string]bool{}
 		var out []string
@@ -905,9 +906,44 @@ EOF`, dir, strings.Join(quoted, ", "), fixtureSugarPkg)
 				// expired between specs and AfterAll, etc.) is logged
 				// to GinkgoWriter rather than silently leaving fixture
 				// packages installed.
-				out, err := testExec.ExecBash(aptCmd("remove", fixturePackages) + " 2>&1")
-				if err != nil {
-					fmt.Fprintf(GinkgoWriter, "WARNING: fixture-package cleanup failed (err=%v):\n%s\n", err, out)
+				//
+				// Re-run the cascade-removal simulation BEFORE the
+				// actual remove. On a long-running native opt-in host,
+				// a package installed CONCURRENTLY with the e2e test
+				// could have started depending on cowsay/sl/tree
+				// between the BeforeAll simulation and this AfterAll
+				// (the BeforeAll check was a snapshot, not a hold).
+				// If the cleanup remove would now cascade onto a non-
+				// fixture package, the restore path doesn't track it
+				// and would leave the host worse off than pre-test —
+				// log the cascade and skip the cleanup remove instead.
+				simOut, simErr := testExec.ExecBash(aptCmd("-s remove", fixturePackages) + " 2>&1")
+				if simErr != nil {
+					fmt.Fprintf(GinkgoWriter, "WARNING: cascade simulation in AfterAll failed (err=%v), skipping fixture remove to avoid host damage:\n%s\n", simErr, simOut)
+				} else {
+					fixtureSet := map[string]bool{}
+					for _, p := range fixturePackages {
+						fixtureSet[p] = true
+					}
+					var cascade []string
+					for line := range strings.SplitSeq(simOut, "\n") {
+						if !strings.HasPrefix(line, "Remv ") {
+							continue
+						}
+						fields := strings.Fields(line)
+						if len(fields) >= 2 && !fixtureSet[fields[1]] {
+							cascade = append(cascade, fields[1])
+						}
+					}
+					sort.Strings(cascade)
+					if len(cascade) > 0 {
+						fmt.Fprintf(GinkgoWriter, "WARNING: AfterAll fixture-package remove would cascade-remove non-fixture package(s) %v — skipping cleanup remove. The restore path will still re-install preTestInstalled. Full simulation output:\n%s\n", cascade, simOut)
+					} else {
+						out, err := testExec.ExecBash(aptCmd("remove", fixturePackages) + " 2>&1")
+						if err != nil {
+							fmt.Fprintf(GinkgoWriter, "WARNING: fixture-package cleanup failed (err=%v):\n%s\n", err, out)
+						}
+					}
 				}
 			}
 			if preflightMutationStarted && preTestPackageSet != nil && os.Getenv("TOMEI_E2E_CONTAINER") != "" {

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"regexp"
 	"runtime"
+	"sort"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -364,20 +365,59 @@ func systemPackageTests() {
 	// the wrong reason. We now match the specific stderr message format
 	// dpkg-query uses for the not-found case and Fail() on anything else.
 	pkgCurrentState := func(pkg string) string {
-		out, err := testExec.Exec("dpkg-query", "-W", "-f=${db:Status-Status}\n", "--", pkg)
+		// pkg is vetted against systemPackageTestPkgNameRE before
+		// reaching this helper: callers come from fixturePackages
+		// (static literals) and from the apply specs (also static),
+		// and writeSystemPackageManifest validates the same set
+		// against the regex. The regex `^[a-z0-9][a-z0-9+\-.]*$`
+		// rejects every shell-meaningful character, so embedding
+		// `pkg` into an ExecBash script is safe here.
+		//
+		// Force C locale: dpkg-query's "no packages found matching"
+		// message is localized on hosts with LANG=ja_JP.UTF-8 / etc.
+		// — without pinning the locale, this English-substring match
+		// would fail on a non-C runner and we'd Fail() on a clean
+		// host that actually had the package absent.
+		Expect(systemPackageTestPkgNameRE.MatchString(pkg)).To(BeTrue(),
+			"pkgCurrentState called with disallowed pkg name %q", pkg)
+		out, err := testExec.ExecBash(`LC_ALL=C LANGUAGE=C dpkg-query -W -f='${db:Status-Status}` + "\n" + `' -- ` + pkg)
 		if err == nil {
 			return strings.TrimSpace(out)
 		}
-		// dpkg-query's stable format for the never-installed /
-		// purged case: `dpkg-query: no packages found matching <pkg>`
-		// (with exit 1). Any other err+output combination indicates
-		// a real failure that must surface — fail the spec rather
-		// than silently treating it as "not installed".
+		// dpkg-query's stable C-locale format for the never-
+		// installed / purged case: `dpkg-query: no packages found
+		// matching <pkg>` (exit 1). Any other err+output combination
+		// indicates a real failure that must surface — fail the
+		// spec rather than silently treating it as "not installed".
 		if strings.Contains(out, "no packages found matching") {
 			return ""
 		}
 		Fail(fmt.Sprintf("dpkg-query failed unexpectedly for %s (not the documented 'no packages found' case): err=%v, output=%q", pkg, err, out))
 		return "" // unreachable: Fail() panics
+	}
+
+	// snapshotInstalledPackages returns the set of currently-installed
+	// package names on the host. Used by the outer AfterAll to detect
+	// any packages added since BeforeAll (typically transitive Depends
+	// pulled in by `apt-get install` for cowsay etc.) so cleanup can
+	// remove them explicitly rather than leaking them onto a native
+	// opt-in runner. Generic + fixture-agnostic: works no matter which
+	// fixture packages we choose or what their Depends graph looks like.
+	//
+	// Locale is forced to C so the dpkg-query Status-Status field
+	// always emits the un-translated tokens (`installed`,
+	// `not-installed`, etc.) the awk filter below matches against.
+	snapshotInstalledPackages := func() map[string]bool {
+		out, err := testExec.ExecBash(`LC_ALL=C LANGUAGE=C dpkg-query -W -f='${db:Status-Status} ${binary:Package}` + "\n" + `' 2>/dev/null`)
+		Expect(err).NotTo(HaveOccurred(), "dpkg-query enumeration failed: %s", out)
+		set := map[string]bool{}
+		for line := range strings.SplitSeq(out, "\n") {
+			fields := strings.Fields(line)
+			if len(fields) >= 2 && fields[0] == "installed" {
+				set[fields[1]] = true
+			}
+		}
+		return set
 	}
 	assertInstalled := func(pkg string) {
 		// pkgCurrentState now collapses dpkg-query's documented exit-1
@@ -555,6 +595,17 @@ func systemPackageTests() {
 	// suite uninstall a package the user expected to keep.
 	preTestInstalled := map[string]bool{}
 
+	// preTestPackageSet is a snapshot of EVERY package installed on
+	// the host at BeforeAll time (not just the fixture set). The
+	// outer AfterAll diffs this against the post-test snapshot to
+	// identify transitive dependencies pulled in by tomei's apt-get
+	// install (e.g. libtext-charwidth-perl for cowsay) and removes
+	// them explicitly. This replaces the earlier blanket
+	// `apt-get autoremove` which Copilot flagged as too broad — the
+	// diff approach only touches packages whose presence is
+	// attributable to this suite's BeforeAll/It path.
+	var preTestPackageSet map[string]bool
+
 	// writeSystemPackageManifest writes a minimal CUE manifest under dir:
 	// SystemInstaller/apt + SystemPackage/tree sugar + SystemPackageSet
 	// cli-tools with the given package list. The single-quoted heredoc
@@ -579,26 +630,25 @@ func systemPackageTests() {
 		for i, p := range pkgs {
 			quoted[i] = `"` + p + `"`
 		}
-		// Clear the target directory before recreating cue.mod /
-		// manifest.cue. The CUE loader reads EVERY *.cue file in the
-		// directory; a stale manifest left by a failed previous run
-		// (or by a developer iterating on the helper) would be loaded
-		// alongside the fresh one and silently shift these assertions.
-		// `rm -rf` of the whole dir is safe here because the regex
-		// allowlist above restricts dir to a flat single-segment
-		// /tmp/<name> path — no risk of clobbering anything outside
-		// the scratch area.
-		// Refuse to rm -rf an existing dir that doesn't carry our
-		// ownership marker. The fixed /tmp paths used here are
-		// predictable across runs, so a concurrent process or another
-		// user could theoretically own a directory at the same path
-		// — without this check, a bare `rm -rf` would silently clobber
-		// it. The marker file `.tomei-e2e-system-package-test` lives
-		// at the dir root; on a previous suite run we wrote it
-		// ourselves, so re-running the suite is still idempotent.
+		// Two-phase setup: claim ownership (rm-if-marker + mkdir +
+		// marker touch), record in scratchDirs, then write content.
+		// Recording the ledger entry BETWEEN the two phases means a
+		// failure during content write (module.cue or manifest.cue
+		// heredoc) still leaves the dir tracked, so AfterAll cleans
+		// it up rather than leaking the partial scratch dir.
+		//
+		// Phase 1 — claim. Refuse to rm -rf an existing dir that
+		// doesn't carry our ownership marker. The fixed /tmp paths
+		// used here are predictable across runs, so a concurrent
+		// process or another user could theoretically own a
+		// directory at the same path — without this check, a bare
+		// `rm -rf` would silently clobber it. The marker file
+		// `.tomei-e2e-system-package-test` lives at the dir root;
+		// on a previous suite run we wrote it ourselves, so re-
+		// running the suite is still idempotent.
 		// `set -euo pipefail` so any setup failure (rm -rf refusal,
-		// mkdir failure, heredoc write failure) aborts the script.
-		script := fmt.Sprintf(`set -euo pipefail
+		// mkdir failure, marker touch failure) aborts the script.
+		claim := fmt.Sprintf(`set -euo pipefail
 if [ -e %[1]s ] && [ ! -f %[1]s/.tomei-e2e-system-package-test ]; then
 	echo "refusing to remove %[1]s: directory exists but lacks the .tomei-e2e-system-package-test ownership marker — another process may own this path" >&2
 	exit 1
@@ -606,6 +656,19 @@ fi
 rm -rf %[1]s
 mkdir -p %[1]s/cue.mod
 touch %[1]s/.tomei-e2e-system-package-test
+`, dir)
+		_, err := testExec.ExecBash(claim)
+		Expect(err).NotTo(HaveOccurred(), "claiming scratch dir %s failed", dir)
+
+		// Record ownership in the ledger BEFORE writing content. If
+		// the subsequent heredoc writes fail, the dir is still
+		// tracked and AfterAll will clean it up.
+		scratchDirs[strings.TrimRight(dir, "/")] = true
+
+		// Phase 2 — content. Heredoc-write module.cue + manifest.cue.
+		// Failure here is surfaced via Expect; the ledger entry above
+		// guarantees AfterAll still cleans up the partial dir.
+		content := fmt.Sprintf(`set -euo pipefail
 cat > %[1]s/cue.mod/module.cue <<'EOF'
 module: "tomei.local@v0"
 language: version: "v0.9.0"
@@ -648,14 +711,8 @@ cliTools: {
 	}
 }
 EOF`, dir, strings.Join(quoted, ", "))
-		_, err := testExec.ExecBash(script)
-		Expect(err).NotTo(HaveOccurred(), "writing manifest for %s failed", dir)
-		// Record this specific dir for AfterAll cleanup. The outer
-		// AfterAll iterates the ledger so it only removes paths this
-		// suite actually wrote — never a pre-existing /tmp directory
-		// nor the OTHER fixture's dir if this BeforeAll didn't write
-		// it (e.g. Context B's removal dir if Context A aborted).
-		scratchDirs[strings.TrimRight(dir, "/")] = true
+		_, err = testExec.ExecBash(content)
+		Expect(err).NotTo(HaveOccurred(), "writing manifest content for %s failed", dir)
 	}
 
 	Context("Apply --system mutates host packages (#200)", func() {
@@ -712,17 +769,26 @@ EOF`, dir, strings.Join(quoted, ", "))
 				// blast-radius broadening) before the restore step
 				// re-installs the host's pre-test set.
 				_, _ = testExec.ExecBash("sudo -n apt-get remove -y " + strings.Join(fixturePackages, " ") + " 2>&1 || true")
-				// autoremove is scoped to TOMEI_E2E_CONTAINER ONLY.
-				// `apt-get autoremove` is a host-global operation: it
-				// removes ANY package currently marked auto-removable,
-				// not just transitive Depends introduced by this
-				// suite. On an ephemeral CI container we own the
-				// filesystem and the broader cleanup is desirable; on
-				// a native runner or developer laptop (even with
-				// TOMEI_E2E_NATIVE=true), it could remove unrelated
-				// auto-installed packages the user expects to keep.
-				if os.Getenv("TOMEI_E2E_CONTAINER") != "" {
-					_, _ = testExec.ExecBash("sudo -n apt-get autoremove -y 2>&1 || true")
+			}
+			if preflightMutationStarted && preTestPackageSet != nil {
+				// Diff-based dep cleanup: any package currently
+				// installed that was NOT in preTestPackageSet was
+				// introduced by tomei's apt-get install (cowsay pulls
+				// libtext-charwidth-perl, etc.). Remove only those —
+				// no host-global autoremove, no risk of clobbering
+				// packages the user opted to keep. Iterate sorted so
+				// the apt-get remove command line is deterministic.
+				currentSet := snapshotInstalledPackages()
+				var leaked []string
+				for pkg := range currentSet {
+					if !preTestPackageSet[pkg] {
+						leaked = append(leaked, pkg)
+					}
+				}
+				sort.Strings(leaked)
+				if len(leaked) > 0 {
+					fmt.Fprintf(GinkgoWriter, "removing %d package(s) introduced by the suite: %v\n", len(leaked), leaked)
+					_, _ = testExec.ExecBash("sudo -n apt-get remove -y " + strings.Join(leaked, " ") + " 2>&1 || true")
 				}
 			}
 			if preflightMutationStarted {
@@ -759,15 +825,27 @@ EOF`, dir, strings.Join(quoted, ", "))
 			// — a pre-existing /tmp/tomei-system-package-removal owned
 			// by something else is not touched.
 			for dir := range scratchDirs {
-				// Defense-in-depth: re-validate the recorded dir against
-				// the helper's regex before rm -rf. scratchDirs is only
-				// ever populated by writeSystemPackageManifest after the
-				// regex check passes, but a future refactor could route
-				// a different writer to this map; the re-check makes the
-				// rm safe regardless.
-				if systemPackageTestDirRE.MatchString(dir) {
-					_, _ = testExec.ExecBash("rm -rf " + dir)
+				// Defense-in-depth: re-validate the recorded dir
+				// against the helper's regex before rm -rf.
+				if !systemPackageTestDirRE.MatchString(dir) {
+					continue
 				}
+				// Marker re-check: only rm if our ownership marker
+				// is still present at the recorded path. If a
+				// concurrent process replaced the directory between
+				// BeforeAll and AfterAll, the marker is gone and we
+				// skip cleanup rather than clobbering a directory the
+				// suite no longer owns. The marker was written under
+				// `set -euo pipefail` in writeSystemPackageManifest
+				// immediately after mkdir, so any successful entry in
+				// scratchDirs implies the marker was there at write
+				// time — re-checking here closes the TOCTOU window.
+				_, markerErr := testExec.ExecBash(`test -f ` + dir + `/.tomei-e2e-system-package-test`)
+				if markerErr != nil {
+					fmt.Fprintf(GinkgoWriter, "skipping rm -rf %s: ownership marker missing (dir may have been replaced by another process)\n", dir)
+					continue
+				}
+				_, _ = testExec.ExecBash("rm -rf " + dir)
 			}
 		})
 
@@ -846,6 +924,15 @@ EOF`, dir, strings.Join(quoted, ", "))
 						preTestInstalled[pkg] = true
 					}
 				}
+
+				// (3a') Take a full host-wide installed-packages
+				// snapshot too, for the dep-leak diff in AfterAll.
+				// Captured here (after fixture preflight snapshot but
+				// before remove) so the post-test diff isolates packages
+				// added by tomei's install step — including transitive
+				// Depends like libtext-charwidth-perl that apt-get
+				// remove without autoremove would otherwise leak.
+				preTestPackageSet = snapshotInstalledPackages()
 
 				// (3b) Mutating: preflight remove-first. Ensures the fixture
 				// packages are NOT installed before tomei runs, so the

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -314,12 +314,15 @@ func systemPackageTests() {
 	// skipped or run with a misleading host state. Outer-scope AfterAll
 	// guarantees host cleanup even when Context A aborts before B starts.
 	//
-	// dpkg-query -W -f='${Status}' is preferred over dpkg -l because
-	// `dpkg -l` exits 0 for the `rc` ("removed but config present") state
-	// after `apt-get remove` without --purge — a false-positive trap for
-	// post-remove assertions. `install ok installed` is the only state
-	// that counts as "installed"; `deinstall ok config-files` (the
-	// post-remove state) is correctly excluded by NotTo ContainSubstring.
+	// dpkg-query -W is preferred over dpkg -l because `dpkg -l` exits 0
+	// for the `rc` ("removed but config present") state after `apt-get
+	// remove` without --purge — a false-positive trap for post-remove
+	// assertions. The helper below queries `${db:Status-Status}` (the
+	// current-state sub-field) and matches `installed` exactly, so
+	// `config-files` (post-remove) and the half-installed transitional
+	// states cleanly fail the installed check; held-installed packages
+	// (`hold ok installed` in the full Status triple) also collapse to
+	// `installed` here and are correctly classified as installed.
 
 	// dpkg-query is invoked via argv form (testExec.Exec) rather than
 	// shell-string concatenation: the package name lives in its own argv
@@ -329,20 +332,37 @@ func systemPackageTests() {
 	// matching package is in the dpkg DB (the post-purge state); for
 	// assertInstalled this is a failure, for assertNotInstalled it counts
 	// as "removed".
+	//
+	// Format string uses `${db:Status-Status}` (the third sub-field of
+	// Status — the *current* state) rather than the full `${Status}`
+	// triple. The full triple is `<DesiredState> <ErrorFlag>
+	// <CurrentState>` so a substring match on "install ok installed"
+	// would miss `hold ok installed` (held packages, which ARE
+	// installed) and misclassify them as removed. Pinning on the
+	// current-state sub-field collapses the answer to a single token
+	// (`installed`, `not-installed`, `config-files`, `half-installed`,
+	// etc.) so the assertion is exact regardless of the desired-state
+	// dimension.
+	pkgCurrentState := func(pkg string) (string, error) {
+		out, err := testExec.Exec("dpkg-query", "-W", "-f=${db:Status-Status}\n", "--", pkg)
+		return strings.TrimSpace(out), err
+	}
 	assertInstalled := func(pkg string) {
-		out, err := testExec.Exec("dpkg-query", "-W", "-f=${Status}\n", "--", pkg)
-		Expect(err).NotTo(HaveOccurred(), "dpkg-query failed for %s: %s", pkg, out)
-		Expect(strings.TrimSpace(out)).To(Equal("install ok installed"),
-			"package %s should be installed; dpkg-query Status: %q", pkg, out)
+		state, err := pkgCurrentState(pkg)
+		Expect(err).NotTo(HaveOccurred(), "dpkg-query failed for %s: %s", pkg, state)
+		Expect(state).To(Equal("installed"),
+			"package %s should be installed; dpkg-query current-state: %q", pkg, state)
 	}
 	assertNotInstalled := func(pkg string) {
-		// apt-get remove (NOT --purge) leaves dpkg in
-		// "deinstall ok config-files"; a never-installed or purged package
-		// produces an exit-1 with empty stdout from dpkg-query. Both count
-		// as "removed"; only "install ok installed" is forbidden.
-		out, _ := testExec.Exec("dpkg-query", "-W", "-f=${Status}\n", "--", pkg)
-		Expect(out).NotTo(ContainSubstring("install ok installed"),
-			"package %s must not be in installed state; dpkg-query: %q", pkg, out)
+		// apt-get remove (NOT --purge) leaves dpkg current-state
+		// as `config-files`; a never-installed or purged package
+		// returns an exit-1 with empty current-state. Both count as
+		// "removed"; `installed` and the half-installed transitional
+		// states are the only values forbidden — anything else means
+		// the package is not currently runnable on the host.
+		state, _ := pkgCurrentState(pkg)
+		Expect(state).NotTo(Equal("installed"),
+			"package %s must not be in installed state; dpkg-query current-state: %q", pkg, state)
 	}
 
 	// stateHash returns sha256 of the system state.json. Used over mtime
@@ -438,10 +458,13 @@ func systemPackageTests() {
 	// state that was on the host before this Context ran.
 	//
 	// Outer AfterAll consults it: if BeforeAll aborted before the
-	// preflight completed (e.g. apt-get update failed, or the
-	// remove-first step left a package installed), the flag stays false
-	// and cleanup is a no-op so the user's pre-existing packages are
-	// preserved exactly as they were.
+	// preflight completed (e.g. the remove-first step left a package
+	// installed and the Expect surfaced the failure), the flag stays
+	// false and cleanup is a no-op so the user's pre-existing packages
+	// are preserved exactly as they were. (`apt-get update` failures
+	// are logged via GinkgoWriter and do NOT abort BeforeAll — a stale
+	// index is usually still functional — so they are deliberately not
+	// in the list of preflight aborts.)
 	var preflightComplete bool
 
 	// writeSystemPackageManifest writes a minimal CUE manifest under dir:
@@ -631,9 +654,15 @@ EOF`, dir, strings.Join(quoted, ", "))
 				// below are the real assertion that the host is clean.
 				_, _ = testExec.ExecBash("sudo -n apt-get remove -y " + strings.Join(fixturePackages, " ") + " 2>&1 || true")
 				for _, pkg := range fixturePackages {
-					out, _ := testExec.Exec("dpkg-query", "-W", "-f=${Status}\n", "--", pkg)
-					Expect(out).NotTo(ContainSubstring("install ok installed"),
-						"preflight failed: %s is still installed after apt-get remove (dpkg-query Status: %q) — the apply spec below would not be exercising a real install", pkg, out)
+					// Mirror the assertNotInstalled helper above: query the
+					// current-state sub-field so a held installed package
+					// (Status `hold ok installed`) cannot pass the
+					// not-installed assertion. Without this, `apt-mark
+					// hold cowsay` on a runner image would slip past the
+					// preflight and make the install spec a no-op.
+					state, _ := pkgCurrentState(pkg)
+					Expect(state).NotTo(Equal("installed"),
+						"preflight failed: %s is still installed after apt-get remove (dpkg-query current-state: %q) — the apply spec below would not be exercising a real install", pkg, state)
 				}
 
 				writeSystemPackageManifest("/tmp/tomei-system-package-install", []string{"cowsay", "sl"})
@@ -669,7 +698,7 @@ EOF`, dir, strings.Join(quoted, ", "))
 			})
 
 			It("records InstalledVersions for the sugar and the set in state.json", func() {
-				// Parse the JSON rather than substring-matching "bc" / "cowsay":
+				// Parse the JSON rather than substring-matching "cowsay" / "sl":
 				// the package names also appear in the `packages` array of the
 				// resource spec snapshot, so a substring match would pass even
 				// if `installedVersions` were empty or missing — exactly the

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"regexp"
@@ -293,9 +294,21 @@ func systemPackageTests() {
 	})
 
 	// SystemPackageSet apply coverage (#200). Mutates host packages, so
-	// gated to linux (apt). The two Contexts below are Ordered: Context A
-	// installs from the canonical fixture; Context B reduces the manifest
-	// to drive an apt-get remove. Context B's AfterAll cleans up the host.
+	// gated to linux (apt) AND to orchestrated e2e runs (TOMEI_E2E_CONTAINER
+	// or TOMEI_E2E_NATIVE — see skipIfNotLinux). The two inner Contexts
+	// below are Ordered (inherited from the suite-level `Describe(...,
+	// Ordered, ...)` in suite_test.go): Context A applies a generated
+	// /tmp/tomei-system-package-install/ manifest and asserts install +
+	// state-record + no-op + idempotency; Context B applies a reduced
+	// /tmp/tomei-system-package-removal/ manifest and asserts remove +
+	// state-shrink + idempotency.
+	//
+	// Wrapped in an outer Context so that the host-cleanup AfterAll
+	// (apt-get remove + rm -rf /tmp) lives at a scope that covers BOTH
+	// inner contexts: if Context A's BeforeAll or any Context A spec
+	// fails partway, an inner Context-B-scoped AfterAll would either be
+	// skipped or run with a misleading host state. Outer-scope AfterAll
+	// guarantees host cleanup even when Context A aborts before B starts.
 	//
 	// dpkg-query -W -f='${Status}' is preferred over dpkg -l because
 	// `dpkg -l` exits 0 for the `rc` ("removed but config present") state
@@ -334,9 +347,24 @@ func systemPackageTests() {
 	// check. sha256sum exits non-zero if the file is missing, which the
 	// Expect surfaces as a clear failure.
 	stateHash := func() string {
-		out, err := testExec.ExecBash("sha256sum ~/.local/share/tomei/system/state.json | awk '{print $1}'")
+		// `set -o pipefail` is required: without it, the pipeline's exit
+		// status is awk's (almost always 0), so a missing or unreadable
+		// state.json would return awk's stderr instead of a hash and the
+		// downstream byte-stability assertions would pass for the wrong
+		// reason. With pipefail, sha256sum's non-zero exit propagates and
+		// the Expect surfaces the real failure.
+		out, err := testExec.ExecBash("set -o pipefail; sha256sum ~/.local/share/tomei/system/state.json | awk '{print $1}'")
 		Expect(err).NotTo(HaveOccurred(), "sha256sum on system state.json failed: %s", out)
-		return strings.TrimSpace(out)
+		hash := strings.TrimSpace(out)
+		// Defence-in-depth in case pipefail is somehow disabled by a
+		// future shell wrapper change: a real sha256sum hash is exactly
+		// 64 lowercase hex chars. Anything else means we got stderr,
+		// "No such file", an awk error, or an empty pipe — fail loudly
+		// instead of silently returning a non-hash that would compare
+		// equal across two equally-broken calls.
+		Expect(hash).To(MatchRegexp(`^[0-9a-f]{64}$`),
+			"stateHash did not return a sha256 hex digest; got %q (state.json may be missing or unreadable)", hash)
+		return hash
 	}
 
 	skipIfNotLinux := func() {
@@ -346,6 +374,16 @@ func systemPackageTests() {
 		}
 		if targetOS != "linux" {
 			Skip("real-apply SystemPackageSet requires apt; current OS is " + targetOS)
+		}
+		// Opt-in gate: a bare `go test ./e2e/...` on a Linux developer
+		// laptop would otherwise run `sudo apt-get install/remove` and
+		// mutate the dev's host packages — surprising and destructive.
+		// The orchestrated e2e modes (`make test-e2e` containerised, and
+		// the CI native legs) both set one of these env vars, so
+		// requiring at least one is opt-in for orchestrated runs while
+		// fail-safe for ad-hoc local invocations.
+		if os.Getenv("TOMEI_E2E_CONTAINER") == "" && os.Getenv("TOMEI_E2E_NATIVE") == "" {
+			Skip("real-apply SystemPackageSet mutates host apt state; set TOMEI_E2E_CONTAINER or TOMEI_E2E_NATIVE to opt in (both are set automatically by `make test-e2e` / CI; a bare `go test ./e2e/...` skips by design)")
 		}
 	}
 
@@ -435,190 +473,245 @@ EOF`, dir, strings.Join(quoted, ", "))
 		Expect(err).NotTo(HaveOccurred(), "writing manifest for %s failed", dir)
 	}
 
-	Context("Apply --system (real install)", func() {
-		BeforeAll(func() {
-			skipIfNotLinux()
-
-			// Ensure tomei is initialized — `tomei apply` aborts early with
-			// "tomei is not initialized" otherwise. --force makes the call
-			// idempotent across prior Contexts (some of which may have
-			// already run init). Pattern: e2e/privileged_test.go:16.
-			_, _ = testExec.Exec("tomei", "init", "--yes", "--force")
-
-			// Reset SYSTEM state only — user-store belongs to other suites.
-			// Top-level JSON keys match internal/state/state.go SystemState.
-			// Failure here means the home directory is misconfigured and
-			// every downstream spec would surface a misleading error, so
-			// fail loudly instead of swallowing the error.
-			_, err := testExec.ExecBash(`mkdir -p ~/.local/share/tomei/system && echo '{"version":"1","systemInstallers":{},"systemPackageRepositories":{},"systemPackages":{}}' > ~/.local/share/tomei/system/state.json`)
-			Expect(err).NotTo(HaveOccurred(), "failed to reset system state.json")
-
-			// Defense-in-depth: if a future Dockerfile change adds any
-			// fixture pkg to the preinstall list, a post-apply dpkg-query
-			// check would pass even if tomei did nothing. Detect that drift
-			// at BeforeAll time with a precise error message.
-			for _, pkg := range []string{"bc", "cowsay", "tree"} {
-				out, _ := testExec.ExecBash("dpkg-query -W -f='${Status}\\n' " + pkg + " 2>&1 || true")
-				Expect(out).NotTo(ContainSubstring("install ok installed"),
-					"fixture invariant violated: %s is preinstalled on the runner — pick a different package", pkg)
-			}
-
-			writeSystemPackageManifest("/tmp/tomei-system-package-install", []string{"bc", "cowsay"})
-
-			// PackageSetInstaller.Install does not refresh the apt index
-			// (PackageRepositoryInstaller does, but only that one). CI
-			// images carry stale indexes; refresh once. Tolerate non-zero
-			// exit — apt exits non-zero on any mirror failure, but a
-			// partial refresh is usually enough for the apply step to
-			// produce a clearer downstream error than `update` would.
-			// The err is captured (not silently dropped) so a complete
-			// mirror outage surfaces in GinkgoWriter alongside the output.
-			out, err := testExec.ExecBash("sudo -n apt-get update -qq 2>&1")
-			fmt.Fprintf(GinkgoWriter, "apt-get update (err=%v):\n%s\n", err, out)
-		})
-
-		It("apply --system installs the manifest packages on the host", func() {
-			out, err := ExecApply(testExec, "--system", installCfgPath)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(out).To(ContainSubstring("SystemPackageSet/cli-tools"))
-			Expect(out).To(ContainSubstring("SystemPackageSet/tree"))
-			assertInstalled("bc")
-			assertInstalled("cowsay")
-			assertInstalled("tree")
-		})
-
-		It("records InstalledVersions for the sugar and the set in state.json", func() {
-			raw, err := testExec.ExecBash("cat ~/.local/share/tomei/system/state.json")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(raw).To(ContainSubstring(`"cli-tools"`))
-			Expect(raw).To(ContainSubstring(`"tree"`))
-			Expect(raw).To(ContainSubstring(`"installedVersions"`))
-			Expect(raw).To(ContainSubstring(`"bc"`))
-			Expect(raw).To(ContainSubstring(`"cowsay"`))
-		})
-
-		It("apply WITHOUT --system is a no-op (system resources skip-downgraded)", func() {
-			// Anchor the prior install: if the previous It silently failed,
-			// the state would be empty and "no rewrite" would trivially
-			// pass. MatchRegexp pins the structural shape — systemPackages
-			// is a non-empty map with cli-tools as a top-level key — so a
-			// stray "cli-tools" substring elsewhere in the JSON (e.g. in a
-			// later nested ref) can't satisfy the assertion.
-			rawBefore, _ := testExec.ExecBash("cat ~/.local/share/tomei/system/state.json")
-			Expect(rawBefore).To(MatchRegexp(`"systemPackages"\s*:\s*\{[^}]*"cli-tools"`),
-				"prerequisite: prior --system apply must have populated systemPackages.cli-tools in state.json before testing no-op semantics; got:\n%s", rawBefore)
-
-			hashBefore := stateHash()
-			out, err := ExecApply(testExec, installCfgPath)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(out).To(ContainSubstring("SystemPackageSet/cli-tools"))
-			assertInstalled("bc")
-			assertInstalled("cowsay")
-			assertInstalled("tree")
-			Expect(stateHash()).To(Equal(hashBefore),
-				"apply without --system must not rewrite system state.json")
-		})
-
-		It("re-apply --system is idempotent (plan shows zero work)", func() {
-			// Plan summary is matched by regex so harmless cosmetic
-			// changes to the tree.go printer (color codes, spacing) do not
-			// break the assertion; the four-counter structure is the
-			// invariant. The trailing `, N disabled` segment only renders
-			// when ActionSkip > 0, which is not the case here post-#216
-			// (SystemPackageSet is no longer skip-downgraded with --system).
-			out, err := testExec.Exec("tomei", "plan", "--system", installCfgPath)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(out).To(MatchRegexp(`Summary:\s+0 to install,\s+0 to upgrade,\s+0 to reinstall,\s+0 to remove\b`))
-
-			hashBefore := stateHash()
-			_, err = ExecApply(testExec, "--system", installCfgPath)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(stateHash()).To(Equal(hashBefore),
-				"idempotent re-apply must not rewrite state.json")
-		})
-	})
-
-	Context("Apply --system removal and idempotency", func() {
-		BeforeAll(func() {
-			skipIfNotLinux()
-
-			// Pre-flight: anchor Context A's post-install state. If
-			// Context A succeeded, bc/cowsay/tree are installed and the
-			// system state.json holds entries for cli-tools/tree. Without
-			// this guard, a silent failure upstream would let Context B's
-			// "WITH --system runs apt-get remove" spec pass trivially
-			// (nothing to remove → state already matches removal target).
-			assertInstalled("bc")
-			assertInstalled("cowsay")
-			assertInstalled("tree")
-
-			// Reduced manifest under /tmp/ — do NOT edit the canonical
-			// fixture at ~/system-package-test/manifest.cue in place; the
-			// prior Contexts (validate / plan / Apply A) depend on it
-			// being byte-stable.
-			writeSystemPackageManifest("/tmp/tomei-system-package-removal", []string{"bc"})
-		})
-
+	Context("Apply --system mutates host packages (#200)", func() {
+		// Outer-scope cleanup. Runs after every inner spec in both
+		// Context A and Context B has completed (or been skipped),
+		// regardless of which inner Context failed. Best-effort:
+		// tolerate non-zero exits so a failure inside cleanup never
+		// masks the spec failure that surfaced the real bug. apt-get
+		// remove (NOT --purge) is enough — we don't care about
+		// lingering config files on an ephemeral CI runner.
 		AfterAll(func() {
-			// Native-mode safety: on a developer laptop (TOMEI_E2E_NATIVE)
-			// the AfterAll would otherwise apt-get remove packages the
-			// developer might use day-to-day, and rm -rf predictable /tmp/
-			// paths that a parallel suite or other tooling could be
-			// writing to. In containerised CI we own the entire FS, so
-			// cleanup is safe and beneficial (run-to-run isolation).
-			if os.Getenv("TOMEI_E2E_NATIVE") == "true" {
-				fmt.Fprintln(GinkgoWriter, "TOMEI_E2E_NATIVE=true: skipping host package + /tmp cleanup")
+			// Outer cleanup gates on the same opt-in env vars that
+			// gate the inner specs (see skipIfNotLinux). Without one
+			// of them, the inner specs Skip()'d and there is nothing
+			// to clean up; running apt-get remove anyway would be
+			// surprising and potentially destructive on a developer
+			// laptop that happens to share this binary.
+			if os.Getenv("TOMEI_E2E_CONTAINER") == "" && os.Getenv("TOMEI_E2E_NATIVE") == "" {
 				return
 			}
-			// Best-effort cleanup. Tolerate non-zero exit so a failure
-			// inside cleanup never masks the spec failure that surfaced
-			// the real bug. apt-get remove (NOT --purge) is enough — we
-			// don't care about lingering config files on an ephemeral CI
-			// runner.
+			// Native-mode safety: on a CI native runner the runner is
+			// ephemeral and apt cleanup is safe. We still keep the
+			// TOMEI_E2E_NATIVE=true short-circuit as an emergency
+			// escape hatch documented for developers who explicitly
+			// opted in to native-mode-with-cleanup-disabled.
+			if os.Getenv("TOMEI_E2E_NATIVE_SKIP_CLEANUP") == "true" {
+				fmt.Fprintln(GinkgoWriter, "TOMEI_E2E_NATIVE_SKIP_CLEANUP=true: skipping host package + /tmp cleanup")
+				return
+			}
 			_, _ = testExec.ExecBash("sudo -n apt-get remove -y bc cowsay tree 2>&1 || true")
 			_, _ = testExec.ExecBash("rm -rf /tmp/tomei-system-package-install /tmp/tomei-system-package-removal")
 		})
 
-		It("apply removal manifest WITHOUT --system retains cowsay in state (no-op)", func() {
-			hashBefore := stateHash()
-			_, err := ExecApply(testExec, removalCfgPath)
-			Expect(err).NotTo(HaveOccurred())
-			raw, _ := testExec.ExecBash("cat ~/.local/share/tomei/system/state.json")
-			Expect(raw).To(ContainSubstring(`"cowsay"`))
-			assertInstalled("cowsay")
-			Expect(stateHash()).To(Equal(hashBefore),
-				"removal manifest applied without --system must not rewrite state.json")
+		Context("Apply --system (real install)", func() {
+			BeforeAll(func() {
+				skipIfNotLinux()
+
+				// Ensure tomei is initialized — `tomei apply` aborts early with
+				// "tomei is not initialized" otherwise. --force makes the call
+				// idempotent across prior Contexts (some of which may have
+				// already run init). Pattern: e2e/privileged_test.go:16.
+				_, _ = testExec.Exec("tomei", "init", "--yes", "--force")
+
+				// Reset SYSTEM state only — user-store belongs to other suites.
+				// Top-level JSON keys match internal/state/state.go SystemState.
+				// Failure here means the home directory is misconfigured and
+				// every downstream spec would surface a misleading error, so
+				// fail loudly instead of swallowing the error.
+				_, err := testExec.ExecBash(`mkdir -p ~/.local/share/tomei/system && echo '{"version":"1","systemInstallers":{},"systemPackageRepositories":{},"systemPackages":{}}' > ~/.local/share/tomei/system/state.json`)
+				Expect(err).NotTo(HaveOccurred(), "failed to reset system state.json")
+
+				// Defense-in-depth: if a future Dockerfile change adds any
+				// fixture pkg to the preinstall list, a post-apply dpkg-query
+				// check would pass even if tomei did nothing. Detect that drift
+				// at BeforeAll time with a precise error message.
+				for _, pkg := range []string{"bc", "cowsay", "tree"} {
+					out, _ := testExec.ExecBash("dpkg-query -W -f='${Status}\\n' " + pkg + " 2>&1 || true")
+					Expect(out).NotTo(ContainSubstring("install ok installed"),
+						"fixture invariant violated: %s is preinstalled on the runner — pick a different package", pkg)
+				}
+
+				writeSystemPackageManifest("/tmp/tomei-system-package-install", []string{"bc", "cowsay"})
+
+				// PackageSetInstaller.Install does not refresh the apt index
+				// (PackageRepositoryInstaller does, but only that one). CI
+				// images carry stale indexes; refresh once. Tolerate non-zero
+				// exit — apt exits non-zero on any mirror failure, but a
+				// partial refresh is usually enough for the apply step to
+				// produce a clearer downstream error than `update` would.
+				// The err is captured (not silently dropped) so a complete
+				// mirror outage surfaces in GinkgoWriter alongside the output.
+				out, err := testExec.ExecBash("sudo -n apt-get update -qq 2>&1")
+				fmt.Fprintf(GinkgoWriter, "apt-get update (err=%v):\n%s\n", err, out)
+			})
+
+			It("apply --system installs the manifest packages on the host", func() {
+				out, err := ExecApply(testExec, "--system", installCfgPath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(out).To(ContainSubstring("SystemPackageSet/cli-tools"))
+				Expect(out).To(ContainSubstring("SystemPackageSet/tree"))
+				assertInstalled("bc")
+				assertInstalled("cowsay")
+				assertInstalled("tree")
+			})
+
+			It("records InstalledVersions for the sugar and the set in state.json", func() {
+				// Parse the JSON rather than substring-matching "bc" / "cowsay":
+				// the package names also appear in the `packages` array of the
+				// resource spec snapshot, so a substring match would pass even
+				// if `installedVersions` were empty or missing — exactly the
+				// regression this spec is meant to catch. Scope the assertion
+				// to systemPackages[name].installedVersions and check map
+				// membership so a future renaming or relocation of the field
+				// surfaces as a real failure rather than a green test.
+				raw, err := testExec.ExecBash("cat ~/.local/share/tomei/system/state.json")
+				Expect(err).NotTo(HaveOccurred())
+
+				// Anonymous struct mirrors only the fields under test; unknown
+				// fields are ignored by encoding/json so this assertion stays
+				// stable as the state schema evolves around it.
+				var parsed struct {
+					SystemPackages map[string]struct {
+						InstalledVersions map[string]string `json:"installedVersions"`
+					} `json:"systemPackages"`
+				}
+				Expect(json.Unmarshal([]byte(raw), &parsed)).To(Succeed(),
+					"state.json must be valid JSON; got:\n%s", raw)
+
+				cliTools, ok := parsed.SystemPackages["cli-tools"]
+				Expect(ok).To(BeTrue(),
+					"systemPackages.cli-tools must exist after --system apply; systemPackages contained: %v",
+					parsed.SystemPackages)
+				Expect(cliTools.InstalledVersions).To(HaveKey("bc"),
+					"systemPackages.cli-tools.installedVersions must record bc; got: %v", cliTools.InstalledVersions)
+				Expect(cliTools.InstalledVersions).To(HaveKey("cowsay"),
+					"systemPackages.cli-tools.installedVersions must record cowsay; got: %v", cliTools.InstalledVersions)
+				// Sanity-check the version field too — an empty version string
+				// would mean InstalledVersions is populated with empty values,
+				// which is a likely regression mode if PackageVersion() ever
+				// silently fails. Non-empty proves we recorded a real version.
+				Expect(cliTools.InstalledVersions["bc"]).NotTo(BeEmpty(),
+					"cli-tools.installedVersions.bc must be a non-empty version string")
+				Expect(cliTools.InstalledVersions["cowsay"]).NotTo(BeEmpty(),
+					"cli-tools.installedVersions.cowsay must be a non-empty version string")
+
+				tree, ok := parsed.SystemPackages["tree"]
+				Expect(ok).To(BeTrue(),
+					"systemPackages.tree (sugar) must exist after --system apply")
+				Expect(tree.InstalledVersions).To(HaveKey("tree"),
+					"systemPackages.tree.installedVersions must record the desugared package; got: %v", tree.InstalledVersions)
+			})
+
+			It("apply WITHOUT --system is a no-op (system resources skip-downgraded)", func() {
+				// Anchor the prior install: if the previous It silently failed,
+				// the state would be empty and "no rewrite" would trivially
+				// pass. MatchRegexp pins the structural shape — systemPackages
+				// is a non-empty map with cli-tools as a top-level key — so a
+				// stray "cli-tools" substring elsewhere in the JSON (e.g. in a
+				// later nested ref) can't satisfy the assertion.
+				rawBefore, _ := testExec.ExecBash("cat ~/.local/share/tomei/system/state.json")
+				Expect(rawBefore).To(MatchRegexp(`"systemPackages"\s*:\s*\{[^}]*"cli-tools"`),
+					"prerequisite: prior --system apply must have populated systemPackages.cli-tools in state.json before testing no-op semantics; got:\n%s", rawBefore)
+
+				hashBefore := stateHash()
+				out, err := ExecApply(testExec, installCfgPath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(out).To(ContainSubstring("SystemPackageSet/cli-tools"))
+				assertInstalled("bc")
+				assertInstalled("cowsay")
+				assertInstalled("tree")
+				Expect(stateHash()).To(Equal(hashBefore),
+					"apply without --system must not rewrite system state.json")
+			})
+
+			It("re-apply --system is idempotent (plan shows zero work)", func() {
+				// Plan summary is matched by regex so harmless cosmetic
+				// changes to the tree.go printer (color codes, spacing) do not
+				// break the assertion; the four-counter structure is the
+				// invariant. The trailing `, N disabled` segment only renders
+				// when ActionSkip > 0, which is not the case here post-#216
+				// (SystemPackageSet is no longer skip-downgraded with --system).
+				out, err := testExec.Exec("tomei", "plan", "--system", installCfgPath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(out).To(MatchRegexp(`Summary:\s+0 to install,\s+0 to upgrade,\s+0 to reinstall,\s+0 to remove\b`))
+
+				hashBefore := stateHash()
+				_, err = ExecApply(testExec, "--system", installCfgPath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(stateHash()).To(Equal(hashBefore),
+					"idempotent re-apply must not rewrite state.json")
+			})
 		})
 
-		It("apply removal manifest WITH --system runs apt-get remove and updates state.json", func() {
-			out, err := ExecApply(testExec, "--system", removalCfgPath)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(out).To(ContainSubstring("SystemPackageSet/cli-tools"))
-			assertNotInstalled("cowsay")
-			assertInstalled("bc")
-			assertInstalled("tree")
-			raw, _ := testExec.ExecBash("cat ~/.local/share/tomei/system/state.json")
-			Expect(raw).To(ContainSubstring(`"cli-tools"`))
-			Expect(raw).To(ContainSubstring(`"bc"`))
-			// The SystemPackage sugar entry must survive a sibling set's
-			// shrink — confirms removal scope is per-resource, not global.
-			Expect(raw).To(ContainSubstring(`"tree"`))
-			Expect(raw).NotTo(ContainSubstring(`"cowsay"`))
-		})
+		Context("Apply --system removal and idempotency", func() {
+			BeforeAll(func() {
+				skipIfNotLinux()
 
-		It("re-apply removal manifest WITH --system is idempotent", func() {
-			// Mirrors Context A's idempotency: once the removal has
-			// converged, a second --system apply against the same reduced
-			// manifest must be a plan-zero / state-byte-stable no-op.
-			out, err := testExec.Exec("tomei", "plan", "--system", removalCfgPath)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(out).To(MatchRegexp(`Summary:\s+0 to install,\s+0 to upgrade,\s+0 to reinstall,\s+0 to remove\b`))
+				// Pre-flight: anchor Context A's post-install state. If
+				// Context A succeeded, bc/cowsay/tree are installed and the
+				// system state.json holds entries for cli-tools/tree. Without
+				// this guard, a silent failure upstream would let Context B's
+				// "WITH --system runs apt-get remove" spec pass trivially
+				// (nothing to remove → state already matches removal target).
+				assertInstalled("bc")
+				assertInstalled("cowsay")
+				assertInstalled("tree")
 
-			hashBefore := stateHash()
-			_, err = ExecApply(testExec, "--system", removalCfgPath)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(stateHash()).To(Equal(hashBefore),
-				"idempotent re-apply of the removal manifest must not rewrite state.json")
+				// Reduced manifest under /tmp/ — do NOT edit the canonical
+				// fixture at ~/system-package-test/manifest.cue in place; the
+				// prior Contexts (validate / plan / Apply A) depend on it
+				// being byte-stable.
+				writeSystemPackageManifest("/tmp/tomei-system-package-removal", []string{"bc"})
+			})
+
+			// Host cleanup is registered at the outer Context scope (see
+			// the parent Context's AfterAll). Keeping it there means a
+			// Context A failure that prevents Context B from starting still
+			// triggers cleanup — an inner AfterAll here would not run in
+			// that case under Ginkgo's Ordered semantics.
+
+			It("apply removal manifest WITHOUT --system retains cowsay in state (no-op)", func() {
+				hashBefore := stateHash()
+				_, err := ExecApply(testExec, removalCfgPath)
+				Expect(err).NotTo(HaveOccurred())
+				raw, _ := testExec.ExecBash("cat ~/.local/share/tomei/system/state.json")
+				Expect(raw).To(ContainSubstring(`"cowsay"`))
+				assertInstalled("cowsay")
+				Expect(stateHash()).To(Equal(hashBefore),
+					"removal manifest applied without --system must not rewrite state.json")
+			})
+
+			It("apply removal manifest WITH --system runs apt-get remove and updates state.json", func() {
+				out, err := ExecApply(testExec, "--system", removalCfgPath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(out).To(ContainSubstring("SystemPackageSet/cli-tools"))
+				assertNotInstalled("cowsay")
+				assertInstalled("bc")
+				assertInstalled("tree")
+				raw, _ := testExec.ExecBash("cat ~/.local/share/tomei/system/state.json")
+				Expect(raw).To(ContainSubstring(`"cli-tools"`))
+				Expect(raw).To(ContainSubstring(`"bc"`))
+				// The SystemPackage sugar entry must survive a sibling set's
+				// shrink — confirms removal scope is per-resource, not global.
+				Expect(raw).To(ContainSubstring(`"tree"`))
+				Expect(raw).NotTo(ContainSubstring(`"cowsay"`))
+			})
+
+			It("re-apply removal manifest WITH --system is idempotent", func() {
+				// Mirrors Context A's idempotency: once the removal has
+				// converged, a second --system apply against the same reduced
+				// manifest must be a plan-zero / state-byte-stable no-op.
+				out, err := testExec.Exec("tomei", "plan", "--system", removalCfgPath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(out).To(MatchRegexp(`Summary:\s+0 to install,\s+0 to upgrade,\s+0 to reinstall,\s+0 to remove\b`))
+
+				hashBefore := stateHash()
+				_, err = ExecApply(testExec, "--system", removalCfgPath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(stateHash()).To(Equal(hashBefore),
+					"idempotent re-apply of the removal manifest must not rewrite state.json")
+			})
 		})
 	})
 }

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -61,19 +61,23 @@ var ubuntuReleaseToCodename = map[string]string{
 // disallowed characters which accepts a wider set of Debian-legal names
 // (e.g., uppercase, longer punctuation); this test-helper allowlist is
 // intentionally narrower — it only needs to admit the small fixture set
-// ("bc", "cowsay", "tree") and refuses anything riskier even if that
+// ("cowsay", "sl", "tree") and refuses anything riskier even if that
 // rejects names production would happily accept. Compiled once at
 // package init to avoid re-parsing per call.
 var systemPackageTestPkgNameRE = regexp.MustCompile(`^[a-z0-9][a-z0-9+\-.]*$`)
 
 // systemPackageTestDirRE is a path allowlist for writeSystemPackageManifest's
-// dir argument. Callers currently pass only static literals under /tmp/,
-// but Sprintf-into-shell-heredoc semantics mean any future caller passing
-// a path with shell metacharacters (`$`, backticks, `;`) would break out
-// of the heredoc. Defense-in-depth: refuse anything that isn't an
-// alphanumeric/`/`/`-`/`_`/`.` path so the failure mode is a loud
-// Expect rather than silent code execution.
-var systemPackageTestDirRE = regexp.MustCompile(`^/[A-Za-z0-9._/\-]+$`)
+// dir argument. The helper documents a `/tmp`-only safety boundary and
+// uses Sprintf-into-shell-heredoc semantics, so the regex must enforce
+// BOTH constraints: the path must live under /tmp/, AND the segment after
+// `/tmp/` must not contain path-traversal components or shell
+// metacharacters. The earlier `^/[A-Za-z0-9._/\-]+$` allowed any absolute
+// path (e.g. `/etc/tomei`) and admitted `..` via the dot character — a
+// caller passing `/tmp/../../etc/tomei` would escape the scratch area.
+// This tighter form pins the prefix to `/tmp/`, forbids consecutive dots
+// (`\.\.`), and forbids embedded slashes inside the segment so a single
+// flat `/tmp/<name>` is the only shape that passes.
+var systemPackageTestDirRE = regexp.MustCompile(`^/tmp/[A-Za-z0-9_\-]+(\.[A-Za-z0-9_\-]+)*/?$`)
 
 // pgdgKeyHashSHA256 is the pinned SHA256 of the PostgreSQL APT signing
 // key referenced from e2e/config/system-package-test/manifest.cue. The
@@ -356,7 +360,7 @@ func systemPackageTests() {
 		out, err := testExec.ExecBash("set -o pipefail; sha256sum ~/.local/share/tomei/system/state.json | awk '{print $1}'")
 		Expect(err).NotTo(HaveOccurred(), "sha256sum on system state.json failed: %s", out)
 		hash := strings.TrimSpace(out)
-		// Defence-in-depth in case pipefail is somehow disabled by a
+		// Defense-in-depth in case pipefail is somehow disabled by a
 		// future shell wrapper change: a real sha256sum hash is exactly
 		// 64 lowercase hex chars. Anything else means we got stderr,
 		// "No such file", an awk error, or an empty pipe — fail loudly
@@ -404,6 +408,22 @@ func systemPackageTests() {
 	const installCfgPath = "/tmp/tomei-system-package-install/"
 	const removalCfgPath = "/tmp/tomei-system-package-removal/"
 
+	// fixturePackages enumerates every package this Context's BeforeAll
+	// may install on the host. Centralized so the BeforeAll remove-first
+	// step, the outer AfterAll cleanup, and any future drift detector
+	// stay in lockstep — adding a fourth package in the manifest without
+	// touching this list would silently leak host state.
+	fixturePackages := []string{"cowsay", "sl", "tree"}
+
+	// fixtureManaged is set to true at the very end of Context A's
+	// BeforeAll, after tomei has had a chance to take ownership of the
+	// fixture packages. Outer AfterAll consults it: if BeforeAll aborted
+	// midway (e.g. the preflight remove-first step failed and the spec
+	// short-circuited), we MUST NOT then unconditionally apt-get remove
+	// the user's pre-existing packages. The flag is the explicit
+	// "we own these now" signal that gates destructive cleanup.
+	var fixtureManaged bool
+
 	// writeSystemPackageManifest writes a minimal CUE manifest under dir:
 	// SystemInstaller/apt + SystemPackage/tree sugar + SystemPackageSet
 	// cli-tools with the given package list. The single-quoted heredoc
@@ -427,7 +447,16 @@ func systemPackageTests() {
 		for i, p := range pkgs {
 			quoted[i] = `"` + p + `"`
 		}
-		script := fmt.Sprintf(`mkdir -p %[1]s/cue.mod && cat > %[1]s/cue.mod/module.cue <<'EOF'
+		// Clear the target directory before recreating cue.mod /
+		// manifest.cue. The CUE loader reads EVERY *.cue file in the
+		// directory; a stale manifest left by a failed previous run
+		// (or by a developer iterating on the helper) would be loaded
+		// alongside the fresh one and silently shift these assertions.
+		// `rm -rf` of the whole dir is safe here because the regex
+		// allowlist above restricts dir to a flat single-segment
+		// /tmp/<name> path — no risk of clobbering anything outside
+		// the scratch area.
+		script := fmt.Sprintf(`rm -rf %[1]s && mkdir -p %[1]s/cue.mod && cat > %[1]s/cue.mod/module.cue <<'EOF'
 module: "tomei.local@v0"
 language: version: "v0.9.0"
 EOF
@@ -491,16 +520,37 @@ EOF`, dir, strings.Join(quoted, ", "))
 			if os.Getenv("TOMEI_E2E_CONTAINER") == "" && os.Getenv("TOMEI_E2E_NATIVE") == "" {
 				return
 			}
-			// Native-mode safety: on a CI native runner the runner is
-			// ephemeral and apt cleanup is safe. We still keep the
-			// TOMEI_E2E_NATIVE=true short-circuit as an emergency
-			// escape hatch documented for developers who explicitly
-			// opted in to native-mode-with-cleanup-disabled.
+			// Emergency escape hatch for developers who opt in to
+			// native mode but want host state preserved for inspection
+			// after a failed run.
 			if os.Getenv("TOMEI_E2E_NATIVE_SKIP_CLEANUP") == "true" {
 				fmt.Fprintln(GinkgoWriter, "TOMEI_E2E_NATIVE_SKIP_CLEANUP=true: skipping host package + /tmp cleanup")
 				return
 			}
-			_, _ = testExec.ExecBash("sudo -n apt-get remove -y bc cowsay tree 2>&1 || true")
+			// Ownership gate: only apt-get remove the fixture packages
+			// if Context A's BeforeAll completed (and therefore tomei,
+			// not the runner/developer, is the owner of these packages
+			// post-test). If the preflight remove-first step or any
+			// earlier setup aborted, fixtureManaged stays false and we
+			// MUST NOT touch packages we did not install — that was the
+			// concrete risk Copilot flagged: a failed preinstall
+			// invariant followed by an unconditional apt-get remove of
+			// the user's pre-existing package. /tmp scratch dirs are
+			// always safe to remove (regex-allowlisted single-segment
+			// paths created by this suite only).
+			if fixtureManaged {
+				// `apt-get autoremove` is intentionally included after
+				// the remove step. cowsay's runtime Depends pulled in
+				// libtext-charwidth-perl (and similar transitive
+				// auto-installed packages); without --autoremove,
+				// `apt-get remove` leaves those orphaned on the runner
+				// across suite invocations, which is exactly the
+				// "still leave host package state changed after the
+				// suite" concern Copilot raised. Best-effort: ignore
+				// non-zero exit so a failure in cleanup never masks a
+				// real spec failure.
+				_, _ = testExec.ExecBash("sudo -n apt-get remove -y " + strings.Join(fixturePackages, " ") + " 2>&1; sudo -n apt-get autoremove -y 2>&1; true")
+			}
 			_, _ = testExec.ExecBash("rm -rf /tmp/tomei-system-package-install /tmp/tomei-system-package-removal")
 		})
 
@@ -522,17 +572,38 @@ EOF`, dir, strings.Join(quoted, ", "))
 				_, err := testExec.ExecBash(`mkdir -p ~/.local/share/tomei/system && echo '{"version":"1","systemInstallers":{},"systemPackageRepositories":{},"systemPackages":{}}' > ~/.local/share/tomei/system/state.json`)
 				Expect(err).NotTo(HaveOccurred(), "failed to reset system state.json")
 
-				// Defense-in-depth: if a future Dockerfile change adds any
-				// fixture pkg to the preinstall list, a post-apply dpkg-query
-				// check would pass even if tomei did nothing. Detect that drift
-				// at BeforeAll time with a precise error message.
-				for _, pkg := range []string{"bc", "cowsay", "tree"} {
-					out, _ := testExec.ExecBash("dpkg-query -W -f='${Status}\\n' " + pkg + " 2>&1 || true")
+				// Preflight remove-first: ensure the fixture packages are
+				// NOT installed before tomei runs, so the subsequent
+				// `apply --system` actually exercises the install path
+				// rather than passing because the package happened to
+				// already be on the runner.
+				//
+				// History: an earlier version of this Context used a hard
+				// fail-on-preinstalled invariant ("pick a different
+				// package") which broke the linux/arm64 native CI leg
+				// because GitHub-hosted ubuntu-24.04 runners preinstall
+				// `bc`. Switching to cowsay/sl (universe, leaf, NOT in
+				// any known runner-image preinstall list) plus this
+				// remove-first step makes the spec robust against future
+				// preinstall drift on either side — if a future runner
+				// image starts shipping cowsay or sl, the remove step
+				// uninstalls it cleanly and the test still validates a
+				// fresh install. We use NOT-purge here so /etc/cowsay
+				// (none exist, but futureproof) is preserved; the outer
+				// AfterAll handles the final removal.
+				//
+				// `2>&1 || true` swallows the failure for packages that
+				// are not installed (apt-get remove exits non-zero) so
+				// the BeforeAll proceeds; the assertNotInstalled checks
+				// below are the real assertion that the host is clean.
+				_, _ = testExec.ExecBash("sudo -n apt-get remove -y " + strings.Join(fixturePackages, " ") + " 2>&1 || true")
+				for _, pkg := range fixturePackages {
+					out, _ := testExec.Exec("dpkg-query", "-W", "-f=${Status}\n", "--", pkg)
 					Expect(out).NotTo(ContainSubstring("install ok installed"),
-						"fixture invariant violated: %s is preinstalled on the runner — pick a different package", pkg)
+						"preflight failed: %s is still installed after apt-get remove (dpkg-query Status: %q) — the apply spec below would not be exercising a real install", pkg, out)
 				}
 
-				writeSystemPackageManifest("/tmp/tomei-system-package-install", []string{"bc", "cowsay"})
+				writeSystemPackageManifest("/tmp/tomei-system-package-install", []string{"cowsay", "sl"})
 
 				// PackageSetInstaller.Install does not refresh the apt index
 				// (PackageRepositoryInstaller does, but only that one). CI
@@ -544,6 +615,14 @@ EOF`, dir, strings.Join(quoted, ", "))
 				// mirror outage surfaces in GinkgoWriter alongside the output.
 				out, err := testExec.ExecBash("sudo -n apt-get update -qq 2>&1")
 				fmt.Fprintf(GinkgoWriter, "apt-get update (err=%v):\n%s\n", err, out)
+
+				// Take ownership: from this point, the outer AfterAll is
+				// authorized to apt-get remove the fixture packages.
+				// Setting this AFTER all preflight steps complete means a
+				// preflight failure leaves it false and the AfterAll
+				// becomes a no-op — preserving the user/runner's
+				// pre-existing host state in that scenario.
+				fixtureManaged = true
 			})
 
 			It("apply --system installs the manifest packages on the host", func() {
@@ -551,8 +630,8 @@ EOF`, dir, strings.Join(quoted, ", "))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).To(ContainSubstring("SystemPackageSet/cli-tools"))
 				Expect(out).To(ContainSubstring("SystemPackageSet/tree"))
-				assertInstalled("bc")
 				assertInstalled("cowsay")
+				assertInstalled("sl")
 				assertInstalled("tree")
 			})
 
@@ -583,24 +662,30 @@ EOF`, dir, strings.Join(quoted, ", "))
 				Expect(ok).To(BeTrue(),
 					"systemPackages.cli-tools must exist after --system apply; systemPackages contained: %v",
 					parsed.SystemPackages)
-				Expect(cliTools.InstalledVersions).To(HaveKey("bc"),
-					"systemPackages.cli-tools.installedVersions must record bc; got: %v", cliTools.InstalledVersions)
 				Expect(cliTools.InstalledVersions).To(HaveKey("cowsay"),
 					"systemPackages.cli-tools.installedVersions must record cowsay; got: %v", cliTools.InstalledVersions)
+				Expect(cliTools.InstalledVersions).To(HaveKey("sl"),
+					"systemPackages.cli-tools.installedVersions must record sl; got: %v", cliTools.InstalledVersions)
 				// Sanity-check the version field too — an empty version string
 				// would mean InstalledVersions is populated with empty values,
 				// which is a likely regression mode if PackageVersion() ever
 				// silently fails. Non-empty proves we recorded a real version.
-				Expect(cliTools.InstalledVersions["bc"]).NotTo(BeEmpty(),
-					"cli-tools.installedVersions.bc must be a non-empty version string")
 				Expect(cliTools.InstalledVersions["cowsay"]).NotTo(BeEmpty(),
 					"cli-tools.installedVersions.cowsay must be a non-empty version string")
+				Expect(cliTools.InstalledVersions["sl"]).NotTo(BeEmpty(),
+					"cli-tools.installedVersions.sl must be a non-empty version string")
 
 				tree, ok := parsed.SystemPackages["tree"]
 				Expect(ok).To(BeTrue(),
 					"systemPackages.tree (sugar) must exist after --system apply")
 				Expect(tree.InstalledVersions).To(HaveKey("tree"),
 					"systemPackages.tree.installedVersions must record the desugared package; got: %v", tree.InstalledVersions)
+				// Parity with the SystemPackageSet assertions above — an
+				// empty version string here would indicate PackageVersion()
+				// returned "" on the desugared path even though dpkg state
+				// was fine, masking a sugar-specific regression.
+				Expect(tree.InstalledVersions["tree"]).NotTo(BeEmpty(),
+					"tree.installedVersions.tree must be a non-empty version string (sugar path)")
 			})
 
 			It("apply WITHOUT --system is a no-op (system resources skip-downgraded)", func() {
@@ -618,8 +703,8 @@ EOF`, dir, strings.Join(quoted, ", "))
 				out, err := ExecApply(testExec, installCfgPath)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).To(ContainSubstring("SystemPackageSet/cli-tools"))
-				assertInstalled("bc")
 				assertInstalled("cowsay")
+				assertInstalled("sl")
 				assertInstalled("tree")
 				Expect(stateHash()).To(Equal(hashBefore),
 					"apply without --system must not rewrite system state.json")
@@ -649,20 +734,23 @@ EOF`, dir, strings.Join(quoted, ", "))
 				skipIfNotLinux()
 
 				// Pre-flight: anchor Context A's post-install state. If
-				// Context A succeeded, bc/cowsay/tree are installed and the
+				// Context A succeeded, cowsay/sl/tree are installed and the
 				// system state.json holds entries for cli-tools/tree. Without
 				// this guard, a silent failure upstream would let Context B's
 				// "WITH --system runs apt-get remove" spec pass trivially
 				// (nothing to remove → state already matches removal target).
-				assertInstalled("bc")
 				assertInstalled("cowsay")
+				assertInstalled("sl")
 				assertInstalled("tree")
 
-				// Reduced manifest under /tmp/ — do NOT edit the canonical
-				// fixture at ~/system-package-test/manifest.cue in place; the
-				// prior Contexts (validate / plan / Apply A) depend on it
-				// being byte-stable.
-				writeSystemPackageManifest("/tmp/tomei-system-package-removal", []string{"bc"})
+				// Reduced manifest under /tmp/: cli-tools shrinks from
+				// {cowsay, sl} to {cowsay}, so the removal driven by
+				// `apply --system` is exactly the sl package. We
+				// generate this as a sibling to the canonical fixture so
+				// prior Contexts (validate / plan / Apply A) that read
+				// ~/system-package-test/manifest.cue keep seeing a
+				// byte-stable manifest.
+				writeSystemPackageManifest("/tmp/tomei-system-package-removal", []string{"cowsay"})
 			})
 
 			// Host cleanup is registered at the outer Context scope (see
@@ -671,13 +759,44 @@ EOF`, dir, strings.Join(quoted, ", "))
 			// triggers cleanup — an inner AfterAll here would not run in
 			// that case under Ginkgo's Ordered semantics.
 
-			It("apply removal manifest WITHOUT --system retains cowsay in state (no-op)", func() {
+			// parseStateInstalled is a Context-B-local helper that parses
+			// state.json into the same struct shape Context A uses for
+			// installedVersions, so the removal-state assertions can
+			// inspect map membership instead of falling back to substring
+			// matches (which were the trap Copilot flagged on the install
+			// path — package names in the resource spec's `packages`
+			// array can satisfy a substring check even when
+			// installedVersions is empty).
+			parseStateInstalled := func() map[string]map[string]string {
+				raw, err := testExec.ExecBash("cat ~/.local/share/tomei/system/state.json")
+				Expect(err).NotTo(HaveOccurred())
+				var parsed struct {
+					SystemPackages map[string]struct {
+						InstalledVersions map[string]string `json:"installedVersions"`
+					} `json:"systemPackages"`
+				}
+				Expect(json.Unmarshal([]byte(raw), &parsed)).To(Succeed(),
+					"state.json must be valid JSON; got:\n%s", raw)
+				out := map[string]map[string]string{}
+				for name, sp := range parsed.SystemPackages {
+					out[name] = sp.InstalledVersions
+				}
+				return out
+			}
+
+			It("apply removal manifest WITHOUT --system retains sl in state (no-op)", func() {
 				hashBefore := stateHash()
 				_, err := ExecApply(testExec, removalCfgPath)
 				Expect(err).NotTo(HaveOccurred())
-				raw, _ := testExec.ExecBash("cat ~/.local/share/tomei/system/state.json")
-				Expect(raw).To(ContainSubstring(`"cowsay"`))
-				assertInstalled("cowsay")
+				installed := parseStateInstalled()
+				// Without --system, cli-tools.installedVersions must
+				// still record sl from Context A's install — system
+				// resources are skip-downgraded and the state shrink
+				// MUST NOT have happened yet.
+				Expect(installed).To(HaveKey("cli-tools"))
+				Expect(installed["cli-tools"]).To(HaveKey("sl"),
+					"sl must still be recorded under cli-tools.installedVersions before --system removal; got: %v", installed["cli-tools"])
+				assertInstalled("sl")
 				Expect(stateHash()).To(Equal(hashBefore),
 					"removal manifest applied without --system must not rewrite state.json")
 			})
@@ -686,16 +805,24 @@ EOF`, dir, strings.Join(quoted, ", "))
 				out, err := ExecApply(testExec, "--system", removalCfgPath)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).To(ContainSubstring("SystemPackageSet/cli-tools"))
-				assertNotInstalled("cowsay")
-				assertInstalled("bc")
+				assertNotInstalled("sl")
+				assertInstalled("cowsay")
 				assertInstalled("tree")
-				raw, _ := testExec.ExecBash("cat ~/.local/share/tomei/system/state.json")
-				Expect(raw).To(ContainSubstring(`"cli-tools"`))
-				Expect(raw).To(ContainSubstring(`"bc"`))
-				// The SystemPackage sugar entry must survive a sibling set's
-				// shrink — confirms removal scope is per-resource, not global.
-				Expect(raw).To(ContainSubstring(`"tree"`))
-				Expect(raw).NotTo(ContainSubstring(`"cowsay"`))
+				installed := parseStateInstalled()
+				Expect(installed).To(HaveKey("cli-tools"),
+					"cli-tools must remain in systemPackages after shrink; got keys: %v", installed)
+				Expect(installed["cli-tools"]).To(HaveKey("cowsay"),
+					"cowsay must remain under cli-tools.installedVersions; got: %v", installed["cli-tools"])
+				Expect(installed["cli-tools"]["cowsay"]).NotTo(BeEmpty(),
+					"cli-tools.installedVersions.cowsay must keep its non-empty version across the shrink")
+				Expect(installed["cli-tools"]).NotTo(HaveKey("sl"),
+					"sl must be removed from cli-tools.installedVersions after --system removal; got: %v", installed["cli-tools"])
+				// The SystemPackage sugar entry must survive a sibling
+				// set's shrink — confirms removal scope is per-resource,
+				// not global.
+				Expect(installed).To(HaveKey("tree"),
+					"sugar entry tree must survive a sibling set's shrink; got keys: %v", installed)
+				Expect(installed["tree"]).To(HaveKey("tree"))
 			})
 
 			It("re-apply removal manifest WITH --system is idempotent", func() {


### PR DESCRIPTION
Adds two Ordered Contexts exercising the SystemPackageSet apply path on
the host: a real install (cowsay, sl, tree) that asserts dpkg state and
state.json InstalledVersions, and a removal/idempotency Context driven
by a reduced sibling manifest. Switches the canonical fixture's
cliTools packages to cowsay/sl — universe-pocket leaf packages NOT
preinstalled on GitHub-hosted ubuntu-24.04 runners (an earlier draft
used `bc`, which broke the native CI legs because GH runners
preinstall it).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>