### PR TITLE
test(e2e): promote SystemPackageRepository apply to It (#218)

### DIFF
--- a/.claude/skills/copilot-loop/SKILL.md
+++ b/.claude/skills/copilot-loop/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: copilot-loop
+description: Iterate Copilot review → fix → push → re-request, until Copilot leaves no new comments. Builds on /copilot for the per-round work.
+disable-model-invocation: true
+allowed-tools:
+  - Bash(gh pr view *)
+  - Bash(gh pr list*)
+  - Bash(gh api *)
+  - Bash(make build)
+  - Bash(make test)
+  - Bash(make test-integration)
+  - Bash(make test-e2e)
+  - Bash(make lint)
+  - Bash(make fmt)
+  - Bash(git add *)
+  - Bash(git commit *)
+  - Bash(git diff *)
+  - Bash(git status*)
+  - Bash(git log *)
+  - Bash(git branch *)
+  - Bash(git push*)
+  - Bash(git rev-parse *)
+  - Read
+  - Grep
+  - Glob
+  - Edit
+---
+
+# Copilot Review Loop
+
+Fully-automated iteration of GitHub Copilot reviews on the current branch's PR.
+Each cycle = request review → wait → triage → fix or reply → commit + push →
+resolve threads → re-request. Loop ends when Copilot's next review adds zero
+new top-level inline comments.
+
+This skill builds on `/copilot` (per-round mechanics). The loop adds:
+1. Initial review request via GraphQL (REST is blocked for the Copilot bot).
+2. Background poll for the next Copilot review to be submitted.
+3. Push between rounds (vs. the single-round skill which never pushes).
+4. Termination condition.
+
+## Dynamic context
+
+```!
+git branch --show-current
+```
+```!
+gh pr view --json number,title,url,headRefName --jq '"#\(.number) \(.title) \(.url) [\(.headRefName)]"' 2>/dev/null || echo "no PR found for current branch"
+```
+
+## Preconditions
+
+- Current branch has an open PR. (If not, surface this and stop.)
+- Local working tree is clean *or* contains only the changes this loop will commit.
+- Copilot bot is reviewable on this repo. The botId is `BOT_kgDOCnlnWA` on
+  terassyi/tomei. For other repos, derive it via:
+  ```
+  gh api graphql -f query='query { repository(owner:"<owner>", name:"<repo>") { id } }'
+  ```
+  then check the suggested reviewers / existing Copilot reviews for the bot id.
+
+## Step 1: Request the first review
+
+GraphQL `requestReviews` with `botIds`. REST `requested_reviewers` does not
+accept the Copilot bot.
+
+```
+PR_NODE=$(gh api repos/<owner>/<repo>/pulls/<n> --jq '.node_id')
+gh api graphql -f query="mutation { requestReviews(input: {pullRequestId: \"$PR_NODE\", botIds: [\"BOT_kgDOCnlnWA\"], union: true}) { pullRequest { id } } }"
+```
+
+If Copilot has *already* reviewed at HEAD, skip the request and go straight
+to Step 3 — re-requesting on an unchanged HEAD will be a no-op.
+
+## Step 2: Wait for the next review
+
+Run a background poller — do NOT poll synchronously. Use `Bash` with
+`run_in_background: true`:
+
+```
+prev=$(gh api 'repos/<o>/<r>/pulls/<n>/reviews?per_page=100' --jq '[.[] | select(.user.login=="copilot-pull-request-reviewer[bot]")] | length')
+for i in $(seq 1 45); do
+  cur=$(gh api 'repos/<o>/<r>/pulls/<n>/reviews?per_page=100' --jq '[.[] | select(.user.login=="copilot-pull-request-reviewer[bot]")] | length' 2>/dev/null || echo $prev)
+  [ "$cur" -gt "$prev" ] && { echo "new-review-count=$cur"; break; }
+  sleep 20
+done
+gh api 'repos/<o>/<r>/pulls/<n>/reviews?per_page=100' --jq '[.[] | select(.user.login=="copilot-pull-request-reviewer[bot]")] | .[-1] | {id, state, submitted_at}'
+```
+
+**Pagination is mandatory**: always use `?per_page=100` when counting
+reviews. Once total reviews on a PR exceed 30, the default page-1 result
+no longer contains the latest Copilot review, and the count-based poller
+sits silent through the new round. Learned the hard way mid-loop.
+
+You will be auto-notified when the background command exits. Do not Read the
+output file in a sleep loop.
+
+If the poller times out without a new review, surface that to the user and
+ask whether to retry, wait longer, or stop.
+
+## Step 3: Fetch the new review's inline comments
+
+```
+gh api repos/<o>/<r>/pulls/<n>/reviews/<review_id> --jq '{body, state}'
+gh api 'repos/<o>/<r>/pulls/<n>/comments?per_page=100&sort=created&direction=desc' \
+  --jq '[.[] | select(.user.login=="Copilot" and .pull_request_review_id==<review_id>)] | .[] | {id, line, path, body}'
+```
+
+Also read the review `body` — Copilot lists low-confidence/suppressed comments
+there. Those are worth addressing even though they have no thread to resolve;
+otherwise they re-surface next round.
+
+## Step 4: Triage each comment (delegate to /copilot semantics)
+
+For each inline comment:
+- Read the file at the cited line.
+- Decide independently: fix, partial fix, or reply with reasoning.
+- Edit code with the Edit tool. Build + lint + run tests as appropriate.
+- Reply via `gh api .../comments -f body="Fixed. <explanation>" -F in_reply_to=<id>`
+  (use `-F` not `-f` for the integer reply id).
+
+## Step 5: Commit + push
+
+```
+git add <files>
+git commit -m "fix(<scope>): address copilot round-N review comments
+  ...
+  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+git push
+```
+
+Push IS required for this skill — Copilot only re-reviews a new HEAD.
+
+## Step 6: Resolve threads
+
+```
+gh api graphql -f query='query { repository(owner:"<o>", name:"<r>") { pullRequest(number:<n>) { reviewThreads(first:50) { nodes { id isResolved } } } } }' \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false) | .id' \
+  | while read tid; do
+      gh api graphql -f query="mutation { resolveReviewThread(input: {threadId: \"$tid\"}) { thread { isResolved } } }" \
+        --jq '.data.resolveReviewThread.thread.isResolved'
+    done
+```
+
+Only resolve threads for comments addressed in *this* round. Threads from
+older rounds should already be resolved.
+
+## Step 7: Loop or terminate
+
+Termination conditions, in order of priority:
+1. Latest Copilot review has **zero new top-level inline comments** (the
+   review body is the summary-only "Pull request overview" with no inline
+   comments). Stop and report.
+2. Latest Copilot review body explicitly states no further changes needed
+   (e.g. "No comments to add", "Looks good"). Stop and report.
+3. Comments have visibly turned from bugs/correctness to pure docstring
+   nits across 2 consecutive rounds → surface a merge option to the user
+   per `feedback_copilot_review_loop` memory, but do NOT stop without
+   confirmation since the explicit instruction is to loop fully-auto.
+
+Otherwise: re-request review (Step 1's GraphQL mutation again, on the same
+PR_NODE) and go to Step 2.
+
+## Telemetry per round (echo to user)
+
+Before each round's Step 4, echo a one-line summary so the user can audit:
+- Round number
+- Review id + submitted_at
+- Count of new inline comments
+- Brief categorization (e.g. "5 substantive, 2 doc nits")
+
+After Step 6, echo: "Round N: pushed <sha>, resolved <k> threads, re-requested review."
+
+## Safety
+
+- NEVER run `tomei apply`, `tomei init`, `chezmoi apply`, or `chezmoi init`.
+- NEVER dismiss reviews — only resolve individual threads.
+- NEVER force-push or rewrite history. Each round is a new commit on top of
+  the previous one.
+- Skip resolving a thread if the comment was answered with "No change needed"
+  and the reviewer's concern is not actually addressed — leave it for the user.
+- If a round's reply count is large (>10), prompt the user once before
+  proceeding to push, so they can sanity-check the batch.
+- Evaluate every comment independently. Do not rubber-stamp Copilot.

--- a/e2e/config/system-package-test/manifest.cue
+++ b/e2e/config/system-package-test/manifest.cue
@@ -82,10 +82,11 @@ cliTools: {
 // sha256sum` and the e2e Go const pgdgKeyHashSHA256 updated in lockstep.
 //
 // Validate and plan only read the manifest — they do NOT fetch keyUrl or
-// hit the network. apply (currently declared as Ginkgo Pending via PIt in
-// e2e/system_package_test.go, awaiting gnupg in the runner image) is the
-// only path that fetches the key, verifies the hash, and reaches the
-// suite. The suite below uses the PGDG-specific naming convention
+// hit the network. apply (exercised against the host in the
+// "Apply --system installs SystemPackageRepository (#218)" Ordered
+// Context in e2e/system_package_test.go; gnupg ships in the runner
+// image via e2e/containers/ubuntu/Dockerfile) is the only path that
+// fetches the key, verifies the hash, and reaches the suite. The suite below uses the PGDG-specific naming convention
 // `<codename>-pgdg` (not bare `<codename>`): the PostgreSQL project ships
 // distributions under e.g. `noble-pgdg`, `jammy-pgdg`, `bookworm-pgdg`.
 // Using a bare suite name would 404 the moment apply lands.

--- a/e2e/containers/ubuntu/Dockerfile
+++ b/e2e/containers/ubuntu/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     file \
     gcc \
+    gnupg \
     libc6-dev \
     sudo
 

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -14,6 +14,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/terassyi/tomei/internal/state"
 )
 
 // pgdgSuite is the second half of the rotation contract: the suite name
@@ -254,49 +256,13 @@ func systemPackageTests() {
 				"plan output must show SystemPackageRepository/pgdg with the [+ install] marker on the same line; got:\n%s", out)
 		})
 
-		// The three apply / idempotency / removal arms are PENDING rather
-		// than Skip()'d-with-a-message. Ginkgo's PIt reports the spec as
-		// "P" (pending, distinct from "S" skipped) in the suite summary,
-		// preserves the Label() for `ginkgo --label-filter` opt-in, and
-		// — crucially — distinguishes a stub-pending-implementation from
-		// an environment-gated Skip (a Skip() reading "needs gnupg" would
-		// silently disappear if the next contributor adds gnupg but
-		// forgets to flip the spec, while a PIt body remains a no-op
-		// until promoted to It). The follow-up PR will flip PIt -> It
-		// once gnupg lands in the runner image and the assertions are
-		// wired against real host state.
-		PIt("apply --system installs the repository on the host",
-			Label("needs-gnupg", "needs-network", "pending-197-followup"),
-			func() {
-				// Pending follow-up. When flipped to It, this spec must:
-				//   - assert /usr/share/keyrings/pgdg.gpg is present with
-				//     mode 0644 root:root,
-				//   - assert /etc/apt/sources.list.d/pgdg.list is present
-				//     and contains signed-by=/usr/share/keyrings/pgdg.gpg,
-				//     the spec URL, and "noble-pgdg main",
-				//   - assert ~/.local/share/tomei/system/state.json contains
-				//     a systemPackageRepositories.pgdg entry pinning
-				//     pgdgKeyHashSHA256.
-				_ = pgdgKeyHashSHA256
-			})
-
-		PIt("apply --system twice is idempotent",
-			Label("needs-gnupg", "needs-network", "pending-197-followup"),
-			func() {
-				// Pending follow-up. When flipped to It, run apply twice
-				// and assert the second `tomei plan --system` between runs
-				// shows no changes for SystemPackageRepository/pgdg.
-			})
-
-		PIt("removing the repo from the manifest cleans up files and state",
-			Label("needs-gnupg", "needs-network", "pending-197-followup"),
-			func() {
-				// Pending follow-up. When flipped to It, write a sibling
-				// manifest without pgdgRepo, re-apply, and assert that
-				//   - /usr/share/keyrings/pgdg.gpg is gone,
-				//   - /etc/apt/sources.list.d/pgdg.list is gone, and
-				//   - state.json no longer mentions pgdg.
-			})
+		// Apply / idempotency / removal / retain-without-flag specs for
+		// SystemPackageRepository live in the sibling Ordered Context
+		// `Apply --system installs SystemPackageRepository (#218)` below.
+		// They are host-mutating (touch /usr/share/keyrings/ and
+		// /etc/apt/sources.list.d/) so they gate on TOMEI_E2E_CONTAINER /
+		// TOMEI_E2E_NATIVE via skipIfNotLinux, whereas the validate/plan
+		// specs in this Context run unconditionally.
 	})
 
 	// SystemPackageSet apply coverage (#200). Mutates host packages, so
@@ -841,6 +807,117 @@ cliTools: {
 EOF`, dir, strings.Join(quoted, ", "), fixtureSugarPkg)
 		_, err = testExec.ExecBash(content)
 		Expect(err).NotTo(HaveOccurred(), "writing manifest content for %s failed", dir)
+	}
+
+	// stateJSONPath returns the literal path string with a leading `~`. Shell
+	// `~` expansion happens in ExecBash (the user's $HOME inside the container
+	// may differ from the host test process's $HOME, so locally os.ExpandEnv
+	// would compute the wrong path). Callers must pass it to a shell builtin
+	// that supports tilde expansion (cat, ls, sha256sum, test, etc.).
+	const stateJSONPath = "~/.local/share/tomei/system/state.json"
+
+	// fileSha256IfExists returns the sha256 hex digest of the file at path,
+	// or "" if the file does not exist (or any cleanup-step error occurs).
+	// Used by the #218 Ordered Context's BeforeAll to capture pre-test state
+	// so AfterAll can distinguish "file we created" from "file that already
+	// existed on the host" and only rm -f the former.
+	fileSha256IfExists := func(path string) string {
+		// `[ -e ... ]` first: missing-file returns "" (not an error). When
+		// the file IS present we need `set -o pipefail` so a sha256sum
+		// failure (permission denied, sha256sum binary missing) doesn't
+		// get masked by awk's exit 0. `set -e` then aborts on any
+		// non-zero in the pipeline and the caller's `if err` branch hits.
+		// stderr is allowed through so the failure surfaces in test logs.
+		out, err := testExec.ExecBash(fmt.Sprintf(
+			"set -euo pipefail; if [ -e %[1]s ]; then sha256sum -- %[1]s | awk '{print $1}'; fi", path))
+		if err != nil {
+			return ""
+		}
+		return strings.TrimSpace(out)
+	}
+
+	// resetSystemState writes a minimal valid empty SystemState to the
+	// system state.json. Used by Ordered Contexts that need a clean slate
+	// without doing a full `tomei init --force` (which would also touch the
+	// user state.json owned by other suites).
+	resetSystemState := func() {
+		_, err := testExec.ExecBash(
+			`mkdir -p ~/.local/share/tomei/system && echo '{"version":"1","systemInstallers":{},"systemPackageRepositories":{},"systemPackages":{}}' > ` + stateJSONPath)
+		Expect(err).NotTo(HaveOccurred(), "resetSystemState: failed to overwrite %s", stateJSONPath)
+	}
+
+	// writeSystemPackageRepositoryManifest writes a /tmp scratch manifest
+	// containing the canonical apt SystemInstaller and, when withRepo=true,
+	// the pgdgRepo SystemPackageRepository (matching the keyHash + suite
+	// pinned in the rotation-contract consts). withRepo=false emits the
+	// installer only — used by the removal and retain-without-flag specs.
+	//
+	// Mirrors writeSystemPackageManifest's two-phase TOCTOU-safe setup:
+	// claim ownership via marker file, record in scratchDirs, then write
+	// content. Validates dir against systemPackageTestDirRE.
+	writeSystemPackageRepositoryManifest := func(dir string, withRepo bool) {
+		Expect(systemPackageTestDirRE.MatchString(dir)).To(BeTrue(),
+			"dir %q does not match the absolute-path allowlist; only static /tmp paths are accepted by this helper", dir)
+		claim := fmt.Sprintf(`set -euo pipefail
+if [ -e %[1]s ] && [ ! -f %[1]s/.tomei-e2e-system-package-test ]; then
+	echo "refusing to remove %[1]s: directory exists but lacks the .tomei-e2e-system-package-test ownership marker — another process may own this path" >&2
+	exit 1
+fi
+rm -rf %[1]s
+mkdir -p %[1]s/cue.mod
+touch %[1]s/.tomei-e2e-system-package-test
+`, dir)
+		_, err := testExec.ExecBash(claim)
+		Expect(err).NotTo(HaveOccurred(), "claiming scratch dir %s failed", dir)
+		scratchDirs[strings.TrimRight(dir, "/")] = true
+
+		repoBlock := ""
+		if withRepo {
+			repoBlock = fmt.Sprintf(`
+pgdgRepo: {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "SystemPackageRepository"
+	metadata: name: "pgdg"
+	spec: {
+		installerRef: "apt"
+		apt: {
+			url:     "https://apt.postgresql.org/pub/repos/apt"
+			keyUrl:  "https://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc"
+			keyHash: "%[1]s"
+			suite:   "%[2]s"
+			components: ["main"]
+		}
+	}
+}
+`, pgdgKeyHashSHA256, pgdgSuite)
+		}
+
+		content := fmt.Sprintf(`set -euo pipefail
+cat > %[1]s/cue.mod/module.cue <<'EOF'
+module: "tomei.local@v0"
+language: version: "v0.9.0"
+EOF
+cat > %[1]s/manifest.cue <<'EOF'
+package tomei
+
+apt: {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "SystemInstaller"
+	metadata: name: "apt"
+	spec: {
+		pattern:    "delegation"
+		privileged: true
+		commands: {
+			install: {command: "sudo apt-get install -y"}
+			remove:  {command: "sudo apt-get remove -y"}
+			check:   {command: "dpkg -s"}
+		}
+	}
+}
+%[2]s
+EOF`, dir, repoBlock)
+		_, err = testExec.ExecBash(content)
+		Expect(err).NotTo(HaveOccurred(), "writing repository manifest content for %s failed", dir)
 	}
 
 	Context("Apply --system mutates host packages (#200)", func() {
@@ -1575,5 +1652,285 @@ EOF`, dir, strings.Join(quoted, ", "), fixtureSugarPkg)
 					"idempotent re-apply of the removal manifest must not rewrite state.json")
 			})
 		})
+	})
+
+	// SystemPackageRepository apply coverage (#218). Sibling to #200 above;
+	// mutates host state (/usr/share/keyrings/pgdg.gpg + /etc/apt/sources.list.d/pgdg.list)
+	// and reaches apt.postgresql.org on apply, so gated to linux + opt-in
+	// e2e (TOMEI_E2E_CONTAINER / TOMEI_E2E_NATIVE) via skipIfNotLinux.
+	//
+	// Spec ordering under Ordered Context is cumulative:
+	//   1. install         — writes pgdg files + state.json entry
+	//   2. idempotency     — depends on spec 1's mutation
+	//   3. retain-without-flag (#169 scenario 7) — depends on spec 1's mutation
+	//   4. removal         — tears down what spec 1 built
+	//
+	// AfterAll restores only paths it created (BeforeAll snapshots
+	// pre-existing keyring/sources.list to avoid clobbering a host that
+	// had PGDG installed before this suite ran).
+	Context("Apply --system installs SystemPackageRepository (#218)", Ordered, func() {
+		const (
+			pgdgKeyringPath = "/usr/share/keyrings/pgdg.gpg"
+			pgdgSourcePath  = "/etc/apt/sources.list.d/pgdg.list"
+		)
+
+		var (
+			repoCfgPath           string // manifest WITH pgdgRepo (specs 1 & 2)
+			installerOnlyCfgPath  string // manifest WITHOUT pgdgRepo (specs 3 & 4)
+			pgdgPreflightComplete bool   // gate for AfterAll: BeforeAll ran far enough to need cleanup
+			pgdgMutationStarted   bool   // gate for AfterAll: spec 1 actually invoked apply --system
+			preTestKeyringHashes  map[string]string
+		)
+
+		// readState parses ~/.local/share/tomei/system/state.json via shell
+		// cat (state.json lives inside the container, not on the host where
+		// the Go test process runs — os.ReadFile would fail).
+		readState := func() state.SystemState {
+			out, err := testExec.ExecBash("cat -- " + stateJSONPath)
+			Expect(err).NotTo(HaveOccurred(), "reading %s failed: %s", stateJSONPath, out)
+			var st state.SystemState
+			Expect(json.Unmarshal([]byte(out), &st)).To(Succeed(),
+				"state.json is not valid JSON; contents:\n%s", out)
+			return st
+		}
+
+		// zeroTimestamps strips the per-apply UpdatedAt field so the
+		// idempotency spec can compare structural equality. The map value
+		// type is `*resource.SystemPackageRepositoryState` (pointer), so
+		// direct mutation suffices — no reassignment to the map is needed.
+		zeroTimestamps := func(s *state.SystemState) {
+			for _, v := range s.SystemPackageRepositories {
+				v.UpdatedAt = time.Time{}
+			}
+		}
+
+		BeforeAll(func() {
+			skipIfNotLinux()
+
+			// NOPASSWD probe — same rationale as the #200 BeforeAll.
+			_, sudoErr := testExec.ExecBash("sudo -k && sudo -n true 2>&1")
+			Expect(sudoErr).NotTo(HaveOccurred(),
+				"non-interactive sudo (NOPASSWD) is required: apply --system invokes apt under sudo")
+
+			// `tomei init --force` is idempotent across Contexts.
+			initOut, initErr := testExec.Exec("tomei", "init", "--yes", "--force")
+			Expect(initErr).NotTo(HaveOccurred(), "tomei init failed before preflight: %s", initOut)
+
+			// Gate the AfterAll cleanup ASAP — partial-failure paths past
+			// this point still need the cleanup branch.
+			pgdgPreflightComplete = true
+
+			resetSystemState()
+
+			// Capture pre-existing host state. If pgdg was already
+			// installed (developer machine, container reuse), we leave
+			// those files alone on AfterAll and only rm the ones we
+			// created. fileSha256IfExists returns "" for missing files.
+			preTestKeyringHashes = map[string]string{
+				pgdgKeyringPath: fileSha256IfExists(pgdgKeyringPath),
+				pgdgSourcePath:  fileSha256IfExists(pgdgSourcePath),
+			}
+
+			scratchSuffix := fmt.Sprintf("%d-%d", os.Getpid(), time.Now().UnixNano())
+			repoCfgPath = "/tmp/tomei-system-package-repository-" + scratchSuffix + "/"
+			installerOnlyCfgPath = "/tmp/tomei-system-package-repository-removal-" + scratchSuffix + "/"
+			writeSystemPackageRepositoryManifest(repoCfgPath, true)
+			writeSystemPackageRepositoryManifest(installerOnlyCfgPath, false)
+		})
+
+		AfterAll(func() {
+			// pgdgMutationStarted gates the host cleanup — if no spec ever
+			// invoked apply --system, the keyring/sources.list files were
+			// never created by this suite and the rm -f loop must not run.
+			if !pgdgPreflightComplete || !pgdgMutationStarted {
+				return
+			}
+			removedAny := false
+			for path, preHash := range preTestKeyringHashes {
+				if preHash == "" {
+					// Best-effort: tolerate non-zero exits so cleanup
+					// failures never mask the spec-failure that surfaced
+					// the real bug.
+					_, _ = testExec.ExecBash("sudo -n rm -f -- " + path)
+					removedAny = true
+				}
+			}
+			// If we touched apt sources, flush the apt cache so subsequent
+			// apt operations in the same container don't 404 trying to
+			// fetch from the now-removed pgdg source. Best-effort: failure
+			// here would only manifest as a confusing apt error later, not
+			// as a masked test-failure now. apt-get update uses APT::Lock
+			// (not DPkg::Lock), so no Lock::Timeout override is meaningful.
+			if removedAny {
+				_, _ = testExec.ExecBash("sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get update -y 2>&1 || true")
+			}
+			resetSystemState()
+		})
+
+		It("apply --system installs the repository on the host",
+			Label("needs-gnupg", "needs-network"), func() {
+				// Irreversible gate: once set, the AfterAll cleanup (L1745)
+				// is mandatory because some host mutation MAY have already
+				// happened, even if ExecApply below returns non-zero. Best-
+				// effort rm -f means partial cleanup never cascades.
+				pgdgMutationStarted = true
+				out, err := ExecApply(testExec, "--system", repoCfgPath)
+				Expect(err).NotTo(HaveOccurred(), "apply --system failed; output:\n%s", out)
+				Expect(out).NotTo(ContainSubstring("system resource apply failed"),
+					"apply --system surfaced a system-engine error as a warning; got:\n%s", out)
+
+				By("keyring + sources.list files exist with correct mode/ownership", func() {
+					_, err := testExec.ExecBash("test -f " + pgdgKeyringPath)
+					Expect(err).NotTo(HaveOccurred(), "missing %s", pgdgKeyringPath)
+					_, err = testExec.ExecBash("test -f " + pgdgSourcePath)
+					Expect(err).NotTo(HaveOccurred(), "missing %s", pgdgSourcePath)
+					_, err = testExec.ExecBash("test -s " + pgdgKeyringPath)
+					Expect(err).NotTo(HaveOccurred(), "%s is empty", pgdgKeyringPath)
+					modeOut, err := testExec.ExecBash("stat -c '%a %U:%G' -- " + pgdgKeyringPath)
+					Expect(err).NotTo(HaveOccurred(), "stat on %s failed", pgdgKeyringPath)
+					Expect(modeOut).To(ContainSubstring("644 root:root"),
+						"keyring mode/ownership mismatch; stat: %s", strings.TrimSpace(modeOut))
+					// Validate keyring is a real GPG keyring. Uses --with-colons
+					// machine-readable output (stable across gpg 2.x versions,
+					// no locale dependency) so `^pub:` matches predictably.
+					// Plain `--list-keys` text format varies (`pub `, `pub:`,
+					// indented variants) across gpg versions.
+					//
+					// stderr is merged into stdout (2>&1) rather than dropped
+					// to /dev/null so a real gpg failure (corrupt keyring,
+					// missing agent socket) surfaces in test logs instead of
+					// being silenced — pipefail propagates the non-zero exit.
+					gpgOut, err := testExec.ExecBash(
+						"set -o pipefail; gpg --no-default-keyring --keyring " + pgdgKeyringPath + " --with-colons --list-keys 2>&1")
+					Expect(err).NotTo(HaveOccurred(),
+						"gpg --list-keys on %s failed; output:\n%s", pgdgKeyringPath, gpgOut)
+					Expect(gpgOut).To(MatchRegexp(`(?m)^pub:`),
+						"%s does not list any public key via gpg --with-colons; output:\n%s", pgdgKeyringPath, gpgOut)
+					// A corrupt dearmor that produces a keyring with a pub
+					// record but no associated user-id is hard to surface
+					// downstream — apt-get update would fetch it and only
+					// complain at first package install with a vague
+					// "NO_PUBKEY" message. Pin the uid presence here.
+					Expect(gpgOut).To(MatchRegexp(`(?m)^uid:`),
+						"%s lists pub but no uid — keyring appears corrupt; output:\n%s", pgdgKeyringPath, gpgOut)
+				})
+
+				By("sources.list references the keyring + suite + url", func() {
+					src, err := testExec.ExecBash("cat -- " + pgdgSourcePath)
+					Expect(err).NotTo(HaveOccurred(), "cat %s failed", pgdgSourcePath)
+					Expect(src).To(ContainSubstring("signed-by=" + pgdgKeyringPath))
+					Expect(src).To(ContainSubstring("https://apt.postgresql.org/pub/repos/apt"))
+					Expect(src).To(ContainSubstring(pgdgSuite + " main"))
+				})
+
+				By("state.json records the repository", func() {
+					st := readState()
+					Expect(st.SystemPackageRepositories).To(HaveKey("pgdg"))
+					pgdg := st.SystemPackageRepositories["pgdg"]
+					Expect(pgdg.InstallerRef).To(Equal("apt"))
+					Expect(pgdg.Apt).NotTo(BeNil(), "state entry missing Apt details")
+					Expect(pgdg.Apt.KeyHash).To(Equal(pgdgKeyHashSHA256))
+					Expect(pgdg.Apt.Suite).To(Equal(pgdgSuite))
+					// InstalledFiles order is deterministic per
+					// internal/installer/apt/repository.go — keyring first,
+					// sources.list second. The Remove path uses a separate
+					// orderedPaths list, in reverse.
+					Expect(pgdg.InstalledFiles).To(Equal([]string{pgdgKeyringPath, pgdgSourcePath}))
+					Expect(pgdg.UpdatedAt).To(BeTemporally("~", time.Now(), 60*time.Second),
+						"UpdatedAt must be set to apply time, not zero or stale")
+				})
+			})
+
+		// Known limitation: a transient 5xx from apt.postgresql.org during
+		// the second apply causes apt-get update inside the Install path to
+		// fail, surfaced via the "system resource apply failed" warning
+		// guard below. That is a network-flake failure mode, not a code
+		// regression — `needs-network` label allows opt-out filtering.
+		It("apply --system twice is idempotent",
+			Label("needs-gnupg", "needs-network"), func() {
+				before := readState()
+				zeroTimestamps(&before)
+
+				out, err := ExecApply(testExec, "--system", repoCfgPath)
+				Expect(err).NotTo(HaveOccurred(), "second apply failed; output:\n%s", out)
+				Expect(out).NotTo(ContainSubstring("system resource apply failed"),
+					"idempotent re-apply surfaced system-engine warning; got:\n%s", out)
+
+				after := readState()
+				zeroTimestamps(&after)
+				Expect(after).To(Equal(before),
+					"idempotent re-apply mutated state.json beyond UpdatedAt")
+
+				// Explicit slice-order pin: structural Equal above already
+				// covers this transitively, but a future regression that
+				// shuffles InstalledFiles non-deterministically (e.g. via
+				// map iteration) is easier to diagnose when the failure
+				// names the slice rather than reading as "state differs".
+				// HaveKey guard prevents a nil-pointer deref if a separate
+				// regression made spec 1's install silently no-op.
+				Expect(after.SystemPackageRepositories).To(HaveKey("pgdg"))
+				Expect(after.SystemPackageRepositories["pgdg"].InstalledFiles).To(
+					Equal([]string{pgdgKeyringPath, pgdgSourcePath}),
+					"InstalledFiles order regressed after idempotent re-apply")
+
+				// Second layer of idempotency: a fresh plan must show no
+				// pending changes. Catches the case where state-write was
+				// correctly skipped but the engine still queued install
+				// actions that just no-op'd.
+				planOut, err := testExec.Exec("tomei", "plan", "--system", repoCfgPath)
+				Expect(err).NotTo(HaveOccurred(), "plan --system failed: %s", planOut)
+				Expect(planOut).To(MatchRegexp(`(?m)^Summary:\s+0 to install,\s+0 to upgrade,\s+0 to reinstall,\s+0 to remove`),
+					"post-apply plan must show zero pending actions; got:\n%s", planOut)
+			})
+
+		It("apply WITHOUT --system skips system resources and retains state (#169 scenario 7)",
+			Label("needs-gnupg"), func() {
+				// Spec intent: even though installerOnlyCfgPath drops
+				// pgdgRepo from the manifest, omitting --system makes
+				// apply ignore system resources entirely — state.json and
+				// on-disk files must stay untouched.
+				//
+				// Scope: filesystem drift between applies (manual keyring
+				// deletion by a user) is intentionally out of scope here
+				// and deferred to a future audit feature.
+				before := readState()
+				Expect(before.SystemPackageRepositories).To(HaveKey("pgdg"))
+
+				out, err := ExecApply(testExec, installerOnlyCfgPath) // NOTE: no --system
+				Expect(err).NotTo(HaveOccurred(), "apply (no --system) failed: %s", out)
+				Expect(out).NotTo(ContainSubstring("system resource apply failed"))
+				// User-visible warning from cmd/tomei/apply.go.
+				// NOTE: this exact string is UX-coupling — if the wording
+				// in apply.go changes, update both in lockstep.
+				Expect(out).To(ContainSubstring("system resource(s) skipped. Use 'tomei apply --system' to manage"),
+					"expected the skip warning to be printed; got:\n%s", out)
+
+				// Files and state must be untouched.
+				_, err = testExec.ExecBash("test -f " + pgdgKeyringPath)
+				Expect(err).NotTo(HaveOccurred(), "keyring missing after no-flag apply")
+				_, err = testExec.ExecBash("test -f " + pgdgSourcePath)
+				Expect(err).NotTo(HaveOccurred(), "sources.list missing after no-flag apply")
+				after := readState()
+				Expect(after.SystemPackageRepositories).To(HaveKey("pgdg"))
+			})
+
+		It("removing the repo from the manifest cleans up files and state",
+			Label("needs-gnupg"), func() {
+				// Spec intent: same installerOnlyCfgPath manifest as the
+				// scenario-7 spec above, but WITH --system this time. The
+				// engine reconciler treats pgdg missing-from-manifest +
+				// present-in-state as an implicit remove signal.
+				out, err := ExecApply(testExec, "--system", installerOnlyCfgPath)
+				Expect(err).NotTo(HaveOccurred(), "removal apply failed: %s", out)
+				Expect(out).NotTo(ContainSubstring("system resource apply failed"))
+
+				for _, p := range []string{pgdgKeyringPath, pgdgSourcePath} {
+					_, err := testExec.ExecBash("test -f " + p)
+					Expect(err).To(HaveOccurred(), "%s should have been removed", p)
+				}
+				st := readState()
+				Expect(st.SystemPackageRepositories).NotTo(HaveKey("pgdg"),
+					"state.json must no longer reference pgdg after removal apply")
+			})
 	})
 }

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -809,24 +809,41 @@ EOF`, dir, strings.Join(quoted, ", "), fixtureSugarPkg)
 	// Used by the #218 Ordered Context's BeforeAll to capture pre-test state
 	// so AfterAll can distinguish "file we created" from "file that already
 	// existed on the host" and only rm -f the former.
-	// Returns (hash, exists). hash is empty when the path is absent;
-	// callers must check `exists` to distinguish "absent" from "present
-	// but unhashable" — the latter aborts the test rather than silently
-	// returning "" and letting the AfterAll treat a transient sha256sum
-	// failure as permission to rm a pre-existing host file.
+	// Returns (hash, exists). exists is true iff *any* filesystem entry
+	// is present at the path — regular file, directory, or symlink
+	// (dangling or otherwise). Callers must check `exists` to decide
+	// whether they are looking at an existing host artifact; in that
+	// case `hash` is the sha256 of the file (for symlinks: of the
+	// target), or "" if the path is not a hashable regular file (e.g.
+	// a dangling symlink, a directory). Hashing/probing errors are
+	// surfaced via Expect rather than silently collapsing to "absent",
+	// so a transient sha256sum or permission failure on a pre-existing
+	// path cannot make the AfterAll mistake that path for one we wrote.
 	fileSha256IfExists := func(path string) (string, bool) {
-		// Stage 1: probe existence. `test -e` exits 0/1 cleanly; any other
-		// exit code (e.g. permission error on the parent dir) is fatal.
+		// Stage 1: existence probe. `-e` follows symlinks (and so
+		// returns false for a dangling symlink); pair with `-L` so a
+		// dangling symlink at this path is still classified as
+		// "exists" — BeforeAll uses this helper to decide whether it's
+		// safe to overwrite the path, and a leftover dangling symlink
+		// at /usr/share/keyrings/pgdg.gpg from a previous botched
+		// install must NOT be treated as a clean slate.
 		existsOut, existsErr := testExec.ExecBash(fmt.Sprintf(
-			"if [ -e %[1]s ]; then echo yes; else echo no; fi", path))
+			"if [ -e %[1]s ] || [ -L %[1]s ]; then echo yes; else echo no; fi", path))
 		Expect(existsErr).NotTo(HaveOccurred(),
 			"probing existence of %s failed: %s", path, existsOut)
 		if strings.TrimSpace(existsOut) == "no" {
 			return "", false
 		}
-		// Stage 2: hash. `set -o pipefail` so a sha256sum failure
-		// surfaces past awk; Expect aborts the test rather than masking
-		// the failure as "absent".
+		// Stage 2: hash. Only hash regular files (or symlinks resolving
+		// to one); dangling symlinks / directories return ("", true)
+		// so callers can still see the path exists without us
+		// fabricating a hash. Hashing failures on a regular file are
+		// fatal — see helper docstring.
+		regOut, _ := testExec.ExecBash(fmt.Sprintf(
+			"if [ -f %[1]s ]; then echo yes; else echo no; fi", path))
+		if strings.TrimSpace(regOut) != "yes" {
+			return "", true
+		}
 		out, err := testExec.ExecBash(fmt.Sprintf(
 			"set -euo pipefail; sha256sum -- %[1]s | awk '{print $1}'", path))
 		Expect(err).NotTo(HaveOccurred(),
@@ -1663,9 +1680,15 @@ EOF`, dir, repoBlock)
 	//   3. retain-without-flag (#169 scenario 7) — depends on spec 1's mutation
 	//   4. removal         — tears down what spec 1 built
 	//
-	// AfterAll restores only paths it created (BeforeAll snapshots
-	// pre-existing keyring/sources.list to avoid clobbering a host that
-	// had PGDG installed before this suite ran).
+	// BeforeAll Skips the Context if either pgdgKeyringPath or
+	// pgdgSourcePath already exists on the host (including as a
+	// dangling symlink) — see the fileSha256IfExists guard. With that
+	// gate in place, any file present at AfterAll time was written by
+	// this Context and is unconditionally safe to remove; no restore
+	// step is needed. TOMEI_E2E_NATIVE_SKIP_CLEANUP=true bypasses the
+	// AfterAll cleanup to preserve host state for inspection after a
+	// failed native opt-in run (same semantics as the sibling #200
+	// Context).
 	Context("Apply --system installs SystemPackageRepository (#218)", Ordered, func() {
 		const (
 			pgdgKeyringPath = "/usr/share/keyrings/pgdg.gpg"
@@ -1729,13 +1752,13 @@ EOF`, dir, repoBlock)
 				"non-interactive sudo (NOPASSWD) is required: apply --system invokes apt under sudo")
 
 			// Refuse to run on a host that already has pgdg configured.
-			// Hashing-with-restore would let us coexist with a developer
-			// machine that uses PGDG, but spec 1's install would still
-			// overwrite the live keyring/sources.list mid-run, and any
-			// failure between overwrite and restore would leave the host
-			// in a worse state than skipping. The container e2e runner
-			// always starts from a clean image, so this gate only fires
-			// in native opt-in runs.
+			// Skipping is simpler and safer than snapshot-and-restore:
+			// spec 1's install overwrites the live keyring/sources.list,
+			// so any failure between overwrite and restore would leave
+			// the host worse off than just skipping. The container e2e
+			// runner always starts from a clean image, so this gate only
+			// fires on native opt-in runs (or a reused container with
+			// leftover pgdg files from a botched previous run).
 			for _, p := range []string{pgdgKeyringPath, pgdgSourcePath} {
 				if _, exists := fileSha256IfExists(p); exists {
 					Skip(fmt.Sprintf("pre-existing %s on host: refusing to clobber a real PGDG setup (re-run this Context in the container e2e runner instead)", p))
@@ -1755,16 +1778,28 @@ EOF`, dir, repoBlock)
 			scratchSuffix := fmt.Sprintf("%d-%d", os.Getpid(), time.Now().UnixNano())
 			repoCfgPath = "/tmp/tomei-system-package-repository-" + scratchSuffix + "/"
 			installerOnlyCfgPath = "/tmp/tomei-system-package-repository-removal-" + scratchSuffix + "/"
+			// Append to repoScratchDirs immediately after each helper
+			// returns, NOT in one shot after both. If the second helper
+			// aborts BeforeAll (Expect inside), the AfterAll still needs
+			// to know about the first dir we already created.
 			writeSystemPackageRepositoryManifest(repoCfgPath, true)
+			repoScratchDirs = append(repoScratchDirs, strings.TrimRight(repoCfgPath, "/"))
 			writeSystemPackageRepositoryManifest(installerOnlyCfgPath, false)
-			repoScratchDirs = []string{
-				strings.TrimRight(repoCfgPath, "/"),
-				strings.TrimRight(installerOnlyCfgPath, "/"),
-			}
+			repoScratchDirs = append(repoScratchDirs, strings.TrimRight(installerOnlyCfgPath, "/"))
 		})
 
 		AfterAll(func() {
 			if !pgdgPreflightComplete {
+				return
+			}
+			// Honor the same native-mode escape hatch the sibling #200
+			// AfterAll uses (see L939-944): a native opt-in run that
+			// sets TOMEI_E2E_NATIVE_SKIP_CLEANUP=true to inspect host
+			// state after a failure must apply consistently here too,
+			// or this Context would silently re-clean what the sibling
+			// preserved.
+			if os.Getenv("TOMEI_E2E_NATIVE_SKIP_CLEANUP") == "true" {
+				fmt.Fprintln(GinkgoWriter, "TOMEI_E2E_NATIVE_SKIP_CLEANUP=true: skipping #218 PGDG file + /tmp cleanup")
 				return
 			}
 			// Scratch-dir cleanup: this Context's helper records its
@@ -1831,9 +1866,16 @@ EOF`, dir, repoBlock)
 					Expect(err).NotTo(HaveOccurred(), "missing %s", pgdgSourcePath)
 					_, err = testExec.ExecBash("test -s " + pgdgKeyringPath)
 					Expect(err).NotTo(HaveOccurred(), "%s is empty", pgdgKeyringPath)
+					// Exact-equality (not ContainSubstring): GNU stat
+					// renders the special bits as a leading digit
+					// (`1644 root:root` for sticky, `2644 root:root`
+					// for setgid). ContainSubstring("644 root:root")
+					// would pass for those, but the 0644 contract
+					// (install -D -m 0644 -o root -g root) means a
+					// regression that flips a special bit must fail.
 					modeOut, err := testExec.ExecBash("stat -c '%a %U:%G' -- " + pgdgKeyringPath)
 					Expect(err).NotTo(HaveOccurred(), "stat on %s failed", pgdgKeyringPath)
-					Expect(modeOut).To(ContainSubstring("644 root:root"),
+					Expect(strings.TrimSpace(modeOut)).To(Equal("644 root:root"),
 						"keyring mode/ownership mismatch; stat: %s", strings.TrimSpace(modeOut))
 					// sources.list is also installed via `install -D -m
 					// 0644 -o root -g root` (see
@@ -1842,7 +1884,7 @@ EOF`, dir, repoBlock)
 					// for the sources.list path is caught.
 					srcModeOut, err := testExec.ExecBash("stat -c '%a %U:%G' -- " + pgdgSourcePath)
 					Expect(err).NotTo(HaveOccurred(), "stat on %s failed", pgdgSourcePath)
-					Expect(srcModeOut).To(ContainSubstring("644 root:root"),
+					Expect(strings.TrimSpace(srcModeOut)).To(Equal("644 root:root"),
 						"sources.list mode/ownership mismatch; stat: %s", strings.TrimSpace(srcModeOut))
 					// Validate keyring is a real GPG keyring. Uses --with-colons
 					// machine-readable output (stable across gpg 2.x versions,
@@ -2011,12 +2053,14 @@ EOF`, dir, repoBlock)
 				Expect(out).NotTo(ContainSubstring("system resource apply failed"))
 
 				for _, p := range []string{pgdgKeyringPath, pgdgSourcePath} {
-					// `test ! -e` (not `! test -f`): the removal
-					// contract is total non-existence, so a leftover
-					// directory or dangling symlink at this path must
-					// also fail the assertion. `test -f` would pass for
-					// either of those failure modes.
-					_, err := testExec.ExecBash("test ! -e " + p)
+					// Removal contract: NO filesystem entry of any kind
+					// at this path. Both `-e` and `-L` are required —
+					// `-e` follows symlinks (so a dangling symlink
+					// passes `! -e`), and `-L` checks the link itself
+					// without following. Pairing them rejects regular
+					// files, directories, dangling symlinks, and live
+					// symlinks alike.
+					_, err := testExec.ExecBash("test ! -e " + p + " && test ! -L " + p)
 					Expect(err).NotTo(HaveOccurred(), "%s should have been removed (file, directory, or symlink left behind)", p)
 				}
 				st := readState()

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -1992,8 +1992,8 @@ EOF`, dir, repoBlock)
 					src, err := testExec.ExecBash("cat -- " + pgdgSourcePath)
 					Expect(err).NotTo(HaveOccurred(), "cat %s failed", pgdgSourcePath)
 					Expect(src).To(ContainSubstring("signed-by=" + pgdgKeyringPath))
-					Expect(src).To(ContainSubstring("https://apt.postgresql.org/pub/repos/apt"))
-					Expect(src).To(ContainSubstring(pgdgSuite + " main"))
+					Expect(src).To(ContainSubstring(pgdgURL))
+					Expect(src).To(ContainSubstring(pgdgSuite + " " + pgdgComponent))
 				})
 
 				By("state.json records the repository", func() {
@@ -2060,19 +2060,25 @@ EOF`, dir, repoBlock)
 				// both legs to actually catch an unnecessary
 				// re-install.
 				preApplyFileHashes := map[string]string{}
-				preApplyFileMtimes := map[string]string{}
+				preApplyFileIdents := map[string]string{}
 				for _, p := range []string{pgdgKeyringPath, pgdgSourcePath} {
 					h, exists := fileSha256IfExists(p)
 					Expect(exists).To(BeTrue(), "pre-apply: %s missing", p)
 					preApplyFileHashes[p] = h
-					// `stat -c %Y` is mtime in seconds since epoch.
-					// `%Z` (ctime) would also catch ownership/mode
-					// rewrites, but apply re-running install would
-					// touch mtime regardless of whether it changed
-					// ownership — mtime is sufficient and stable.
-					mtimeOut, err := testExec.ExecBash("stat -c '%Y' -- " + p)
-					Expect(err).NotTo(HaveOccurred(), "pre-apply: stat %Y on %s failed", p)
-					preApplyFileMtimes[p] = strings.TrimSpace(mtimeOut)
+					// Identify the file by inode + full-precision
+					// mtime (`%y` includes nanoseconds). The installer
+					// uses `install -D` which writes to a tmpfile and
+					// renames into place, producing a NEW inode on
+					// every run — so an inode change is a definitive
+					// "install path re-ran" signal even when the
+					// rewrite happens within the same wall-clock
+					// second (whole-second `%Y` would miss that). The
+					// nanosecond mtime is a redundant second leg in
+					// case a filesystem (e.g. tmpfs without strictatime)
+					// somehow recycles inodes.
+					identOut, err := testExec.ExecBash("stat -c '%i|%y' -- " + p)
+					Expect(err).NotTo(HaveOccurred(), "pre-apply: stat on %s failed", p)
+					preApplyFileIdents[p] = strings.TrimSpace(identOut)
 				}
 
 				out, err := ExecApply(testExec, "--system", repoCfgPath)
@@ -2085,10 +2091,10 @@ EOF`, dir, repoBlock)
 					Expect(exists).To(BeTrue(), "post-second-apply: %s missing", p)
 					Expect(h).To(Equal(preApplyFileHashes[p]),
 						"%s contents changed across idempotent re-apply (sha256 mismatch); the install path re-ran when it should have no-op'd", p)
-					mtimeOut, err := testExec.ExecBash("stat -c '%Y' -- " + p)
-					Expect(err).NotTo(HaveOccurred(), "post-apply: stat %Y on %s failed", p)
-					Expect(strings.TrimSpace(mtimeOut)).To(Equal(preApplyFileMtimes[p]),
-						"%s mtime advanced across idempotent re-apply; the install path re-wrote identical bytes when it should have no-op'd", p)
+					identOut, err := testExec.ExecBash("stat -c '%i|%y' -- " + p)
+					Expect(err).NotTo(HaveOccurred(), "post-apply: stat on %s failed", p)
+					Expect(strings.TrimSpace(identOut)).To(Equal(preApplyFileIdents[p]),
+						"%s inode or mtime changed across idempotent re-apply; the install path re-wrote identical bytes (likely via install -D) when it should have no-op'd", p)
 				}
 
 				after := readState()

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -820,24 +820,21 @@ EOF`, dir, strings.Join(quoted, ", "), fixtureSugarPkg)
 
 	// fileSha256IfExists.
 	//
-	// Returns (hash, exists). exists is true iff *any* filesystem entry
-	// is present at the path — regular file, directory, or symlink
-	// (dangling or otherwise). Callers must check `exists` to decide
-	// whether they are looking at an existing host artifact; in that
-	// case `hash` is the sha256 of the file (for symlinks: of the
-	// target), or "" if the path is not a hashable regular file (e.g.
-	// a dangling symlink, a directory). Hashing/probing errors are
-	// surfaced via Expect rather than silently collapsing to "absent",
-	// so a transient sha256sum or permission failure on a pre-existing
-	// path cannot make the AfterAll mistake that path for one we wrote.
+	// Returns (hash, exists) for a file the SUITE itself wrote and
+	// expects to be present. Current use is the post-install snapshot
+	// in the #218 install spec, which captures the just-installed
+	// keyring/sources.list bytes so the no-flag retention spec can
+	// later assert byte-identity. Pre-existing-path safety guards in
+	// BeforeAll use pathExistsAny instead — that path must NEVER hash
+	// a host-owned file. Hashing/probing errors here are surfaced via
+	// Expect (not collapsed to "absent") so a regression in the suite-
+	// owned file is loud rather than silent.
 	fileSha256IfExists := func(path string) (string, bool) {
 		// Stage 1: existence probe. `-e` follows symlinks (and so
 		// returns false for a dangling symlink); pair with `-L` so a
 		// dangling symlink at this path is still classified as
-		// "exists" — BeforeAll uses this helper to decide whether it's
-		// safe to overwrite the path, and a leftover dangling symlink
-		// at /usr/share/keyrings/pgdg.gpg from a previous botched
-		// install must NOT be treated as a clean slate.
+		// "exists" — defensive against an out-of-band tampering of
+		// the suite-owned file between install and snapshot.
 		existsOut, existsErr := testExec.ExecBash(fmt.Sprintf(
 			"if [ -e %[1]s ] || [ -L %[1]s ]; then echo yes; else echo no; fi", path))
 		Expect(existsErr).NotTo(HaveOccurred(),
@@ -1693,10 +1690,10 @@ EOF`, dir, repoBlock)
 	//
 	// BeforeAll Skips the Context if either pgdgKeyringPath or
 	// pgdgSourcePath already exists on the host (including as a
-	// dangling symlink) — see the fileSha256IfExists guard. With that
-	// gate in place, any file present at AfterAll time was written by
-	// this Context and is unconditionally safe to remove; no restore
-	// step is needed. TOMEI_E2E_NATIVE_SKIP_CLEANUP=true bypasses the
+	// dangling symlink) — see the pathExistsAny guard. With that gate
+	// in place, any file present at AfterAll time was written by this
+	// Context and is unconditionally safe to remove; no restore step
+	// is needed. TOMEI_E2E_NATIVE_SKIP_CLEANUP=true bypasses the
 	// AfterAll cleanup to preserve host state for inspection after a
 	// failed native opt-in run (same semantics as the sibling #200
 	// Context).
@@ -1995,10 +1992,41 @@ EOF`, dir, repoBlock)
 				before := readState()
 				zeroTimestamps(&before)
 
+				// PRE-apply plan must already show zero work — this
+				// catches a regression where the second apply WOULD
+				// re-run install (rewriting bytes to the same content)
+				// even though the post-apply structural state-equality
+				// below would still pass. Without this guard, an
+				// unnecessary re-install would only surface as a flaky
+				// network-traffic spike.
+				preplanOut, err := testExec.Exec("tomei", "plan", "--system", repoCfgPath)
+				Expect(err).NotTo(HaveOccurred(), "pre-apply plan failed: %s", preplanOut)
+				Expect(preplanOut).To(MatchRegexp(`(?m)^Summary:\s+0 to install,\s+0 to upgrade,\s+0 to reinstall,\s+0 to remove\s*$`),
+					"pre-second-apply plan must already show zero work; got:\n%s", preplanOut)
+
+				// Byte snapshot of the on-disk files going into the
+				// second apply. After the apply we re-hash and assert
+				// the bytes are identical, so an unnecessary re-write
+				// (same content, new mtime) is still caught even
+				// though state.json structural equality would survive.
+				preApplyFileHashes := map[string]string{}
+				for _, p := range []string{pgdgKeyringPath, pgdgSourcePath} {
+					h, exists := fileSha256IfExists(p)
+					Expect(exists).To(BeTrue(), "pre-apply: %s missing", p)
+					preApplyFileHashes[p] = h
+				}
+
 				out, err := ExecApply(testExec, "--system", repoCfgPath)
 				Expect(err).NotTo(HaveOccurred(), "second apply failed; output:\n%s", out)
 				Expect(out).NotTo(ContainSubstring("system resource apply failed"),
 					"idempotent re-apply surfaced system-engine warning; got:\n%s", out)
+
+				for _, p := range []string{pgdgKeyringPath, pgdgSourcePath} {
+					h, exists := fileSha256IfExists(p)
+					Expect(exists).To(BeTrue(), "post-second-apply: %s missing", p)
+					Expect(h).To(Equal(preApplyFileHashes[p]),
+						"%s contents changed across idempotent re-apply (sha256 mismatch); the install path re-ran when it should have no-op'd", p)
+				}
 
 				after := readState()
 				zeroTimestamps(&after)

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -493,18 +493,13 @@ func systemPackageTests() {
 
 	// installCfgPath / removalCfgPath are sibling manifests under /tmp/
 	// that exercise the SystemPackageSet apply path WITHOUT pgdgRepo.
-	// pgdg's installer needs `gpg --dearmor` and `gnupg` is intentionally
-	// not in the runner image (#197 follow-up will add it together with a
-	// network mock). The canonical fixture at ~/system-package-test/ keeps
-	// pgdgRepo so the prior validate/plan/PIt Contexts continue to assert
-	// against it; the apply Contexts here use their own sibling manifests
-	// to isolate the SystemPackageSet apply path.
-	//
-	// TODO(#197-followup): once gnupg lands in the runner image and PGDG
-	// network access can be mocked, re-align the install/removal heredocs
-	// with the canonical fixture (add pgdgRepo) and either promote the
-	// existing PIts to It or fold the SystemPackageRepository apply
-	// coverage into this Context.
+	// SystemPackageRepository apply now lives in the sibling
+	// "Apply --system installs SystemPackageRepository (#218)" Context
+	// below (gnupg is now installed in the runner image; see
+	// e2e/containers/ubuntu/Dockerfile). Keeping the SystemPackageSet
+	// apply heredocs PGDG-free lets that Context exercise the package-
+	// install path in isolation, without reaching apt.postgresql.org
+	// over the network on every run.
 	// Scratch paths carry a per-process unguessable suffix
 	// (PID + ns timestamp). The earlier fixed paths
 	// (`/tmp/tomei-system-package-install/`, etc.) were predictable
@@ -797,18 +792,34 @@ EOF`, dir, strings.Join(quoted, ", "), fixtureSugarPkg)
 		Expect(err).NotTo(HaveOccurred(), "writing manifest content for %s failed", dir)
 	}
 
-	// stateJSONPath returns the literal path string with a leading `~`. Shell
-	// `~` expansion happens in ExecBash (the user's $HOME inside the container
-	// may differ from the host test process's $HOME, so locally os.ExpandEnv
-	// would compute the wrong path). Callers must pass it to a shell builtin
-	// that supports tilde expansion (cat, ls, sha256sum, test, etc.).
+	// stateJSONPath is the literal path string with a leading `~`.
+	// Tilde expansion is a shell feature performed at parse time on
+	// the command line, not by individual commands — so the path must
+	// be interpolated into a shell command via ExecBash (where the
+	// user's $HOME inside the container may differ from the host test
+	// process's $HOME, so locally os.ExpandEnv would compute the wrong
+	// path). It is safe with any command that consumes argv from a
+	// shell parse (cat, ls, sha256sum, test, etc.); it is NOT safe
+	// passed directly as an argv element to argv-form Exec.
 	const stateJSONPath = "~/.local/share/tomei/system/state.json"
 
-	// fileSha256IfExists returns the sha256 hex digest of the file at path,
-	// or "" if the file does not exist (or any cleanup-step error occurs).
-	// Used by the #218 Ordered Context's BeforeAll to capture pre-test state
-	// so AfterAll can distinguish "file we created" from "file that already
-	// existed on the host" and only rm -f the former.
+	// pathExistsAny reports whether ANY filesystem entry sits at path
+	// (regular file, directory, live symlink, or dangling symlink). It
+	// does NOT read the file, so an unreadable root-owned file or a
+	// dangling symlink whose target is missing still classifies as
+	// "exists". Use this in safety guards that only need the existence
+	// bit and must not abort on hash/permission errors — e.g. the
+	// pre-test "refuse to clobber" check in the #218 BeforeAll.
+	pathExistsAny := func(path string) bool {
+		out, err := testExec.ExecBash(fmt.Sprintf(
+			"if [ -e %[1]s ] || [ -L %[1]s ]; then echo yes; else echo no; fi", path))
+		Expect(err).NotTo(HaveOccurred(),
+			"probing existence of %s failed: %s", path, out)
+		return strings.TrimSpace(out) == "yes"
+	}
+
+	// fileSha256IfExists.
+	//
 	// Returns (hash, exists). exists is true iff *any* filesystem entry
 	// is present at the path — regular file, directory, or symlink
 	// (dangling or otherwise). Callers must check `exists` to decide
@@ -1707,8 +1718,17 @@ EOF`, dir, repoBlock)
 			// checks would miss a regression that rewrites the files
 			// while preserving their paths).
 			postInstallFileHashes map[string]string
-			repoScratchDirs       []string // /tmp dirs this Context owns, for AfterAll cleanup
 		)
+		// repoScratchDirPrefix matches /tmp scratch dirs registered by
+		// writeSystemPackageRepositoryManifest into the suite-level
+		// scratchDirs ledger. AfterAll filters scratchDirs by this
+		// prefix instead of maintaining a parallel ledger — the helper
+		// registers each dir at claim time (before content write), so a
+		// content-write failure mid-helper still leaves a registered
+		// entry for cleanup to consume. The sibling #200 Context's
+		// AfterAll only iterates scratchDirs entries that were present
+		// when it ran, so #218 entries (added after) are still here.
+		const repoScratchDirPrefix = "/tmp/tomei-system-package-repository"
 
 		// readState parses ~/.local/share/tomei/system/state.json via shell
 		// cat (state.json lives inside the container, not on the host where
@@ -1759,8 +1779,12 @@ EOF`, dir, repoBlock)
 			// runner always starts from a clean image, so this gate only
 			// fires on native opt-in runs (or a reused container with
 			// leftover pgdg files from a botched previous run).
+			// Use pathExistsAny (existence-only, never hashes) so a
+			// pre-existing unreadable root-owned PGDG file gets us a
+			// clean Skip instead of an Expect failure inside the hash
+			// step of fileSha256IfExists.
 			for _, p := range []string{pgdgKeyringPath, pgdgSourcePath} {
-				if _, exists := fileSha256IfExists(p); exists {
+				if pathExistsAny(p) {
 					Skip(fmt.Sprintf("pre-existing %s on host: refusing to clobber a real PGDG setup (re-run this Context in the container e2e runner instead)", p))
 				}
 			}
@@ -1778,14 +1802,14 @@ EOF`, dir, repoBlock)
 			scratchSuffix := fmt.Sprintf("%d-%d", os.Getpid(), time.Now().UnixNano())
 			repoCfgPath = "/tmp/tomei-system-package-repository-" + scratchSuffix + "/"
 			installerOnlyCfgPath = "/tmp/tomei-system-package-repository-removal-" + scratchSuffix + "/"
-			// Append to repoScratchDirs immediately after each helper
-			// returns, NOT in one shot after both. If the second helper
-			// aborts BeforeAll (Expect inside), the AfterAll still needs
-			// to know about the first dir we already created.
+			// The helper registers each dir into the suite-level
+			// scratchDirs ledger at claim time (right after the marker
+			// touch, before the content write). So even if the second
+			// call's content write aborts BeforeAll, AfterAll's prefix-
+			// filtered cleanup will still find and remove the partial
+			// dir — no separate per-Context ledger needed.
 			writeSystemPackageRepositoryManifest(repoCfgPath, true)
-			repoScratchDirs = append(repoScratchDirs, strings.TrimRight(repoCfgPath, "/"))
 			writeSystemPackageRepositoryManifest(installerOnlyCfgPath, false)
-			repoScratchDirs = append(repoScratchDirs, strings.TrimRight(installerOnlyCfgPath, "/"))
 		})
 
 		AfterAll(func() {
@@ -1802,13 +1826,17 @@ EOF`, dir, repoBlock)
 				fmt.Fprintln(GinkgoWriter, "TOMEI_E2E_NATIVE_SKIP_CLEANUP=true: skipping #218 PGDG file + /tmp cleanup")
 				return
 			}
-			// Scratch-dir cleanup: this Context's helper records its
-			// dirs in the suite-level scratchDirs map, but that ledger's
-			// rm-loop is scoped to the sibling #200 Context's AfterAll
-			// — which has already run by the time we land here. Iterate
-			// our own list so /tmp/tomei-system-package-repository-*
-			// does not leak after the suite.
-			for _, dir := range repoScratchDirs {
+			// Scratch-dir cleanup: filter the suite-level scratchDirs
+			// ledger by the #218 repo prefix. The sibling #200
+			// AfterAll's cleanup loop has already run, but it didn't
+			// delete map entries — and the helper registers our dirs at
+			// claim time (right after marker touch), so a partial
+			// content-write failure inside writeSystemPackageRepository-
+			// Manifest still leaves an entry for us to remove.
+			for dir := range scratchDirs {
+				if !strings.HasPrefix(dir, repoScratchDirPrefix) {
+					continue
+				}
 				if !systemPackageTestDirRE.MatchString(dir) {
 					continue
 				}
@@ -1844,15 +1872,23 @@ EOF`, dir, repoBlock)
 			if removedAny {
 				_, _ = testExec.ExecBash("sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get update -y 2>&1 || true")
 			}
-			resetSystemState()
+			// Best-effort: bypass resetSystemState (which Expects) and
+			// directly overwrite state.json, tolerating non-zero exits.
+			// The rest of this AfterAll is best-effort so a cleanup-only
+			// failure does not mask the spec failure that drove cleanup
+			// here in the first place; the strict resetSystemState would
+			// add an extra failure on a temporarily-unwritable path.
+			_, _ = testExec.ExecBash(
+				`mkdir -p ~/.local/share/tomei/system && echo '{"version":"1","systemInstallers":{},"systemPackageRepositories":{},"systemPackages":{}}' > ` + stateJSONPath + ` || true`)
 		})
 
 		It("apply --system installs the repository on the host",
 			Label("needs-gnupg", "needs-network"), func() {
-				// Irreversible gate: once set, the AfterAll cleanup (L1745)
-				// is mandatory because some host mutation MAY have already
-				// happened, even if ExecApply below returns non-zero. Best-
-				// effort rm -f means partial cleanup never cascades.
+				// Irreversible gate: once set, the AfterAll cleanup
+				// (above) is mandatory because some host mutation MAY
+				// have already happened, even if ExecApply below
+				// returns non-zero. Best-effort rm -f means partial
+				// cleanup never cascades.
 				pgdgMutationStarted = true
 				out, err := ExecApply(testExec, "--system", repoCfgPath)
 				Expect(err).NotTo(HaveOccurred(), "apply --system failed; output:\n%s", out)

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -98,6 +98,19 @@ var systemPackageTestDirRE = regexp.MustCompile(`^/tmp/[A-Za-z0-9_\-]+(\.[A-Za-z
 // unverified key.
 const pgdgKeyHashSHA256 = "sha256:0144068502a1eddd2a0280ede10ef607d1ec592ce819940991203941564e8e76"
 
+// pgdgURL / pgdgKeyURL / pgdgComponent pin the remaining AptSource
+// fields. The drift detector below asserts each against the canonical
+// fixture at e2e/config/system-package-test/manifest.cue so the scratch
+// /tmp manifest emitted by writeSystemPackageRepositoryManifest cannot
+// silently diverge from what validate/plan exercise. Without these
+// pins, the apply path could test against a different repo URL than
+// the validate/plan coverage and a fixture edit would not be caught.
+const (
+	pgdgURL       = "https://apt.postgresql.org/pub/repos/apt"
+	pgdgKeyURL    = "https://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc"
+	pgdgComponent = "main"
+)
+
 func systemPackageTests() {
 	const cfgPath = "~/system-package-test/"
 
@@ -179,6 +192,18 @@ func systemPackageTests() {
 				"manifest.cue spec.apt.keyHash and the Go const pgdgKeyHashSHA256 must stay in lockstep — see the manifest header comment for the rotation procedure")
 			Expect(string(raw)).To(ContainSubstring(`suite:   "`+pgdgSuite+`"`),
 				"manifest.cue spec.apt.suite and the Go const pgdgSuite must stay in lockstep — PGDG uses the <codename>-pgdg convention, a bare codename would 404 at apt-get update")
+			// Pin the remaining AptSource fields against the canonical
+			// fixture: the apply path's scratch /tmp manifest uses
+			// these Go consts directly, so without these drift checks
+			// the fixture could be edited (e.g. mirror URL change) and
+			// the validate/plan vs. apply coverage would silently
+			// exercise different repository definitions.
+			Expect(string(raw)).To(ContainSubstring(`url:     "`+pgdgURL+`"`),
+				"manifest.cue spec.apt.url and the Go const pgdgURL must stay in lockstep")
+			Expect(string(raw)).To(ContainSubstring(`keyUrl:  "`+pgdgKeyURL+`"`),
+				"manifest.cue spec.apt.keyUrl and the Go const pgdgKeyURL must stay in lockstep")
+			Expect(string(raw)).To(ContainSubstring(`components: ["`+pgdgComponent+`"]`),
+				"manifest.cue spec.apt.components and the Go const pgdgComponent must stay in lockstep")
 		})
 
 		It("Dockerfile Ubuntu release matches pgdgUbuntuRelease and pgdgSuite codename (rotation contract)", func() {
@@ -904,15 +929,15 @@ pgdgRepo: {
 	spec: {
 		installerRef: "apt"
 		apt: {
-			url:     "https://apt.postgresql.org/pub/repos/apt"
-			keyUrl:  "https://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc"
+			url:     "%[3]s"
+			keyUrl:  "%[4]s"
 			keyHash: "%[1]s"
 			suite:   "%[2]s"
-			components: ["main"]
+			components: ["%[5]s"]
 		}
 	}
 }
-`, pgdgKeyHashSHA256, pgdgSuite)
+`, pgdgKeyHashSHA256, pgdgSuite, pgdgURL, pgdgKeyURL, pgdgComponent)
 		}
 
 		content := fmt.Sprintf(`set -euo pipefail
@@ -1758,8 +1783,19 @@ EOF`, dir, repoBlock)
 			// native opt-in run on a minimal Debian/Ubuntu host without
 			// gnupg would fail mid-apply with a confusing error instead
 			// of skipping with a clear prerequisite message.
+			//
+			// In TOMEI_E2E_CONTAINER mode the Dockerfile is supposed to
+			// install gnupg (see e2e/containers/ubuntu/Dockerfile). A
+			// regression that drops the gnupg apt-get line must FAIL
+			// CI rather than turn this whole Context into a silent
+			// skip, so the missing-gpg branch only Skips for native
+			// opt-in runs and Expects in container mode.
 			_, gpgErr := testExec.ExecBash("command -v gpg >/dev/null 2>&1")
 			if gpgErr != nil {
+				if os.Getenv("TOMEI_E2E_CONTAINER") != "" {
+					Expect(gpgErr).NotTo(HaveOccurred(),
+						"gpg missing in TOMEI_E2E_CONTAINER mode: the runner image is supposed to install gnupg via e2e/containers/ubuntu/Dockerfile — a regression there silently turned repository apply coverage into a skip")
+				}
 				Skip("gpg not found on PATH: SystemPackageRepository apply requires gnupg (install `gnupg` or use the container e2e runner)")
 			}
 
@@ -1929,8 +1965,16 @@ EOF`, dir, repoBlock)
 					// to /dev/null so a real gpg failure (corrupt keyring,
 					// missing agent socket) surfaces in test logs instead of
 					// being silenced — pipefail propagates the non-zero exit.
+					// Isolate gpg from the host's GNUPGHOME / gpg.conf:
+					// `--homedir` to a fresh /tmp directory, `--no-options`
+					// so a developer's gpg.conf can't change command
+					// semantics, and `--batch` to prevent any pinentry/
+					// agent prompt. Mirrors the dearmor isolation done by
+					// the installer in internal/installer/apt/repository.go.
+					// trap-cleanup removes the homedir on success or
+					// failure so a leaked /tmp/gpghome-* does not pile up.
 					gpgOut, err := testExec.ExecBash(
-						"set -o pipefail; gpg --no-default-keyring --keyring " + pgdgKeyringPath + " --with-colons --list-keys 2>&1")
+						"set -o pipefail; H=$(mktemp -d -t tomei-e2e-gpg-XXXXXX); trap 'rm -rf -- \"$H\"' EXIT; gpg --homedir \"$H\" --no-options --batch --no-default-keyring --keyring " + pgdgKeyringPath + " --with-colons --list-keys 2>&1")
 					Expect(err).NotTo(HaveOccurred(),
 						"gpg --list-keys on %s failed; output:\n%s", pgdgKeyringPath, gpgOut)
 					Expect(gpgOut).To(MatchRegexp(`(?m)^pub:`),
@@ -1982,11 +2026,15 @@ EOF`, dir, repoBlock)
 				}
 			})
 
-		// Known limitation: a transient 5xx from apt.postgresql.org during
-		// the second apply causes apt-get update inside the Install path to
-		// fail, surfaced via the "system resource apply failed" warning
-		// guard below. That is a network-flake failure mode, not a code
-		// regression — `needs-network` label allows opt-out filtering.
+		// A truly idempotent second apply does NOT enter Install at
+		// all — the pre-apply plan-zero-work guard below proves the
+		// reconciler agrees there's nothing to do, and the post-apply
+		// sha256 check proves no rewrite happened. If a second apply
+		// reaches apt.postgresql.org / apt-get update at all, that is
+		// the regression this spec catches, NOT a network flake to
+		// dismiss. The `needs-network` label only documents that the
+		// upstream install spec (which this depends on via Ordered)
+		// hits the network — not that this spec is allowed to.
 		It("apply --system twice is idempotent",
 			Label("needs-gnupg", "needs-network"), func() {
 				before := readState()
@@ -2004,16 +2052,27 @@ EOF`, dir, repoBlock)
 				Expect(preplanOut).To(MatchRegexp(`(?m)^Summary:\s+0 to install,\s+0 to upgrade,\s+0 to reinstall,\s+0 to remove\s*$`),
 					"pre-second-apply plan must already show zero work; got:\n%s", preplanOut)
 
-				// Byte snapshot of the on-disk files going into the
-				// second apply. After the apply we re-hash and assert
-				// the bytes are identical, so an unnecessary re-write
-				// (same content, new mtime) is still caught even
-				// though state.json structural equality would survive.
+				// Byte + mtime snapshot of the on-disk files going
+				// into the second apply. After the apply we re-check
+				// both: a same-content rewrite (e.g. `install -D`
+				// run again with identical bytes) leaves the sha256
+				// unchanged but advances mtime/ctime, so we need
+				// both legs to actually catch an unnecessary
+				// re-install.
 				preApplyFileHashes := map[string]string{}
+				preApplyFileMtimes := map[string]string{}
 				for _, p := range []string{pgdgKeyringPath, pgdgSourcePath} {
 					h, exists := fileSha256IfExists(p)
 					Expect(exists).To(BeTrue(), "pre-apply: %s missing", p)
 					preApplyFileHashes[p] = h
+					// `stat -c %Y` is mtime in seconds since epoch.
+					// `%Z` (ctime) would also catch ownership/mode
+					// rewrites, but apply re-running install would
+					// touch mtime regardless of whether it changed
+					// ownership — mtime is sufficient and stable.
+					mtimeOut, err := testExec.ExecBash("stat -c '%Y' -- " + p)
+					Expect(err).NotTo(HaveOccurred(), "pre-apply: stat %Y on %s failed", p)
+					preApplyFileMtimes[p] = strings.TrimSpace(mtimeOut)
 				}
 
 				out, err := ExecApply(testExec, "--system", repoCfgPath)
@@ -2026,6 +2085,10 @@ EOF`, dir, repoBlock)
 					Expect(exists).To(BeTrue(), "post-second-apply: %s missing", p)
 					Expect(h).To(Equal(preApplyFileHashes[p]),
 						"%s contents changed across idempotent re-apply (sha256 mismatch); the install path re-ran when it should have no-op'd", p)
+					mtimeOut, err := testExec.ExecBash("stat -c '%Y' -- " + p)
+					Expect(err).NotTo(HaveOccurred(), "post-apply: stat %Y on %s failed", p)
+					Expect(strings.TrimSpace(mtimeOut)).To(Equal(preApplyFileMtimes[p]),
+						"%s mtime advanced across idempotent re-apply; the install path re-wrote identical bytes when it should have no-op'd", p)
 				}
 
 				after := readState()

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -142,22 +142,10 @@ func systemPackageTests() {
 	// determined action passes through to the printer, so plan shows
 	// "[+ install]" for an uninstalled pgdg.
 	//
-	// The apply / removal / idempotency arms of the spec are declared as
-	// Ginkgo Pending specs (PIt) rather than running real apply against
-	// the host. Rationale:
-	//
-	//   - The e2e runner image (e2e/containers/ubuntu/Dockerfile) does
-	//     not currently install gnupg, so apt.PackageRepositoryInstaller's
-	//     `gpg --dearmor` step would fail. Adding gnupg is out of scope
-	//     for this PR; #197 follow-up will land the Dockerfile bump plus
-	//     promote these PIt specs to It with real assertions.
-	//   - Even with gnupg present, apply --system mutates host state
-	//     (/usr/share/keyrings/pgdg.gpg and /etc/apt/sources.list.d/pgdg.list)
-	//     which would persist across containerised tests if the runner is
-	//     reused, and would reach apt.postgresql.org over the network at
-	//     test time — a brittle dependency for CI. The PIt bodies
-	//     document the expected post-apply invariants so the follow-up
-	//     PR has a single place to flip PIt -> It.
+	// The apply / removal / idempotency arms of the spec are exercised
+	// against the host in the sibling Ordered Context "Apply --system
+	// installs SystemPackageRepository (#218)" below (gnupg now ships in
+	// the e2e runner image; see e2e/containers/ubuntu/Dockerfile).
 	Context("SystemPackageRepository (#197)", func() {
 		It("validates the manifest", func() {
 			out, err := testExec.Exec("tomei", "validate", cfgPath)
@@ -821,19 +809,29 @@ EOF`, dir, strings.Join(quoted, ", "), fixtureSugarPkg)
 	// Used by the #218 Ordered Context's BeforeAll to capture pre-test state
 	// so AfterAll can distinguish "file we created" from "file that already
 	// existed on the host" and only rm -f the former.
-	fileSha256IfExists := func(path string) string {
-		// `[ -e ... ]` first: missing-file returns "" (not an error). When
-		// the file IS present we need `set -o pipefail` so a sha256sum
-		// failure (permission denied, sha256sum binary missing) doesn't
-		// get masked by awk's exit 0. `set -e` then aborts on any
-		// non-zero in the pipeline and the caller's `if err` branch hits.
-		// stderr is allowed through so the failure surfaces in test logs.
-		out, err := testExec.ExecBash(fmt.Sprintf(
-			"set -euo pipefail; if [ -e %[1]s ]; then sha256sum -- %[1]s | awk '{print $1}'; fi", path))
-		if err != nil {
-			return ""
+	// Returns (hash, exists). hash is empty when the path is absent;
+	// callers must check `exists` to distinguish "absent" from "present
+	// but unhashable" — the latter aborts the test rather than silently
+	// returning "" and letting the AfterAll treat a transient sha256sum
+	// failure as permission to rm a pre-existing host file.
+	fileSha256IfExists := func(path string) (string, bool) {
+		// Stage 1: probe existence. `test -e` exits 0/1 cleanly; any other
+		// exit code (e.g. permission error on the parent dir) is fatal.
+		existsOut, existsErr := testExec.ExecBash(fmt.Sprintf(
+			"if [ -e %[1]s ]; then echo yes; else echo no; fi", path))
+		Expect(existsErr).NotTo(HaveOccurred(),
+			"probing existence of %s failed: %s", path, existsOut)
+		if strings.TrimSpace(existsOut) == "no" {
+			return "", false
 		}
-		return strings.TrimSpace(out)
+		// Stage 2: hash. `set -o pipefail` so a sha256sum failure
+		// surfaces past awk; Expect aborts the test rather than masking
+		// the failure as "absent".
+		out, err := testExec.ExecBash(fmt.Sprintf(
+			"set -euo pipefail; sha256sum -- %[1]s | awk '{print $1}'", path))
+		Expect(err).NotTo(HaveOccurred(),
+			"%s exists but sha256sum failed: %s", path, out)
+		return strings.TrimSpace(out), true
 	}
 
 	// resetSystemState writes a minimal valid empty SystemState to the
@@ -1679,7 +1677,14 @@ EOF`, dir, repoBlock)
 			installerOnlyCfgPath  string // manifest WITHOUT pgdgRepo (specs 3 & 4)
 			pgdgPreflightComplete bool   // gate for AfterAll: BeforeAll ran far enough to need cleanup
 			pgdgMutationStarted   bool   // gate for AfterAll: spec 1 actually invoked apply --system
-			preTestKeyringHashes  map[string]string
+			// Post-install file hashes captured at the end of spec 1.
+			// Spec 3 ("apply WITHOUT --system retains state") compares
+			// against these to verify a no-flag apply truly leaves the
+			// keyring + sources.list bytes untouched (existence-only
+			// checks would miss a regression that rewrites the files
+			// while preserving their paths).
+			postInstallFileHashes map[string]string
+			repoScratchDirs       []string // /tmp dirs this Context owns, for AfterAll cleanup
 		)
 
 		// readState parses ~/.local/share/tomei/system/state.json via shell
@@ -1707,10 +1712,35 @@ EOF`, dir, repoBlock)
 		BeforeAll(func() {
 			skipIfNotLinux()
 
+			// gpg is required by apt.PackageRepositoryInstaller (gpg
+			// --dearmor) AND by the keyring assertion in spec 1.
+			// skipIfNotLinux only probes apt-get / dpkg-query, so a
+			// native opt-in run on a minimal Debian/Ubuntu host without
+			// gnupg would fail mid-apply with a confusing error instead
+			// of skipping with a clear prerequisite message.
+			_, gpgErr := testExec.ExecBash("command -v gpg >/dev/null 2>&1")
+			if gpgErr != nil {
+				Skip("gpg not found on PATH: SystemPackageRepository apply requires gnupg (install `gnupg` or use the container e2e runner)")
+			}
+
 			// NOPASSWD probe — same rationale as the #200 BeforeAll.
 			_, sudoErr := testExec.ExecBash("sudo -k && sudo -n true 2>&1")
 			Expect(sudoErr).NotTo(HaveOccurred(),
 				"non-interactive sudo (NOPASSWD) is required: apply --system invokes apt under sudo")
+
+			// Refuse to run on a host that already has pgdg configured.
+			// Hashing-with-restore would let us coexist with a developer
+			// machine that uses PGDG, but spec 1's install would still
+			// overwrite the live keyring/sources.list mid-run, and any
+			// failure between overwrite and restore would leave the host
+			// in a worse state than skipping. The container e2e runner
+			// always starts from a clean image, so this gate only fires
+			// in native opt-in runs.
+			for _, p := range []string{pgdgKeyringPath, pgdgSourcePath} {
+				if _, exists := fileSha256IfExists(p); exists {
+					Skip(fmt.Sprintf("pre-existing %s on host: refusing to clobber a real PGDG setup (re-run this Context in the container e2e runner instead)", p))
+				}
+			}
 
 			// `tomei init --force` is idempotent across Contexts.
 			initOut, initErr := testExec.Exec("tomei", "init", "--yes", "--force")
@@ -1722,38 +1752,53 @@ EOF`, dir, repoBlock)
 
 			resetSystemState()
 
-			// Capture pre-existing host state. If pgdg was already
-			// installed (developer machine, container reuse), we leave
-			// those files alone on AfterAll and only rm the ones we
-			// created. fileSha256IfExists returns "" for missing files.
-			preTestKeyringHashes = map[string]string{
-				pgdgKeyringPath: fileSha256IfExists(pgdgKeyringPath),
-				pgdgSourcePath:  fileSha256IfExists(pgdgSourcePath),
-			}
-
 			scratchSuffix := fmt.Sprintf("%d-%d", os.Getpid(), time.Now().UnixNano())
 			repoCfgPath = "/tmp/tomei-system-package-repository-" + scratchSuffix + "/"
 			installerOnlyCfgPath = "/tmp/tomei-system-package-repository-removal-" + scratchSuffix + "/"
 			writeSystemPackageRepositoryManifest(repoCfgPath, true)
 			writeSystemPackageRepositoryManifest(installerOnlyCfgPath, false)
+			repoScratchDirs = []string{
+				strings.TrimRight(repoCfgPath, "/"),
+				strings.TrimRight(installerOnlyCfgPath, "/"),
+			}
 		})
 
 		AfterAll(func() {
-			// pgdgMutationStarted gates the host cleanup — if no spec ever
-			// invoked apply --system, the keyring/sources.list files were
-			// never created by this suite and the rm -f loop must not run.
-			if !pgdgPreflightComplete || !pgdgMutationStarted {
+			if !pgdgPreflightComplete {
+				return
+			}
+			// Scratch-dir cleanup: this Context's helper records its
+			// dirs in the suite-level scratchDirs map, but that ledger's
+			// rm-loop is scoped to the sibling #200 Context's AfterAll
+			// — which has already run by the time we land here. Iterate
+			// our own list so /tmp/tomei-system-package-repository-*
+			// does not leak after the suite.
+			for _, dir := range repoScratchDirs {
+				if !systemPackageTestDirRE.MatchString(dir) {
+					continue
+				}
+				_, markerErr := testExec.ExecBash(`test -f ` + dir + `/.tomei-e2e-system-package-test`)
+				if markerErr != nil {
+					continue
+				}
+				_, _ = testExec.ExecBash("rm -rf " + dir)
+			}
+			// pgdgMutationStarted gates the host cleanup — if no spec
+			// ever invoked apply --system, the keyring/sources.list
+			// files were never created by this suite. The BeforeAll
+			// Skip guarantees both paths were absent pre-test, so any
+			// surviving file here was written by this Context and is
+			// safe to remove unconditionally.
+			if !pgdgMutationStarted {
 				return
 			}
 			removedAny := false
-			for path, preHash := range preTestKeyringHashes {
-				if preHash == "" {
-					// Best-effort: tolerate non-zero exits so cleanup
-					// failures never mask the spec-failure that surfaced
-					// the real bug.
-					_, _ = testExec.ExecBash("sudo -n rm -f -- " + path)
-					removedAny = true
-				}
+			for _, path := range []string{pgdgKeyringPath, pgdgSourcePath} {
+				// Best-effort: tolerate non-zero exits so cleanup
+				// failures never mask the spec-failure that surfaced
+				// the real bug.
+				_, _ = testExec.ExecBash("sudo -n rm -f -- " + path)
+				removedAny = true
 			}
 			// If we touched apt sources, flush the apt cache so subsequent
 			// apt operations in the same container don't 404 trying to
@@ -1790,6 +1835,15 @@ EOF`, dir, repoBlock)
 					Expect(err).NotTo(HaveOccurred(), "stat on %s failed", pgdgKeyringPath)
 					Expect(modeOut).To(ContainSubstring("644 root:root"),
 						"keyring mode/ownership mismatch; stat: %s", strings.TrimSpace(modeOut))
+					// sources.list is also installed via `install -D -m
+					// 0644 -o root -g root` (see
+					// internal/installer/apt/repository.go) — assert the
+					// same so a regression that drops the install flags
+					// for the sources.list path is caught.
+					srcModeOut, err := testExec.ExecBash("stat -c '%a %U:%G' -- " + pgdgSourcePath)
+					Expect(err).NotTo(HaveOccurred(), "stat on %s failed", pgdgSourcePath)
+					Expect(srcModeOut).To(ContainSubstring("644 root:root"),
+						"sources.list mode/ownership mismatch; stat: %s", strings.TrimSpace(srcModeOut))
 					// Validate keyring is a real GPG keyring. Uses --with-colons
 					// machine-readable output (stable across gpg 2.x versions,
 					// no locale dependency) so `^pub:` matches predictably.
@@ -1839,6 +1893,18 @@ EOF`, dir, repoBlock)
 					Expect(pgdg.UpdatedAt).To(BeTemporally("~", time.Now(), 60*time.Second),
 						"UpdatedAt must be set to apply time, not zero or stale")
 				})
+
+				// Snapshot the post-install file bytes so the no-flag
+				// retention spec (#169 scenario 7) can prove the files
+				// are not silently rewritten. Capturing here avoids
+				// re-running spec 1 from the retention spec just to
+				// know the "expected" content.
+				postInstallFileHashes = map[string]string{}
+				for _, p := range []string{pgdgKeyringPath, pgdgSourcePath} {
+					h, exists := fileSha256IfExists(p)
+					Expect(exists).To(BeTrue(), "post-install snapshot: %s should exist", p)
+					postInstallFileHashes[p] = h
+				}
 			})
 
 		// Known limitation: a transient 5xx from apt.postgresql.org during
@@ -1879,12 +1945,17 @@ EOF`, dir, repoBlock)
 				// actions that just no-op'd.
 				planOut, err := testExec.Exec("tomei", "plan", "--system", repoCfgPath)
 				Expect(err).NotTo(HaveOccurred(), "plan --system failed: %s", planOut)
-				Expect(planOut).To(MatchRegexp(`(?m)^Summary:\s+0 to install,\s+0 to upgrade,\s+0 to reinstall,\s+0 to remove`),
+				Expect(planOut).To(MatchRegexp(`(?m)^Summary:\s+0 to install,\s+0 to upgrade,\s+0 to reinstall,\s+0 to remove\s*$`),
 					"post-apply plan must show zero pending actions; got:\n%s", planOut)
 			})
 
 		It("apply WITHOUT --system skips system resources and retains state (#169 scenario 7)",
-			Label("needs-gnupg"), func() {
+			// needs-network: this spec reads state populated by the
+			// upstream install spec in the same Ordered Context. A
+			// label filter that excludes network tests must therefore
+			// exclude this one too, or the prior install will not run
+			// and `before.SystemPackageRepositories` is empty.
+			Label("needs-gnupg", "needs-network"), func() {
 				// Spec intent: even though installerOnlyCfgPath drops
 				// pgdgRepo from the manifest, omitting --system makes
 				// apply ignore system resources entirely — state.json and
@@ -1895,6 +1966,8 @@ EOF`, dir, repoBlock)
 				// and deferred to a future audit feature.
 				before := readState()
 				Expect(before.SystemPackageRepositories).To(HaveKey("pgdg"))
+				Expect(postInstallFileHashes).NotTo(BeEmpty(),
+					"postInstallFileHashes must have been captured by the upstream install spec")
 
 				out, err := ExecApply(testExec, installerOnlyCfgPath) // NOTE: no --system
 				Expect(err).NotTo(HaveOccurred(), "apply (no --system) failed: %s", out)
@@ -1905,17 +1978,30 @@ EOF`, dir, repoBlock)
 				Expect(out).To(ContainSubstring("system resource(s) skipped. Use 'tomei apply --system' to manage"),
 					"expected the skip warning to be printed; got:\n%s", out)
 
-				// Files and state must be untouched.
-				_, err = testExec.ExecBash("test -f " + pgdgKeyringPath)
-				Expect(err).NotTo(HaveOccurred(), "keyring missing after no-flag apply")
-				_, err = testExec.ExecBash("test -f " + pgdgSourcePath)
-				Expect(err).NotTo(HaveOccurred(), "sources.list missing after no-flag apply")
+				// Files and state must be byte-identical to the
+				// post-install snapshot. Existence-only checks would
+				// miss a regression that rewrites the keyring or
+				// sources.list while keeping the path.
+				for _, p := range []string{pgdgKeyringPath, pgdgSourcePath} {
+					h, exists := fileSha256IfExists(p)
+					Expect(exists).To(BeTrue(), "%s missing after no-flag apply", p)
+					Expect(h).To(Equal(postInstallFileHashes[p]),
+						"%s contents changed after no-flag apply (sha256 mismatch); the no-flag path must not touch system files", p)
+				}
 				after := readState()
 				Expect(after.SystemPackageRepositories).To(HaveKey("pgdg"))
+				// Structural state equality. Same rationale as files:
+				// a no-flag apply must not perturb state.json either.
+				Expect(after).To(Equal(before),
+					"state.json changed after no-flag apply; system resources must not be reconciled")
 			})
 
 		It("removing the repo from the manifest cleans up files and state",
-			Label("needs-gnupg"), func() {
+			// needs-network: depends on the upstream install spec to
+			// have populated state.json with pgdg. Without it, the
+			// reconciler would have nothing to remove and the test
+			// would fail for setup reasons rather than testing removal.
+			Label("needs-gnupg", "needs-network"), func() {
 				// Spec intent: same installerOnlyCfgPath manifest as the
 				// scenario-7 spec above, but WITH --system this time. The
 				// engine reconciler treats pgdg missing-from-manifest +
@@ -1925,8 +2011,13 @@ EOF`, dir, repoBlock)
 				Expect(out).NotTo(ContainSubstring("system resource apply failed"))
 
 				for _, p := range []string{pgdgKeyringPath, pgdgSourcePath} {
-					_, err := testExec.ExecBash("test -f " + p)
-					Expect(err).To(HaveOccurred(), "%s should have been removed", p)
+					// `test ! -e` (not `! test -f`): the removal
+					// contract is total non-existence, so a leftover
+					// directory or dangling symlink at this path must
+					// also fail the assertion. `test -f` would pass for
+					// either of those failure modes.
+					_, err := testExec.ExecBash("test ! -e " + p)
+					Expect(err).NotTo(HaveOccurred(), "%s should have been removed (file, directory, or symlink left behind)", p)
 				}
 				st := readState()
 				Expect(st.SystemPackageRepositories).NotTo(HaveKey("pgdg"),

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -1817,7 +1817,7 @@ EOF`, dir, repoBlock)
 				return
 			}
 			// Honor the same native-mode escape hatch the sibling #200
-			// AfterAll uses (see L939-944): a native opt-in run that
+			// AfterAll uses: a native opt-in run that
 			// sets TOMEI_E2E_NATIVE_SKIP_CLEANUP=true to inspect host
 			// state after a failure must apply consistently here too,
 			// or this Context would silently re-clean what the sibling


### PR DESCRIPTION
Replaces the three Ginkgo Pending (PIt) specs in the
SystemPackageRepository (#197) Context with a new Ordered Context that
exercises the real apply path against the PGDG repository. Adds gnupg
to the e2e Ubuntu runner image so apt.PackageRepositoryInstaller's
`gpg --dearmor` step works in CI.

The new Context contains four specs (cumulative state under Ordered):
1. install — asserts keyring + sources.list files, mode/ownership,
   gpg --with-colons output (pub: + uid: present), state.json shape,
   and InstalledFiles slice order (keyring, sources.list per
   repository.go).
2. idempotency — re-applies the same manifest, asserts state equality
   after zeroing UpdatedAt, plus an explicit InstalledFiles
   order assertion for diagnostic clarity.
3. apply WITHOUT --system retains state (#169 scenario 7) — verifies
   that omitting the flag skips system resources entirely and emits
   the documented warning string.
4. removal — applies the installer-only manifest with --system, asserts
   files and state.json `pgdg` entry are gone.

Adds four function-scope helpers alongside the existing
writeSystemPackageManifest:

- stateJSONPath const (shell-expanded ~)
- fileSha256IfExists — pre-test snapshot for non-destructive AfterAll
- resetSystemState — empty SystemState heredoc
- writeSystemPackageRepositoryManifest — TOCTOU-safe two-phase scratch
  with optional pgdgRepo block

Closes #218 (filed during planning as #197 follow-up).
Ticks #169 scenarios 5/6/7/8 for SystemPackageRepository.
A separate follow-up for multi-repository apply-ordering unit-test
coverage is tracked as #219.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
