### PR TITLE
feat(installer): add portable symlink helpers with sudo fallback (#226)

### DIFF
--- a/internal/installer/place/symlink.go
+++ b/internal/installer/place/symlink.go
@@ -1,0 +1,162 @@
+package place
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// errSudoFallback is wrapped into errors when the direct syscall hit
+// fs.ErrPermission and the helper fell back to `sudo -n`. Tests use
+// errors.Is to detect "this operation required privilege escalation."
+// Stays unexported until callers outside this package actually need it.
+var errSudoFallback = errors.New("sudo fallback")
+
+// symlinkOverrides groups the three swappable function dependencies of the
+// portable-symlink helpers. Production callers must not touch this; the test
+// file in this package overrides the fields. Because the value is a package
+// global, tests that touch it must NOT call t.Parallel().
+var symlinkOverrides = struct {
+	symlink func(target, linkPath string) error
+	remove  func(name string) error
+	sudoRun func(ctx context.Context, args ...string) error
+}{
+	symlink: os.Symlink,
+	remove:  os.Remove,
+	sudoRun: defaultSudoRun,
+}
+
+// defaultSudoRun executes `sudo -n <args...>`, capturing stderr for diagnostics.
+// Successful-run stderr is intentionally discarded — only-on-error capture
+// keeps logs quiet on the happy path while turning the otherwise-opaque
+// "exit status 1" into something actionable (e.g. "sudo: a password is
+// required" when the cached ticket has expired).
+func defaultSudoRun(ctx context.Context, args ...string) error {
+	var stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, "sudo", append([]string{"-n"}, args...)...)
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			return err
+		}
+		return fmt.Errorf("%w: %s", err, msg)
+	}
+	return nil
+}
+
+// installSymlink creates linkPath -> target, escalating to `sudo -n ln -sf`
+// on permission error. Existing symlinks at linkPath are replaced; existing
+// non-symlinks (regular files, directories) are refused to avoid silently
+// clobbering operator-installed binaries.
+//
+// Assumes the caller has already cached a sudo ticket via sudoHandler
+// (cmd/tomei/apply.go); the -n flag never prompts.
+func installSymlink(ctx context.Context, target, linkPath string) error {
+	if target == "" {
+		return errors.New("symlink: target is empty")
+	}
+	if err := validateLinkPath(linkPath); err != nil {
+		return err
+	}
+	info, exists, err := classifyLstat(linkPath)
+	if err != nil {
+		return fmt.Errorf("install symlink %q: lstat: %w", linkPath, err)
+	}
+	if exists {
+		if info.Mode()&os.ModeSymlink == 0 {
+			return fmt.Errorf("install symlink %q: refusing to replace non-symlink", linkPath)
+		}
+		if rmErr := symlinkOverrides.remove(linkPath); rmErr != nil && !errors.Is(rmErr, fs.ErrNotExist) {
+			if errors.Is(rmErr, fs.ErrPermission) {
+				return sudoInstallSymlink(ctx, target, linkPath)
+			}
+			return fmt.Errorf("install symlink %q: remove existing: %w", linkPath, rmErr)
+		}
+	}
+	if err := symlinkOverrides.symlink(target, linkPath); err != nil {
+		if errors.Is(err, fs.ErrPermission) {
+			return sudoInstallSymlink(ctx, target, linkPath)
+		}
+		return fmt.Errorf("install symlink %q -> %q: %w", target, linkPath, err)
+	}
+	return nil
+}
+
+// removeSymlink removes linkPath, escalating to `sudo -n rm -f` on permission
+// error. A missing linkPath is a no-op (matches `rm -f`). Refuses to remove a
+// non-symlink at linkPath — the helper is named removeSymlink for a reason.
+func removeSymlink(ctx context.Context, linkPath string) error {
+	if err := validateLinkPath(linkPath); err != nil {
+		return err
+	}
+	info, exists, err := classifyLstat(linkPath)
+	if err != nil {
+		return fmt.Errorf("remove symlink %q: lstat: %w", linkPath, err)
+	}
+	if !exists {
+		return nil
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return fmt.Errorf("remove symlink %q: refusing to remove non-symlink", linkPath)
+	}
+
+	rmErr := symlinkOverrides.remove(linkPath)
+	if rmErr == nil || errors.Is(rmErr, fs.ErrNotExist) {
+		return nil
+	}
+	if errors.Is(rmErr, fs.ErrPermission) {
+		if sudoErr := symlinkOverrides.sudoRun(ctx, "rm", "-f", "--", linkPath); sudoErr != nil {
+			return fmt.Errorf("remove symlink %q: %w: %w", linkPath, errSudoFallback, sudoErr)
+		}
+		return nil
+	}
+	return fmt.Errorf("remove symlink %q: %w", linkPath, rmErr)
+}
+
+// classifyLstat is the single audit point for the safety invariant "refuse on
+// un-classified Lstat". Callers must treat `err != nil` as a hard stop —
+// proceeding to a sudo fallback would let sudo act on whatever is at linkPath,
+// bypassing later non-symlink safety checks.
+func classifyLstat(linkPath string) (info os.FileInfo, exists bool, err error) {
+	info, lstatErr := os.Lstat(linkPath)
+	if errors.Is(lstatErr, fs.ErrNotExist) {
+		return nil, false, nil
+	}
+	if lstatErr != nil {
+		return nil, false, lstatErr
+	}
+	return info, true, nil
+}
+
+func sudoInstallSymlink(ctx context.Context, target, linkPath string) error {
+	// `ln -snf`: -s symbolic, -f force-replace, -n = treat dest as file even
+	// if it's a symlink to a directory (without this, ln dereferences and
+	// creates the new link *inside* the directory).
+	if err := symlinkOverrides.sudoRun(ctx, "ln", "-snf", "--", target, linkPath); err != nil {
+		return fmt.Errorf("install symlink %q -> %q: %w: %w", target, linkPath, errSudoFallback, err)
+	}
+	return nil
+}
+
+// validateLinkPath rejects obviously-dangerous inputs so a buggy caller can't
+// have sudo cheerfully run `rm -f -- ""` or similar. Deeper allow-listing
+// (refuse /etc, /bin, …) belongs at the call site that knows binDir intent.
+func validateLinkPath(linkPath string) error {
+	if linkPath == "" {
+		return errors.New("symlink: linkPath is empty")
+	}
+	if !filepath.IsAbs(linkPath) {
+		return fmt.Errorf("symlink: linkPath %q is not absolute", linkPath)
+	}
+	if filepath.Clean(linkPath) == "/" {
+		return errors.New("symlink: linkPath resolves to root directory")
+	}
+	return nil
+}

--- a/internal/installer/place/symlink.go
+++ b/internal/installer/place/symlink.go
@@ -12,10 +12,13 @@ import (
 	"strings"
 )
 
-// errSudoFallback is wrapped into errors when the direct syscall hit
-// fs.ErrPermission and the helper fell back to `sudo -n`. Tests use
-// errors.Is to detect "this operation required privilege escalation."
-// Stays unexported until callers outside this package actually need it.
+// errSudoFallback is wrapped into the returned error only when the helper
+// fell back to `sudo -n` AND that sudo invocation itself failed. A successful
+// sudo fallback returns nil (callers can't tell from the return value that
+// escalation occurred). Tests assert errors.Is(err, errSudoFallback) to
+// distinguish "sudo path was taken but failed" from "direct syscall failed
+// for a non-permission reason." Stays unexported until callers outside this
+// package actually need it.
 var errSudoFallback = errors.New("sudo fallback")
 
 // symlinkOverrides groups the three swappable function dependencies of the
@@ -51,10 +54,11 @@ func defaultSudoRun(ctx context.Context, args ...string) error {
 	return nil
 }
 
-// installSymlink creates linkPath -> target, escalating to `sudo -n ln -sf`
-// on permission error. Existing symlinks at linkPath are replaced; existing
-// non-symlinks (regular files, directories) are refused to avoid silently
-// clobbering operator-installed binaries.
+// installSymlink creates linkPath -> target, escalating to `sudo -n ln -snf`
+// on permission error (-s symbolic, -n no-deref to avoid the symlink-to-dir
+// foot-gun, -f force-replace). Existing symlinks at linkPath are replaced;
+// existing non-symlinks (regular files, directories) are refused to avoid
+// silently clobbering operator-installed binaries.
 //
 // Assumes the caller has already cached a sudo ticket via sudoHandler
 // (cmd/tomei/apply.go); the -n flag never prompts.
@@ -84,7 +88,7 @@ func installSymlink(ctx context.Context, target, linkPath string) error {
 		if errors.Is(err, fs.ErrPermission) {
 			return sudoInstallSymlink(ctx, target, linkPath)
 		}
-		return fmt.Errorf("install symlink %q -> %q: %w", target, linkPath, err)
+		return fmt.Errorf("install symlink %q -> %q: %w", linkPath, target, err)
 	}
 	return nil
 }
@@ -140,7 +144,7 @@ func sudoInstallSymlink(ctx context.Context, target, linkPath string) error {
 	// if it's a symlink to a directory (without this, ln dereferences and
 	// creates the new link *inside* the directory).
 	if err := symlinkOverrides.sudoRun(ctx, "ln", "-snf", "--", target, linkPath); err != nil {
-		return fmt.Errorf("install symlink %q -> %q: %w: %w", target, linkPath, errSudoFallback, err)
+		return fmt.Errorf("install symlink %q -> %q: %w: %w", linkPath, target, errSudoFallback, err)
 	}
 	return nil
 }

--- a/internal/installer/place/symlink_test.go
+++ b/internal/installer/place/symlink_test.go
@@ -97,9 +97,10 @@ func TestInstallSymlink_FallsBackOnPermissionError(t *testing.T) {
 		},
 	)
 
-	err := installSymlink(context.Background(), "/some/target", "/usr/local/bin/foo")
+	linkPath := filepath.Join(t.TempDir(), "foo")
+	err := installSymlink(context.Background(), "/some/target", linkPath)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"ln", "-snf", "--", "/some/target", "/usr/local/bin/foo"}, capturedArgs)
+	assert.Equal(t, []string{"ln", "-snf", "--", "/some/target", linkPath}, capturedArgs)
 }
 
 func TestInstallSymlink_NonPermissionErrorNotEscalated(t *testing.T) {
@@ -132,10 +133,11 @@ func TestInstallSymlink_SudoFallbackFailurePropagates(t *testing.T) {
 		},
 	)
 
-	err := installSymlink(context.Background(), "/t", "/usr/local/bin/foo")
+	linkPath := filepath.Join(t.TempDir(), "foo")
+	err := installSymlink(context.Background(), "/t", linkPath)
 	require.Error(t, err)
 	require.ErrorIs(t, err, errSudoFallback)
-	assert.Contains(t, err.Error(), "/usr/local/bin/foo")
+	assert.Contains(t, err.Error(), linkPath)
 	assert.Contains(t, err.Error(), "sudo: a password is required")
 }
 

--- a/internal/installer/place/symlink_test.go
+++ b/internal/installer/place/symlink_test.go
@@ -1,0 +1,352 @@
+package place
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withStubs swaps the symlinkOverrides fields and restores them via t.Cleanup.
+// Pass nil to leave a field at its production default. Tests that touch
+// package globals must NOT call t.Parallel.
+func withStubs(
+	t *testing.T,
+	sym func(target, linkPath string) error,
+	rm func(name string) error,
+	sudo func(ctx context.Context, args ...string) error,
+) {
+	t.Helper()
+	orig := symlinkOverrides
+	t.Cleanup(func() { symlinkOverrides = orig })
+	if sym != nil {
+		symlinkOverrides.symlink = sym
+	}
+	if rm != nil {
+		symlinkOverrides.remove = rm
+	}
+	if sudo != nil {
+		symlinkOverrides.sudoRun = sudo
+	}
+}
+
+func TestInstallSymlink_DirectPath(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	require.NoError(t, os.WriteFile(target, []byte("x"), 0o644))
+	linkPath := filepath.Join(dir, "link")
+
+	require.NoError(t, installSymlink(context.Background(), target, linkPath))
+
+	got, err := os.Readlink(linkPath)
+	require.NoError(t, err)
+	assert.Equal(t, target, got)
+}
+
+func TestInstallSymlink_ReplacesExisting(t *testing.T) {
+	dir := t.TempDir()
+	linkPath := filepath.Join(dir, "link")
+	require.NoError(t, os.Symlink("/old", linkPath))
+
+	require.NoError(t, installSymlink(context.Background(), "/new", linkPath))
+
+	got, err := os.Readlink(linkPath)
+	require.NoError(t, err)
+	assert.Equal(t, "/new", got)
+}
+
+func TestInstallSymlink_RefusesToReplaceRegularFile(t *testing.T) {
+	dir := t.TempDir()
+	linkPath := filepath.Join(dir, "regular")
+	require.NoError(t, os.WriteFile(linkPath, []byte("operator-installed"), 0o755))
+
+	var sudoCalled bool
+	withStubs(t, nil, nil, func(ctx context.Context, args ...string) error {
+		sudoCalled = true
+		return nil
+	})
+
+	err := installSymlink(context.Background(), "/some/target", linkPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to replace non-symlink")
+	assert.False(t, sudoCalled, "sudo must not be called")
+
+	// Original file still intact.
+	body, readErr := os.ReadFile(linkPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, "operator-installed", string(body))
+}
+
+func TestInstallSymlink_FallsBackOnPermissionError(t *testing.T) {
+	var capturedArgs []string
+	withStubs(t,
+		func(target, linkPath string) error {
+			return &os.PathError{Op: "symlink", Path: linkPath, Err: syscall.EACCES}
+		},
+		nil,
+		func(ctx context.Context, args ...string) error {
+			capturedArgs = args
+			return nil
+		},
+	)
+
+	err := installSymlink(context.Background(), "/some/target", "/usr/local/bin/foo")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ln", "-snf", "--", "/some/target", "/usr/local/bin/foo"}, capturedArgs)
+}
+
+func TestInstallSymlink_NonPermissionErrorNotEscalated(t *testing.T) {
+	var sudoCalled bool
+	withStubs(t,
+		func(target, linkPath string) error { return errors.New("disk full") },
+		nil,
+		func(ctx context.Context, args ...string) error {
+			sudoCalled = true
+			return nil
+		},
+	)
+
+	dir := t.TempDir()
+	err := installSymlink(context.Background(), "/t", filepath.Join(dir, "link"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "disk full")
+	require.NotErrorIs(t, err, errSudoFallback)
+	assert.False(t, sudoCalled)
+}
+
+func TestInstallSymlink_SudoFallbackFailurePropagates(t *testing.T) {
+	withStubs(t,
+		func(target, linkPath string) error {
+			return &os.PathError{Op: "symlink", Path: linkPath, Err: syscall.EACCES}
+		},
+		nil,
+		func(ctx context.Context, args ...string) error {
+			return errors.New("sudo: a password is required")
+		},
+	)
+
+	err := installSymlink(context.Background(), "/t", "/usr/local/bin/foo")
+	require.Error(t, err)
+	require.ErrorIs(t, err, errSudoFallback)
+	assert.Contains(t, err.Error(), "/usr/local/bin/foo")
+	assert.Contains(t, err.Error(), "sudo: a password is required")
+}
+
+func TestInstallSymlink_RejectsBadInput(t *testing.T) {
+	tests := []struct {
+		name     string
+		target   string
+		linkPath string
+		wantMsg  string
+	}{
+		{"empty target", "", "/usr/local/bin/foo", "target is empty"},
+		{"empty linkPath", "/t", "", "linkPath is empty"},
+		{"relative linkPath", "/t", "relative/path", "is not absolute"},
+		{"root linkPath", "/t", "/", "resolves to root"},
+		{"double-slash root", "/t", "//", "resolves to root"},
+		{"dotdot to root", "/t", "/foo/..", "resolves to root"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sudoCalled bool
+			withStubs(t, nil, nil, func(ctx context.Context, args ...string) error {
+				sudoCalled = true
+				return nil
+			})
+
+			err := installSymlink(context.Background(), tt.target, tt.linkPath)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantMsg)
+			assert.False(t, sudoCalled)
+		})
+	}
+}
+
+// lockedDir creates a 0o000 subdir inside t.TempDir(), restoring permissions
+// in t.Cleanup so TempDir can clean up. Skips on non-Linux and when running
+// as root (chmod is bypassed).
+func lockedDir(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS != "linux" {
+		t.Skip("chmod 0000 unreliable outside Linux")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses chmod permissions")
+	}
+	dir := t.TempDir()
+	locked := filepath.Join(dir, "locked")
+	require.NoError(t, os.Mkdir(locked, 0o700))
+	require.NoError(t, os.Chmod(locked, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o700) })
+	return locked
+}
+
+func TestInstallSymlink_LstatFailureNotEscalated(t *testing.T) {
+	locked := lockedDir(t)
+
+	var sudoCalled bool
+	withStubs(t, nil, nil, func(ctx context.Context, args ...string) error {
+		sudoCalled = true
+		return nil
+	})
+
+	err := installSymlink(context.Background(), "/some/target", filepath.Join(locked, "link"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "lstat:")
+	assert.False(t, sudoCalled)
+}
+
+func TestInstallSymlink_ExistingSymlinkRemoveEACCESFallsBack(t *testing.T) {
+	dir := t.TempDir()
+	linkPath := filepath.Join(dir, "link")
+	require.NoError(t, os.Symlink("/old", linkPath))
+
+	var capturedArgs []string
+	withStubs(t,
+		nil,
+		func(name string) error {
+			return &os.PathError{Op: "remove", Path: name, Err: syscall.EACCES}
+		},
+		func(ctx context.Context, args ...string) error {
+			capturedArgs = args
+			return nil
+		},
+	)
+
+	err := installSymlink(context.Background(), "/new", linkPath)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ln", "-snf", "--", "/new", linkPath}, capturedArgs)
+}
+
+func TestRemoveSymlink_DirectPath(t *testing.T) {
+	dir := t.TempDir()
+	linkPath := filepath.Join(dir, "link")
+	require.NoError(t, os.Symlink("/anywhere", linkPath))
+
+	require.NoError(t, removeSymlink(context.Background(), linkPath))
+
+	_, err := os.Lstat(linkPath)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+}
+
+func TestRemoveSymlink_MissingIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	linkPath := filepath.Join(dir, "absent")
+	assert.NoError(t, removeSymlink(context.Background(), linkPath))
+}
+
+func TestRemoveSymlink_RefusesNonSymlink(t *testing.T) {
+	dir := t.TempDir()
+	linkPath := filepath.Join(dir, "regular")
+	require.NoError(t, os.WriteFile(linkPath, []byte("data"), 0o644))
+
+	var sudoCalled bool
+	withStubs(t, nil, nil, func(ctx context.Context, args ...string) error {
+		sudoCalled = true
+		return nil
+	})
+
+	err := removeSymlink(context.Background(), linkPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to remove non-symlink")
+	assert.False(t, sudoCalled)
+
+	_, statErr := os.Stat(linkPath)
+	assert.NoError(t, statErr, "regular file must not be deleted")
+}
+
+func TestRemoveSymlink_FallsBackOnPermissionError(t *testing.T) {
+	dir := t.TempDir()
+	linkPath := filepath.Join(dir, "link")
+	require.NoError(t, os.Symlink("/anywhere", linkPath))
+
+	var capturedArgs []string
+	withStubs(t,
+		nil,
+		func(name string) error {
+			return &os.PathError{Op: "remove", Path: name, Err: syscall.EACCES}
+		},
+		func(ctx context.Context, args ...string) error {
+			capturedArgs = args
+			return nil
+		},
+	)
+
+	err := removeSymlink(context.Background(), linkPath)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"rm", "-f", "--", linkPath}, capturedArgs)
+}
+
+func TestRemoveSymlink_LstatFailureNotEscalated(t *testing.T) {
+	locked := lockedDir(t)
+
+	var sudoCalled bool
+	withStubs(t, nil, nil, func(ctx context.Context, args ...string) error {
+		sudoCalled = true
+		return nil
+	})
+
+	err := removeSymlink(context.Background(), filepath.Join(locked, "link"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "lstat:")
+	assert.False(t, sudoCalled)
+}
+
+func TestRemoveSymlink_SudoFallbackFailurePropagates(t *testing.T) {
+	dir := t.TempDir()
+	linkPath := filepath.Join(dir, "link")
+	require.NoError(t, os.Symlink("/anywhere", linkPath))
+
+	withStubs(t,
+		nil,
+		func(name string) error {
+			return &os.PathError{Op: "remove", Path: name, Err: syscall.EACCES}
+		},
+		func(ctx context.Context, args ...string) error {
+			return errors.New("sudo: a password is required")
+		},
+	)
+
+	err := removeSymlink(context.Background(), linkPath)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errSudoFallback)
+	assert.Contains(t, err.Error(), linkPath)
+	assert.Contains(t, err.Error(), "sudo: a password is required")
+}
+
+func TestRemoveSymlink_RejectsBadLinkPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		linkPath string
+		wantMsg  string
+	}{
+		{"empty", "", "linkPath is empty"},
+		{"relative", "relative/path", "is not absolute"},
+		{"root", "/", "resolves to root"},
+		{"double-slash root", "//", "resolves to root"},
+		{"dotdot to root", "/foo/..", "resolves to root"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sudoCalled bool
+			withStubs(t, nil, nil, func(ctx context.Context, args ...string) error {
+				sudoCalled = true
+				return nil
+			})
+
+			err := removeSymlink(context.Background(), tt.linkPath)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantMsg)
+			assert.False(t, sudoCalled)
+		})
+	}
+}


### PR DESCRIPTION
Foundation for Phase 2 privileged tool installation: installSymlink /
removeSymlink try the direct syscall first, escalate to `sudo -n ln -snf`
/ `sudo -n rm -f` only on permission error. Both refuse to act on
non-symlinks at linkPath and refuse any non-NotExist Lstat result to
prevent sudo from acting on un-classified targets. Assumes sudoHandler
has cached a ticket; the -n flag never prompts.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
