### PR TITLE
refactor(installer): parameterize Placer LinkPath by bin directory (#225)

### DIFF
--- a/cmd/tomei/apply.go
+++ b/cmd/tomei/apply.go
@@ -238,10 +238,9 @@ func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 	downloader := download.NewDownloaderWithClient(dlClient, download.WithDownloadTimeout(cfg.timeout))
 	toolsDir := pathConfig.UserDataDir() + "/tools"
 	runtimesDir := pathConfig.UserDataDir() + "/runtimes"
-	binDir := pathConfig.UserBinDir()
 
-	placer := place.NewPlacer(toolsDir, binDir)
-	toolInstaller := tool.NewInstaller(downloader, placer)
+	placer := place.NewPlacer(toolsDir)
+	toolInstaller := tool.NewInstaller(downloader, placer, pathConfig.UserBinDir())
 	runtimeInstaller := runtime.NewInstaller(downloader, runtimesDir)
 	reposDir := pathConfig.UserDataDir() + "/repositories"
 	repoInstaller := repository.NewInstaller(reposDir)

--- a/internal/installer/place/placer.go
+++ b/internal/installer/place/placer.go
@@ -3,6 +3,7 @@ package place
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -187,8 +188,7 @@ func (p *filePlacer) Symlink(target Target, binDir string) (string, error) {
 	// Reject empty / relative / root binDir before any syscall — a relative
 	// linkPath would resolve against the cwd of `tomei apply`, silently
 	// planting the symlink in whatever directory the operator ran from.
-	// Reuses the same checks #226's privileged path enforces.
-	if err := validateLinkPath(binDir); err != nil {
+	if err := validateBinDir(binDir); err != nil {
 		return "", err
 	}
 
@@ -237,6 +237,22 @@ func (p *filePlacer) Cleanup(path string) error {
 // ToolsDir returns the root tools directory path.
 func (p *filePlacer) ToolsDir() string {
 	return p.toolsDir
+}
+
+// validateBinDir rejects empty / non-absolute / "/" binDir values before any
+// syscall. Mirrors the three checks in validateLinkPath (symlink.go) but with
+// binDir-named error messages so failures from Placer methods are unambiguous.
+func validateBinDir(binDir string) error {
+	if binDir == "" {
+		return errors.New("placer: binDir is empty")
+	}
+	if !filepath.IsAbs(binDir) {
+		return fmt.Errorf("placer: binDir %q is not absolute", binDir)
+	}
+	if filepath.Clean(binDir) == "/" {
+		return errors.New("placer: binDir resolves to root directory")
+	}
+	return nil
 }
 
 // findBinary searches for a binary in srcDir and its subdirectories.

--- a/internal/installer/place/placer.go
+++ b/internal/installer/place/placer.go
@@ -52,8 +52,8 @@ type Placer interface {
 	// BinaryPath returns the full path where the binary would be placed.
 	BinaryPath(target Target) string
 
-	// LinkPath returns the full path where the symlink would be created.
-	LinkPath(target Target) string
+	// LinkPath returns the full path where the symlink would be created in binDir.
+	LinkPath(target Target, binDir string) string
 
 	// Validate checks the binary state and returns the required action.
 	// expectedHash is the expected SHA256 hash of the binary.
@@ -64,8 +64,9 @@ type Placer interface {
 	Place(srcDir string, target Target) (*Result, error)
 
 	// Symlink creates a symlink in binDir pointing to the placed binary.
-	// Returns the path to the created symlink.
-	Symlink(target Target) (string, error)
+	// Returns the path to the created symlink. Rejects empty, relative, or
+	// root binDir values to prevent silent cwd-relative symlinks.
+	Symlink(target Target, binDir string) (string, error)
 
 	// Cleanup removes a file or directory.
 	// Does not return error if path does not exist.
@@ -80,15 +81,12 @@ var _ Placer = (*filePlacer)(nil)
 // filePlacer implements Placer.
 type filePlacer struct {
 	toolsDir string // e.g., ~/.local/share/tomei/tools
-	binDir   string // e.g., ~/.local/bin
 }
 
-// NewPlacer creates a new Placer.
-func NewPlacer(toolsDir, binDir string) Placer {
-	return &filePlacer{
-		toolsDir: toolsDir,
-		binDir:   binDir,
-	}
+// NewPlacer creates a new Placer. The bin directory is per-call; the placer
+// holds no default — see LinkPath / Symlink.
+func NewPlacer(toolsDir string) Placer {
+	return &filePlacer{toolsDir: toolsDir}
 }
 
 // BinaryPath returns the full path where the binary would be placed.
@@ -96,9 +94,11 @@ func (p *filePlacer) BinaryPath(target Target) string {
 	return filepath.Join(p.toolsDir, target.Name, target.Version, target.BinaryName)
 }
 
-// LinkPath returns the full path where the symlink would be created.
-func (p *filePlacer) LinkPath(target Target) string {
-	return filepath.Join(p.binDir, target.BinaryName)
+// LinkPath returns the full path where the symlink would be created in binDir.
+// Pure path arithmetic — no validation; Symlink is where the syscall happens
+// and where bad binDir values are rejected.
+func (p *filePlacer) LinkPath(target Target, binDir string) string {
+	return filepath.Join(binDir, target.BinaryName)
 }
 
 // Validate checks the binary state and returns the required action.
@@ -183,9 +183,17 @@ func (p *filePlacer) Place(srcDir string, target Target) (*Result, error) {
 }
 
 // Symlink creates a symlink in binDir pointing to the placed binary.
-func (p *filePlacer) Symlink(target Target) (string, error) {
+func (p *filePlacer) Symlink(target Target, binDir string) (string, error) {
+	// Reject empty / relative / root binDir before any syscall — a relative
+	// linkPath would resolve against the cwd of `tomei apply`, silently
+	// planting the symlink in whatever directory the operator ran from.
+	// Reuses the same checks #226's privileged path enforces.
+	if err := validateLinkPath(binDir); err != nil {
+		return "", err
+	}
+
 	srcPath := filepath.Join(p.toolsDir, target.Name, target.Version, target.BinaryName)
-	slog.Debug("creating symlink", "src", srcPath, "binDir", p.binDir, "linkName", target.BinaryName)
+	slog.Debug("creating symlink", "src", srcPath, "binDir", binDir, "linkName", target.BinaryName)
 
 	// Verify source exists
 	if _, err := os.Stat(srcPath); os.IsNotExist(err) {
@@ -193,11 +201,11 @@ func (p *filePlacer) Symlink(target Target) (string, error) {
 	}
 
 	// Create binDir
-	if err := os.MkdirAll(p.binDir, 0755); err != nil {
+	if err := os.MkdirAll(binDir, 0755); err != nil {
 		return "", fmt.Errorf("failed to create bin directory: %w", err)
 	}
 
-	linkPath := filepath.Join(p.binDir, target.BinaryName)
+	linkPath := filepath.Join(binDir, target.BinaryName)
 
 	// Remove existing symlink if present
 	if _, err := os.Lstat(linkPath); err == nil {

--- a/internal/installer/place/placer_test.go
+++ b/internal/installer/place/placer_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestNewPlacer(t *testing.T) {
 	t.Parallel()
-	p := NewPlacer("/tools", "/bin")
+	p := NewPlacer("/tools")
 	assert.NotNil(t, p)
 }
 
@@ -93,11 +93,10 @@ func TestPlacer_Validate(t *testing.T) {
 			t.Parallel()
 			tmpDir := t.TempDir()
 			toolsDir := filepath.Join(tmpDir, "tools")
-			binDir := filepath.Join(tmpDir, "bin")
 
 			tt.setup(t, toolsDir, tt.target)
 
-			p := NewPlacer(toolsDir, binDir)
+			p := NewPlacer(toolsDir)
 			action, err := p.Validate(tt.target, tt.expectedHash)
 
 			if tt.wantErr {
@@ -239,14 +238,13 @@ func TestPlacer_Place(t *testing.T) {
 			tmpDir := t.TempDir()
 			srcDir := filepath.Join(tmpDir, "src")
 			toolsDir := filepath.Join(tmpDir, "tools")
-			binDir := filepath.Join(tmpDir, "bin")
 
 			err := os.MkdirAll(srcDir, 0755)
 			require.NoError(t, err)
 
 			tt.setup(t, srcDir)
 
-			p := NewPlacer(toolsDir, binDir)
+			p := NewPlacer(toolsDir)
 			result, err := p.Place(srcDir, tt.target)
 
 			if tt.wantErr {
@@ -347,8 +345,8 @@ func TestPlacer_Symlink(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			p := NewPlacer(toolsDir, binDir)
-			linkPath, err := p.Symlink(tt.target)
+			p := NewPlacer(toolsDir)
+			linkPath, err := p.Symlink(tt.target, binDir)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -368,6 +366,99 @@ func TestPlacer_Symlink(t *testing.T) {
 			actualTarget, err := os.Readlink(linkPath)
 			require.NoError(t, err)
 			assert.Equal(t, expectedTarget, actualTarget)
+		})
+	}
+}
+
+func TestPlacer_Symlink_RoutesToProvidedBinDir(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	toolsDir := filepath.Join(tmpDir, "tools")
+	userBinDir := filepath.Join(tmpDir, "userbin")
+	sysBinDir := filepath.Join(tmpDir, "sysbin")
+	target := Target{Name: "mytool", Version: "1.0.0", BinaryName: "tool"}
+
+	binPath := filepath.Join(toolsDir, target.Name, target.Version, target.BinaryName)
+	require.NoError(t, os.MkdirAll(filepath.Dir(binPath), 0755))
+	require.NoError(t, os.WriteFile(binPath, []byte("binary"), 0755))
+
+	p := NewPlacer(toolsDir)
+
+	gotUser, err := p.Symlink(target, userBinDir)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(userBinDir, target.BinaryName), gotUser)
+
+	gotSys, err := p.Symlink(target, sysBinDir)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(sysBinDir, target.BinaryName), gotSys)
+
+	// Both links must coexist — proves the placer carries no hidden bin-dir state.
+	userTarget, err := os.Readlink(gotUser)
+	require.NoError(t, err)
+	assert.Equal(t, binPath, userTarget)
+	sysTarget, err := os.Readlink(gotSys)
+	require.NoError(t, err)
+	assert.Equal(t, binPath, sysTarget)
+}
+
+func TestPlacer_LinkPath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		binDir string
+		target Target
+		want   string
+	}{
+		{
+			name:   "user binDir",
+			binDir: "/home/user/.local/bin",
+			target: Target{Name: "ripgrep", Version: "14.1.1", BinaryName: "rg"},
+			want:   "/home/user/.local/bin/rg",
+		},
+		{
+			name:   "system binDir",
+			binDir: "/usr/local/bin",
+			target: Target{Name: "kubectl", Version: "1.30.0", BinaryName: "kubectl"},
+			want:   "/usr/local/bin/kubectl",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := NewPlacer("/tools")
+			assert.Equal(t, tt.want, p.LinkPath(tt.target, tt.binDir))
+		})
+	}
+}
+
+func TestPlacer_Symlink_RejectsBadBinDir(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	toolsDir := filepath.Join(tmpDir, "tools")
+	target := Target{Name: "mytool", Version: "1.0.0", BinaryName: "tool"}
+
+	binPath := filepath.Join(toolsDir, target.Name, target.Version, target.BinaryName)
+	require.NoError(t, os.MkdirAll(filepath.Dir(binPath), 0755))
+	require.NoError(t, os.WriteFile(binPath, []byte("binary"), 0755))
+
+	tests := []struct {
+		name    string
+		binDir  string
+		wantMsg string
+	}{
+		{"empty", "", "is empty"},
+		{"relative", "relative/bin", "is not absolute"},
+		{"root", "/", "resolves to root"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := NewPlacer(toolsDir)
+			_, err := p.Symlink(target, tt.binDir)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantMsg)
 		})
 	}
 }
@@ -416,7 +507,7 @@ func TestPlacer_Cleanup(t *testing.T) {
 			tmpDir := t.TempDir()
 			path := tt.setup(t, tmpDir)
 
-			p := NewPlacer(filepath.Join(tmpDir, "tools"), filepath.Join(tmpDir, "bin"))
+			p := NewPlacer(filepath.Join(tmpDir, "tools"))
 			err := p.Cleanup(path)
 
 			if tt.wantErr {

--- a/internal/installer/tool/installer.go
+++ b/internal/installer/tool/installer.go
@@ -54,6 +54,7 @@ type CommandRunner interface {
 type Installer struct {
 	downloader       download.Downloader
 	placer           place.Placer
+	userBinDir       string // bin directory passed to placer for non-privileged installs
 	cmdExecutor      CommandRunner
 	versionResolver  *resolve.Resolver         // shared version resolver (optional)
 	runtimes         map[string]*RuntimeInfo   // name -> RuntimeInfo
@@ -66,11 +67,12 @@ type Installer struct {
 }
 
 // NewInstaller creates a new tool Installer.
-func NewInstaller(downloader download.Downloader, placer place.Placer) *Installer {
+func NewInstaller(downloader download.Downloader, placer place.Placer, userBinDir string) *Installer {
 	cmdExec := command.NewExecutor("")
 	return &Installer{
 		downloader:      downloader,
 		placer:          placer,
+		userBinDir:      userBinDir,
 		cmdExecutor:     cmdExec,
 		versionResolver: resolve.NewResolver(cmdExec, http.DefaultClient),
 		runtimes:        make(map[string]*RuntimeInfo),
@@ -79,10 +81,11 @@ func NewInstaller(downloader download.Downloader, placer place.Placer) *Installe
 }
 
 // NewInstallerWithRunner creates a new tool Installer with a custom CommandRunner (for testing).
-func NewInstallerWithRunner(downloader download.Downloader, placer place.Placer, runner CommandRunner) *Installer {
+func NewInstallerWithRunner(downloader download.Downloader, placer place.Placer, userBinDir string, runner CommandRunner) *Installer {
 	return &Installer{
 		downloader:  downloader,
 		placer:      placer,
+		userBinDir:  userBinDir,
 		cmdExecutor: runner,
 		runtimes:    make(map[string]*RuntimeInfo),
 		installers:  make(map[string]*InstallerInfo),
@@ -272,7 +275,7 @@ func (i *Installer) installByDownload(ctx context.Context, res *resource.Tool, n
 	case place.ValidateActionSkip:
 		slog.Debug("tool already installed, skipping", "name", name, "version", spec.Version)
 		// Even if binary exists, ensure symlink points to correct version
-		linkPath, err := i.placer.Symlink(target)
+		linkPath, err := i.placer.Symlink(target, i.userBinDir)
 		if err != nil {
 			return nil, fmt.Errorf("failed to update symlink: %w", err)
 		}
@@ -360,7 +363,7 @@ func (i *Installer) installByDownload(ctx context.Context, res *resource.Tool, n
 	}
 
 	// Create symlink
-	linkPath, err := i.placer.Symlink(target)
+	linkPath, err := i.placer.Symlink(target, i.userBinDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create symlink: %w", err)
 	}
@@ -554,7 +557,7 @@ func (i *Installer) buildState(spec *resource.ToolSpec, target place.Target, dig
 		SpecVersion:  spec.Version,
 		Digest:       digest,
 		InstallPath:  i.placer.BinaryPath(target),
-		BinPath:      i.placer.LinkPath(target),
+		BinPath:      i.placer.LinkPath(target, i.userBinDir),
 		Source:       spec.Source,
 		RuntimeRef:   spec.RuntimeRef,
 		Package:      spec.Package,

--- a/internal/installer/tool/installer_test.go
+++ b/internal/installer/tool/installer_test.go
@@ -27,9 +27,9 @@ import (
 func TestNewInstaller(t *testing.T) {
 	t.Parallel()
 	downloader := download.NewDownloader()
-	placer := place.NewPlacer("/tools", "/bin")
+	placer := place.NewPlacer("/tools")
 
-	installer := NewInstaller(downloader, placer)
+	installer := NewInstaller(downloader, placer, "/bin")
 	assert.NotNil(t, installer)
 }
 
@@ -86,7 +86,7 @@ func TestToolInstaller_Install(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := &mockDownloader{archiveData: tarGzContent}
-			installer := NewInstaller(dl, &mockPlacer{})
+			installer := NewInstaller(dl, &mockPlacer{}, "/bin")
 
 			state, err := installer.Install(context.Background(), tt.tool, tt.tool.Name())
 
@@ -108,6 +108,49 @@ func TestToolInstaller_Install(t *testing.T) {
 	}
 }
 
+// TestToolInstaller_PassesUserBinDirToPlacer pins the wire that the Installer
+// threads its userBinDir field into every binDir-taking Placer call. Without
+// this, a copy-paste regression (passing "" or i.toolsDir at any of the 3
+// callsites) would compile and other tests would still pass since mockPlacer
+// previously ignored its args.
+func TestToolInstaller_PassesUserBinDirToPlacer(t *testing.T) {
+	t.Parallel()
+	const sentinel = "/sentinel/bin"
+
+	binaryContent := []byte("#!/bin/sh\necho hello")
+	tarGzContent := createTarGzContent(t, "ripgrep", binaryContent)
+	archiveHash := sha256Hash(tarGzContent)
+
+	dl := &mockDownloader{archiveData: tarGzContent}
+	mp := &mockPlacer{}
+	installer := NewInstaller(dl, mp, sentinel)
+
+	tool := &resource.Tool{
+		BaseResource: resource.BaseResource{
+			Metadata: resource.Metadata{Name: "ripgrep"},
+		},
+		ToolSpec: &resource.ToolSpec{
+			InstallerRef: "download",
+			Version:      "14.1.1",
+			Source: &resource.DownloadSource{
+				URL:         "https://example.com/ripgrep.tar.gz",
+				Checksum:    &resource.Checksum{Value: "sha256:" + archiveHash},
+				ArchiveType: "tar.gz",
+			},
+		},
+	}
+
+	state, err := installer.Install(context.Background(), tool, tool.Name())
+	require.NoError(t, err)
+	require.NotNil(t, state)
+
+	require.NotEmpty(t, mp.gotSymlinkBinDirs, "Symlink must be called during install")
+	for _, got := range mp.gotSymlinkBinDirs {
+		assert.Equal(t, sentinel, got, "Symlink must receive the installer's userBinDir")
+	}
+	assert.Equal(t, sentinel, mp.gotLinkPathBinDir, "LinkPath must receive the installer's userBinDir")
+}
+
 func TestToolInstaller_Install_Skip(t *testing.T) {
 	t.Parallel()
 	binaryContent := []byte("#!/bin/sh\necho hello")
@@ -124,8 +167,8 @@ func TestToolInstaller_Install_Skip(t *testing.T) {
 	require.NoError(t, err)
 
 	downloader := download.NewDownloader()
-	placer := place.NewPlacer(toolsDir, binDir)
-	inst := NewInstaller(downloader, placer)
+	placer := place.NewPlacer(toolsDir)
+	inst := NewInstaller(downloader, placer, binDir)
 
 	// No checksum - will skip if binary exists
 	tool := &resource.Tool{
@@ -158,8 +201,8 @@ func TestToolInstaller_InstallFromRegistry_NoResolver(t *testing.T) {
 	binDir := filepath.Join(tmpDir, "bin")
 
 	downloader := download.NewDownloader()
-	placer := place.NewPlacer(toolsDir, binDir)
-	installer := NewInstaller(downloader, placer)
+	placer := place.NewPlacer(toolsDir)
+	installer := NewInstaller(downloader, placer, binDir)
 
 	// No resolver set - should fail
 
@@ -190,8 +233,8 @@ func TestToolInstaller_InstallFromRegistry_NoRegistryRef(t *testing.T) {
 	cacheDir := filepath.Join(tmpDir, "cache")
 
 	downloader := download.NewDownloader()
-	placer := place.NewPlacer(toolsDir, binDir)
-	installer := NewInstaller(downloader, placer)
+	placer := place.NewPlacer(toolsDir)
+	installer := NewInstaller(downloader, placer, binDir)
 
 	// Set resolver but no registry ref
 	resolver := createMockResolver(t, cacheDir, "http://example.com")
@@ -284,14 +327,19 @@ func (m *mockDownloader) Verify(_ context.Context, _ string, cs *resource.Checks
 }
 
 // mockPlacer always returns install action and succeeds.
-type mockPlacer struct{}
+// Captures binDir args from Symlink / LinkPath for sentinel assertions.
+type mockPlacer struct {
+	gotSymlinkBinDirs []string
+	gotLinkPathBinDir string
+}
 
 func (m *mockPlacer) BinaryPath(target place.Target) string {
 	return "/tools/" + target.Name + "/" + target.Version + "/" + target.BinaryName
 }
 
-func (m *mockPlacer) LinkPath(target place.Target) string {
-	return "/bin/" + target.BinaryName
+func (m *mockPlacer) LinkPath(target place.Target, binDir string) string {
+	m.gotLinkPathBinDir = binDir
+	return binDir + "/" + target.BinaryName
 }
 
 func (m *mockPlacer) Validate(_ place.Target, _ string) (place.ValidateAction, error) {
@@ -304,8 +352,9 @@ func (m *mockPlacer) Place(_ string, target place.Target) (*place.Result, error)
 	}, nil
 }
 
-func (m *mockPlacer) Symlink(target place.Target) (string, error) {
-	return "/bin/" + target.BinaryName, nil
+func (m *mockPlacer) Symlink(target place.Target, binDir string) (string, error) {
+	m.gotSymlinkBinDirs = append(m.gotSymlinkBinDirs, binDir)
+	return binDir + "/" + target.BinaryName, nil
 }
 
 func (m *mockPlacer) Cleanup(_ string) error {
@@ -384,7 +433,7 @@ func TestToolInstaller_Install_Args(t *testing.T) {
 			tmpDir := t.TempDir()
 			captureFile := filepath.Join(tmpDir, "captured_cmd.txt")
 
-			inst := NewInstaller(download.NewDownloader(), place.NewPlacer(filepath.Join(tmpDir, "tools"), filepath.Join(tmpDir, "bin")))
+			inst := NewInstaller(download.NewDownloader(), place.NewPlacer(filepath.Join(tmpDir, "tools")), filepath.Join(tmpDir, "bin"))
 			tt.setup(inst, captureFile)
 
 			tool := tt.tool(captureFile)
@@ -454,7 +503,7 @@ func TestToolInstaller_ProgressCallback_Priority(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := &mockDownloader{archiveData: archiveData}
-			installer := NewInstaller(dl, &mockPlacer{})
+			installer := NewInstaller(dl, &mockPlacer{}, "/bin")
 
 			var fieldCalled, ctxCalled bool
 
@@ -767,7 +816,7 @@ func TestInstallByCommands(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			runner := &mockCommandRunner{checkResult: tt.checkResult, executeErr: tt.executeErr}
-			inst := NewInstallerWithRunner(download.NewDownloader(), &mockPlacer{}, runner)
+			inst := NewInstallerWithRunner(download.NewDownloader(), &mockPlacer{}, "/bin", runner)
 
 			if tt.resolver != nil {
 				inst.SetVersionResolver(resolve.NewResolver(tt.resolver, nil))
@@ -860,7 +909,7 @@ func TestRemoveByCommands(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			runner := &mockCommandRunner{checkResult: true, executeErr: tt.executeErr}
-			inst := NewInstallerWithRunner(download.NewDownloader(), &mockPlacer{}, runner)
+			inst := NewInstallerWithRunner(download.NewDownloader(), &mockPlacer{}, "/bin", runner)
 
 			err := inst.Remove(context.Background(), tt.state, "mytool")
 
@@ -907,7 +956,7 @@ func TestInstallFromRegistry_ChecksumAlgorithmPropagation(t *testing.T) {
 	require.NoError(t, os.WriteFile(cacheFile, []byte(registryYAML), 0o644))
 
 	dl := &mockDownloader{archiveData: tarGzContent}
-	inst := NewInstaller(dl, &mockPlacer{})
+	inst := NewInstaller(dl, &mockPlacer{}, "/bin")
 
 	resolver := aqua.NewResolver(cacheDir, nil)
 	inst.SetResolver(resolver, ref)

--- a/tests/tool_installer_test.go
+++ b/tests/tool_installer_test.go
@@ -49,8 +49,8 @@ func TestToolInstaller_Install_HTTP(t *testing.T) {
 	binDir := filepath.Join(tmpDir, "bin")
 
 	dl := download.NewDownloader()
-	placer := place.NewPlacer(toolsDir, binDir)
-	installer := toolpkg.NewInstaller(dl, placer)
+	placer := place.NewPlacer(toolsDir)
+	installer := toolpkg.NewInstaller(dl, placer, binDir)
 
 	tool := &resource.Tool{
 		BaseResource: resource.BaseResource{
@@ -121,8 +121,8 @@ func TestToolInstaller_InstallFromRegistry_HTTP(t *testing.T) {
 	cacheDir := filepath.Join(tmpDir, "cache")
 
 	dl := download.NewDownloader()
-	placer := place.NewPlacer(toolsDir, binDir)
-	installer := toolpkg.NewInstaller(dl, placer)
+	placer := place.NewPlacer(toolsDir)
+	installer := toolpkg.NewInstaller(dl, placer, binDir)
 
 	resolver := aqua.NewResolverWithBaseURL(cacheDir, server.URL)
 	installer.SetResolver(resolver, "v4.465.0")
@@ -179,8 +179,8 @@ func TestToolInstaller_Install_HTTP_BinaryName(t *testing.T) {
 	binDir := filepath.Join(tmpDir, "bin")
 
 	dl := download.NewDownloader()
-	placer := place.NewPlacer(toolsDir, binDir)
-	installer := toolpkg.NewInstaller(dl, placer)
+	placer := place.NewPlacer(toolsDir)
+	installer := toolpkg.NewInstaller(dl, placer, binDir)
 
 	tool := &resource.Tool{
 		BaseResource: resource.BaseResource{
@@ -251,8 +251,8 @@ func TestToolInstaller_InstallFromRegistry_HTTP_BinaryName(t *testing.T) {
 	cacheDir := filepath.Join(tmpDir, "cache")
 
 	dl := download.NewDownloader()
-	placer := place.NewPlacer(toolsDir, binDir)
-	installer := toolpkg.NewInstaller(dl, placer)
+	placer := place.NewPlacer(toolsDir)
+	installer := toolpkg.NewInstaller(dl, placer, binDir)
 
 	resolver := aqua.NewResolverWithBaseURL(cacheDir, server.URL)
 	installer.SetResolver(resolver, "v4.465.0")
@@ -302,8 +302,8 @@ func TestToolInstaller_Install_HTTP_BinaryName_OldSymlinkCleanup(t *testing.T) {
 	binDir := filepath.Join(tmpDir, "bin")
 
 	dl := download.NewDownloader()
-	placer := place.NewPlacer(toolsDir, binDir)
-	installer := toolpkg.NewInstaller(dl, placer)
+	placer := place.NewPlacer(toolsDir)
+	installer := toolpkg.NewInstaller(dl, placer, binDir)
 
 	// First install: no binaryName override → symlink at binDir/krew
 	tool1 := &resource.Tool{


### PR DESCRIPTION
Threads `binDir` through `Placer.LinkPath` / `Placer.Symlink` as a per-call
parameter instead of capturing one bin directory at construction time. Adds
`userBinDir` to `tool.Installer` so the value flows from a single source of
truth at the call site. Behavior unchanged — every caller still passes
`UserBinDir`. SUB5 (#228) will branch on `spec.Privileged` to pass
`SystemBinDir` for privileged tools, which becomes a value-flip rather than
an API expansion.

Reuses `validateLinkPath` from #226 to reject empty/relative/root binDir
values; an empty or relative binDir would let `os.Symlink` plant the link
under the apply-command cwd.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
