### PR TITLE
feat(resource): extend Tool.IsPrivileged for download/registry, reject privileged+runtimeRef (#227)

### DIFF
--- a/internal/resource/expand.go
+++ b/internal/resource/expand.go
@@ -74,12 +74,11 @@ func ExpandSets(resources []Resource) ([]Resource, error) {
 }
 
 // IsPrivileged reports whether a resource requires privileged (sudo) execution.
-// Only Tool resources using the commands pattern (spec.commands set) actually
-// honor the privileged flag — other install patterns (download, registry,
-// delegation) ignore it. All other kinds return false.
+// Tool resources honor the privileged flag for Commands and download/registry
+// install patterns; see Tool.IsPrivileged for the full predicate. All other
+// kinds return false.
 func IsPrivileged(res Resource) bool {
 	if t, ok := res.(*Tool); ok {
-		// Tool.IsPrivileged already constrains this to command-based tools.
 		return t.IsPrivileged()
 	}
 	return false

--- a/internal/resource/expand.go
+++ b/internal/resource/expand.go
@@ -73,10 +73,12 @@ func ExpandSets(resources []Resource) ([]Resource, error) {
 	return result, nil
 }
 
-// IsPrivileged reports whether a resource requires privileged (sudo) execution.
-// Tool resources honor the privileged flag for Commands and download/registry
-// install patterns; see Tool.IsPrivileged for the full predicate. All other
-// kinds return false.
+// IsPrivileged reports whether a resource requires --system. Tool resources
+// honor the privileged flag for Commands and download/registry install
+// patterns; see Tool.IsPrivileged for the full predicate. Note this gates the
+// --system requirement and does not by itself imply sudo execution (download/
+// registry tools are placed by tomei, not run via sudo). All other kinds
+// return false.
 func IsPrivileged(res Resource) bool {
 	if t, ok := res.(*Tool); ok {
 		return t.IsPrivileged()

--- a/internal/resource/expand_test.go
+++ b/internal/resource/expand_test.go
@@ -640,7 +640,7 @@ func TestIsPrivileged(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "privileged tool without commands (non-commands pattern ignores privileged)",
+			name: "privileged tool with no install method",
 			res:  &Tool{ToolSpec: &ToolSpec{Privileged: true}},
 			want: false,
 		},
@@ -658,6 +658,19 @@ func TestIsPrivileged(t *testing.T) {
 			name: "runtime (not a tool)",
 			res:  &Runtime{RuntimeSpec: &RuntimeSpec{Version: "1.22.0"}},
 			want: false,
+		},
+		{
+			// Smoke test for non-Commands privileged → IsPrivileged delegation
+			// to Tool.IsPrivileged. Full pattern matrix lives in
+			// TestTool_IsPrivileged (tool_test.go).
+			name: "privileged download tool delegates through to Tool.IsPrivileged",
+			res: &Tool{ToolSpec: &ToolSpec{
+				InstallerRef: "aqua",
+				Version:      "1.0.0",
+				Source:       &DownloadSource{URL: "https://example.com/tool.tar.gz"},
+				Privileged:   true,
+			}},
+			want: true,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/resource/tool.go
+++ b/internal/resource/tool.go
@@ -279,14 +279,16 @@ type ToolSpec struct {
 	//     user and escalate internally (e.g., Homebrew) work with
 	//     Privileged alone.
 	//
-	//   - Download / Registry (InstallerRef set, no RuntimeRef, Package is
-	//     registry or empty): the binary is placed under SystemBinDir
-	//     (/usr/local/bin) via a sudo-backed symlink. This field gates
-	//     routing to SystemBinDir.
+	//   - Download (Source set) / Registry (owner/repo Package via aqua):
+	//     tomei downloads and places the binary itself. Today this gates
+	//     the --system requirement; the planned follow-up routes these
+	//     placements under SystemBinDir (/usr/local/bin) via a sudo-backed
+	//     symlink rather than the user bin dir.
 	//
-	//   - Name-delegation (InstallerRef set + Package.IsName(), e.g.
-	//     "go install" / "cargo install"): ignored. The runtime or
-	//     installer owns the destination directory.
+	//   - Installer- / name-delegation (InstallerRef with no Source and a
+	//     non-registry Package, e.g. "go install" / "cargo install" /
+	//     helm): ignored. The installer or runtime owns the destination
+	//     directory.
 	//
 	//   - Runtime delegation (RuntimeRef set): rejected by Validate —
 	//     Privileged + RuntimeRef has no coherent meaning.
@@ -410,9 +412,10 @@ func (t *Tool) IsEnabled() bool {
 }
 
 // IsPrivileged reports whether this tool requires --system. The predicate
-// honors the privileged flag for Commands and for download/registry install
-// patterns; it ignores the flag for name-delegation (runtime-managed dir)
-// and for RuntimeRef (rejected by Validate).
+// honors the privileged flag only for patterns where tomei itself places the
+// binary: Commands, download (Source), and registry (aqua / owner-repo
+// Package). For installer- or runtime-delegation the installer/runtime owns
+// the destination directory, so privileged is ignored.
 func (t *Tool) IsPrivileged() bool {
 	if t.ToolSpec == nil || !t.ToolSpec.Privileged {
 		return false
@@ -421,19 +424,17 @@ func (t *Tool) IsPrivileged() bool {
 	switch {
 	case s.Commands != nil:
 		return true
-	case s.RuntimeRef != "":
-		// Validate forbids Privileged+RuntimeRef; this arm defends a
-		// pre-Validate or migrated spec from falling through to the
-		// default-true arm.
-		return false
-	case s.InstallerRef == "":
-		return false
-	case s.Package != nil && s.Package.IsName():
-		// Name-delegation (e.g. installerRef: go + package.name: ...)
-		// lands in runtime-managed dirs, not SystemBinDir.
-		return false
-	default:
+	case s.Source != nil:
+		// Download pattern: tomei downloads and places the binary.
 		return true
+	case s.Package.IsRegistry():
+		// Registry pattern (aqua): tomei resolves the URL and places the binary.
+		return true
+	default:
+		// Name-/installer-delegation and runtime delegation let the
+		// installer or runtime own the destination dir, so privileged is
+		// ignored. RuntimeRef additionally fails Validate.
+		return false
 	}
 }
 

--- a/internal/resource/tool.go
+++ b/internal/resource/tool.go
@@ -268,7 +268,10 @@ type ToolSpec struct {
 	// Example: ["--with-executables-from", "ansible-core"] for uv tool install.
 	Args []string `json:"args,omitempty"`
 
-	// Privileged declares that this tool requires --system to install.
+	// Privileged is honored only for specific install patterns (Commands and
+	// the tomei-managed download/registry patterns); for those it makes the
+	// tool require --system (and be skipped without it). For installer-/name-
+	// delegation it is ignored, and with RuntimeRef it is a Validate error.
 	// Semantics depend on the install pattern:
 	//
 	//   - Commands: tomei pre-acquires a cached sudo timestamp so "sudo ..."
@@ -412,8 +415,9 @@ func (t *Tool) IsEnabled() bool {
 }
 
 // IsPrivileged reports whether this tool requires --system. The predicate
-// honors the privileged flag only for patterns where tomei itself places the
-// binary: Commands, download (Source), and registry (aqua / owner-repo
+// honors the privileged flag for two kinds of pattern: Commands (where it
+// gates a cached sudo timestamp for the user's commands) and the tomei-managed
+// placement patterns, download (Source) and registry (aqua / owner-repo
 // Package). For installer- or runtime-delegation the installer/runtime owns
 // the destination directory, so privileged is ignored.
 func (t *Tool) IsPrivileged() bool {

--- a/internal/resource/tool.go
+++ b/internal/resource/tool.go
@@ -424,16 +424,22 @@ func (t *Tool) IsPrivileged() bool {
 	switch {
 	case s.Commands != nil:
 		return true
+	case s.InstallerRef == "":
+		// Without an installer there is no tomei-managed placement to
+		// escalate: runtime delegation and any spec lacking an install
+		// method fall out here (RuntimeRef additionally fails Validate).
+		return false
 	case s.Source != nil:
 		// Download pattern: tomei downloads and places the binary.
 		return true
 	case s.Package.IsRegistry():
-		// Registry pattern (aqua): tomei resolves the URL and places the binary.
+		// Registry pattern (aqua): tomei resolves the URL and places the
+		// binary. Validate enforces that a registry Package requires
+		// installerRef: aqua, so we don't re-check the installer here.
 		return true
 	default:
-		// Name-/installer-delegation and runtime delegation let the
-		// installer or runtime own the destination dir, so privileged is
-		// ignored. RuntimeRef additionally fails Validate.
+		// Installer-/name-delegation lets the installer own the
+		// destination dir, so privileged is ignored.
 		return false
 	}
 }

--- a/internal/resource/tool.go
+++ b/internal/resource/tool.go
@@ -268,20 +268,30 @@ type ToolSpec struct {
 	// Example: ["--with-executables-from", "ansible-core"] for uv tool install.
 	Args []string `json:"args,omitempty"`
 
-	// Privileged declares that this tool's Commands require a cached sudo
-	// timestamp while they run. Only meaningful together with Commands;
-	// ignored for other install patterns (InstallerRef, RuntimeRef).
+	// Privileged declares that this tool requires --system to install.
+	// Semantics depend on the install pattern:
 	//
-	// The commands themselves always execute as the invoking user via
-	// "sh -c" — tomei does not wrap them in sudo. With --system, tomei
-	// pre-acquires a sudo timestamp so that "sudo ..." invocations inside
-	// the command can use the cached ticket without re-prompting, subject
-	// to the host's sudoers policy. Without --system, privileged tools
-	// are skipped.
+	//   - Commands: tomei pre-acquires a cached sudo timestamp so "sudo ..."
+	//     invocations inside the command run without re-prompting. The
+	//     commands themselves execute as the invoking user via "sh -c";
+	//     tomei does not wrap them in sudo. If a step must run as root,
+	//     write it as "sudo <cmd>" explicitly. Installers that run as the
+	//     user and escalate internally (e.g., Homebrew) work with
+	//     Privileged alone.
 	//
-	// If a step must run as root, write it as "sudo <cmd>" explicitly in
-	// the command string. Installers that run as the user and escalate
-	// internally (e.g., Homebrew) work with Privileged alone.
+	//   - Download / Registry (InstallerRef set, no RuntimeRef, Package is
+	//     registry or empty): the binary is placed under SystemBinDir
+	//     (/usr/local/bin) via a sudo-backed symlink. This field gates
+	//     routing to SystemBinDir.
+	//
+	//   - Name-delegation (InstallerRef set + Package.IsName(), e.g.
+	//     "go install" / "cargo install"): ignored. The runtime or
+	//     installer owns the destination directory.
+	//
+	//   - Runtime delegation (RuntimeRef set): rejected by Validate —
+	//     Privileged + RuntimeRef has no coherent meaning.
+	//
+	// Without --system, privileged tools are skipped.
 	//
 	// Migration note: earlier versions wrapped the entire command in
 	// "sudo -n sh -c ..." when Privileged was set. Manifests that relied
@@ -320,6 +330,12 @@ func (s *ToolSpec) Validate() error {
 	}
 	if (hasInstaller && hasRuntime) || (hasRuntime && hasCommands) || (hasInstaller && hasCommands) {
 		return fmt.Errorf("installerRef, runtimeRef, and commands are mutually exclusive")
+	}
+
+	// Privileged + RuntimeRef has no coherent semantics: runtime-managed install
+	// dirs are owned by the runtime, not tomei, so there is nothing to escalate.
+	if s.Privileged && hasRuntime {
+		return fmt.Errorf("privileged: true is not supported with runtimeRef")
 	}
 
 	// Commands must have at least Install
@@ -393,14 +409,32 @@ func (t *Tool) IsEnabled() bool {
 	return t.ToolSpec.IsEnabled()
 }
 
-// IsPrivileged returns true if this tool declares that its install/update/
-// remove commands expect a cached sudo timestamp (i.e. require --system).
-// The privileged flag is only meaningful for command-based tools
-// (spec.commands set); other install patterns (download, registry,
-// delegation) ignore it, so this method returns false for them even when
-// spec.privileged is true.
+// IsPrivileged reports whether this tool requires --system. The predicate
+// honors the privileged flag for Commands and for download/registry install
+// patterns; it ignores the flag for name-delegation (runtime-managed dir)
+// and for RuntimeRef (rejected by Validate).
 func (t *Tool) IsPrivileged() bool {
-	return t.ToolSpec != nil && t.ToolSpec.Commands != nil && t.ToolSpec.Privileged
+	if t.ToolSpec == nil || !t.ToolSpec.Privileged {
+		return false
+	}
+	s := t.ToolSpec
+	switch {
+	case s.Commands != nil:
+		return true
+	case s.RuntimeRef != "":
+		// Validate forbids Privileged+RuntimeRef; this arm defends a
+		// pre-Validate or migrated spec from falling through to the
+		// default-true arm.
+		return false
+	case s.InstallerRef == "":
+		return false
+	case s.Package != nil && s.Package.IsName():
+		// Name-delegation (e.g. installerRef: go + package.name: ...)
+		// lands in runtime-managed dirs, not SystemBinDir.
+		return false
+	default:
+		return true
+	}
 }
 
 // IsEnabled returns whether the tool spec is enabled.

--- a/internal/resource/tool_test.go
+++ b/internal/resource/tool_test.go
@@ -211,6 +211,66 @@ func TestToolSpec_Validate(t *testing.T) {
 			},
 			wantErr: "cannot specify both owner/repo and name",
 		},
+		{
+			name: "privileged + runtimeRef rejected",
+			spec: &ToolSpec{
+				RuntimeRef: "go",
+				Package:    &Package{Name: "golang.org/x/tools/gopls"},
+				Privileged: true,
+			},
+			wantErr: "privileged: true is not supported with runtimeRef",
+		},
+		{
+			name: "privileged + commands accepted",
+			spec: &ToolSpec{
+				Commands: &ToolCommandSet{
+					CommandSet: CommandSet{Install: []string{"curl -fsSL https://example.com/install.sh | sudo sh"}},
+				},
+				Privileged: true,
+			},
+			wantErr: "",
+		},
+		{
+			name: "privileged + download accepted",
+			spec: &ToolSpec{
+				InstallerRef: "aqua",
+				Version:      "1.0.0",
+				Source:       &DownloadSource{URL: "https://example.com/tool.tar.gz"},
+				Privileged:   true,
+			},
+			wantErr: "",
+		},
+		{
+			name: "privileged + registry accepted",
+			spec: &ToolSpec{
+				InstallerRef: "aqua",
+				Package:      &Package{Owner: "cli", Repo: "cli"},
+				Privileged:   true,
+			},
+			wantErr: "",
+		},
+		{
+			// Ordering pin (above): empty spec + Privileged=true must hit the
+			// "one of installerRef..." error before the new privileged check.
+			// Locks the privileged check below mutual-exclusivity.
+			name: "privileged on empty spec hits install-method-required first",
+			spec: &ToolSpec{
+				Privileged: true,
+			},
+			wantErr: "one of installerRef, runtimeRef, or commands is required",
+		},
+		{
+			// Ordering pin (below): privileged + runtimeRef without Package
+			// must hit the new privileged error, not "package is required
+			// when using runtimeRef". Locks the privileged check above the
+			// runtime-requires-package check.
+			name: "privileged + runtimeRef without package hits privileged error first",
+			spec: &ToolSpec{
+				RuntimeRef: "go",
+				Privileged: true,
+			},
+			wantErr: "privileged: true is not supported with runtimeRef",
+		},
 	}
 
 	for _, tt := range tests {
@@ -222,6 +282,94 @@ func TestToolSpec_Validate(t *testing.T) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 			}
+		})
+	}
+}
+
+func TestTool_IsPrivileged(t *testing.T) {
+	t.Parallel()
+	commandsSpec := func(priv bool) *ToolSpec {
+		return &ToolSpec{
+			Commands:   &ToolCommandSet{CommandSet: CommandSet{Install: []string{"echo ok"}}},
+			Privileged: priv,
+		}
+	}
+	tests := []struct {
+		name string
+		tool *Tool
+		want bool
+	}{
+		{
+			name: "nil spec",
+			tool: &Tool{},
+			want: false,
+		},
+		{
+			name: "privileged=false on commands",
+			tool: &Tool{ToolSpec: commandsSpec(false)},
+			want: false,
+		},
+		{
+			name: "privileged=true on commands",
+			tool: &Tool{ToolSpec: commandsSpec(true)},
+			want: true,
+		},
+		{
+			name: "privileged=true on download (installerRef + source + version)",
+			tool: &Tool{ToolSpec: &ToolSpec{
+				InstallerRef: "aqua",
+				Version:      "1.0.0",
+				Source:       &DownloadSource{URL: "https://example.com/tool.tar.gz"},
+				Privileged:   true,
+			}},
+			want: true,
+		},
+		{
+			name: "privileged=true on registry (installerRef=aqua + owner/repo)",
+			tool: &Tool{ToolSpec: &ToolSpec{
+				InstallerRef: "aqua",
+				Package:      &Package{Owner: "cli", Repo: "cli"},
+				Privileged:   true,
+			}},
+			want: true,
+		},
+		{
+			name: "privileged=true on registry-implicit (installerRef=aqua + version only)",
+			tool: &Tool{ToolSpec: &ToolSpec{
+				InstallerRef: "aqua",
+				Version:      "1.0.0",
+				Privileged:   true,
+			}},
+			want: true,
+		},
+		{
+			name: "privileged=true on name-delegation (installerRef=go + package.name)",
+			tool: &Tool{ToolSpec: &ToolSpec{
+				InstallerRef: "go",
+				Package:      &Package{Name: "golang.org/x/tools/gopls"},
+				Privileged:   true,
+			}},
+			want: false,
+		},
+		{
+			name: "privileged=true on runtimeRef (defensive — Validate rejects)",
+			tool: &Tool{ToolSpec: &ToolSpec{
+				RuntimeRef: "go",
+				Package:    &Package{Name: "golang.org/x/tools/gopls"},
+				Privileged: true,
+			}},
+			want: false,
+		},
+		{
+			name: "privileged=true but no install method",
+			tool: &Tool{ToolSpec: &ToolSpec{Privileged: true}},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.tool.IsPrivileged())
 		})
 	}
 }

--- a/internal/resource/tool_test.go
+++ b/internal/resource/tool_test.go
@@ -334,13 +334,15 @@ func TestTool_IsPrivileged(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "privileged=true on registry-implicit (installerRef=aqua + version only)",
+			// installerRef + version only (no Source, no registry Package) is
+			// not a tomei-placed tool, so privileged is ignored.
+			name: "privileged=true on installerRef + version only",
 			tool: &Tool{ToolSpec: &ToolSpec{
 				InstallerRef: "aqua",
 				Version:      "1.0.0",
 				Privileged:   true,
 			}},
-			want: true,
+			want: false,
 		},
 		{
 			name: "privileged=true on name-delegation (installerRef=go + package.name)",


### PR DESCRIPTION
Recognize privileged download- and registry-pattern tools (not just
Commands) so they can later be routed to SystemBinDir, and promote the
incoherent Privileged+RuntimeRef combination from silently-ignored to a
Validate error.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
