### PR TITLE
feat(resource): add ToolState.BinDirKind with read-time backward-compat default (#229)

### DIFF
--- a/internal/installer/tool/installer.go
+++ b/internal/installer/tool/installer.go
@@ -558,6 +558,7 @@ func (i *Installer) buildState(spec *resource.ToolSpec, target place.Target, dig
 		Digest:       digest,
 		InstallPath:  i.placer.BinaryPath(target),
 		BinPath:      i.placer.LinkPath(target, i.userBinDir),
+		BinDirKind:   resource.BinDirKindUser,
 		Source:       spec.Source,
 		RuntimeRef:   spec.RuntimeRef,
 		Package:      spec.Package,

--- a/internal/installer/tool/installer_test.go
+++ b/internal/installer/tool/installer_test.go
@@ -104,6 +104,8 @@ func TestToolInstaller_Install(t *testing.T) {
 			assert.Equal(t, tt.tool.ToolSpec.Version, state.Version)
 			assert.NotEmpty(t, state.InstallPath)
 			assert.NotEmpty(t, state.BinPath)
+			assert.Equal(t, resource.BinDirKindUser, state.BinDirKind,
+				"download/registry install should stamp BinDirKindUser so the gap closes on next apply (SUB6 #229)")
 		})
 	}
 }

--- a/internal/resource/tool.go
+++ b/internal/resource/tool.go
@@ -690,6 +690,16 @@ type ToolState struct {
 	// `tomei apply --system` to refresh state before triggering removal.
 	Privileged bool `json:"privileged,omitempty"`
 
+	// BinDirKind records which bin directory this tool's symlink lives in
+	// ("user" or "system"). Empty in pre-SUB6 state files; read via
+	// BinDirKindOrDefault, which treats empty as user. Privileged download/
+	// registry tools (routed by SUB5) will carry "system" here.
+	//
+	// Set independently of Privileged: SUB5's routing decides the bin dir,
+	// and Privileged tracks sudo-wrapping of commands. Do not derive one
+	// from the other.
+	BinDirKind BinDirKind `json:"binDirKind,omitempty"`
+
 	// TaintReason indicates why this tool needs reinstallation.
 	// Empty string means the tool is not tainted.
 	TaintReason TaintReason `json:"taintReason,omitempty"`
@@ -707,6 +717,17 @@ func (t *ToolState) GetBinPath() string {
 		return ""
 	}
 	return t.BinPath
+}
+
+// BinDirKindOrDefault returns the tool's bin-directory classification,
+// treating an empty value (pre-SUB6 state files, or a nil receiver) as
+// BinDirKindUser. The getter does not validate non-empty values: an unknown
+// kind passes through unchanged.
+func (t *ToolState) BinDirKindOrDefault() BinDirKind {
+	if t == nil || t.BinDirKind == "" {
+		return BinDirKindUser
+	}
+	return t.BinDirKind
 }
 
 // IsTainted returns true if the tool needs reinstallation.

--- a/internal/resource/tool_test.go
+++ b/internal/resource/tool_test.go
@@ -1298,6 +1298,97 @@ func TestToolState_GetBinPath(t *testing.T) {
 	assert.Empty(t, emptyState.GetBinPath())
 }
 
+func TestToolState_BinDirKindOrDefault(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		state *ToolState
+		want  BinDirKind
+	}{
+		{name: "nil receiver defaults to user", state: nil, want: BinDirKindUser},
+		{name: "empty field defaults to user", state: &ToolState{}, want: BinDirKindUser},
+		{name: "explicit user", state: &ToolState{BinDirKind: BinDirKindUser}, want: BinDirKindUser},
+		{name: "explicit system", state: &ToolState{BinDirKind: BinDirKindSystem}, want: BinDirKindSystem},
+		{name: "unknown value passes through unchanged", state: &ToolState{BinDirKind: BinDirKind("bogus")}, want: BinDirKind("bogus")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.state.BinDirKindOrDefault())
+		})
+	}
+}
+
+func TestToolState_BinDirKind_JSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("pre-SUB6 state without binDirKind unmarshals to empty and defaults to user", func(t *testing.T) {
+		t.Parallel()
+		// A representative pre-SUB6 state JSON (no binDirKind key).
+		blob := `{"installerRef":"aqua","version":"2.0.0","installPath":"/foo","binPath":"/home/user/.local/bin/foo","versionKind":"exact","updatedAt":"2025-01-01T00:00:00Z"}`
+		var got ToolState
+		require.NoError(t, json.Unmarshal([]byte(blob), &got))
+		assert.Equal(t, BinDirKind(""), got.BinDirKind)
+		assert.Equal(t, BinDirKindUser, got.BinDirKindOrDefault())
+	})
+
+	t.Run("explicit system unmarshals", func(t *testing.T) {
+		t.Parallel()
+		blob := `{"installerRef":"aqua","version":"2.0.0","installPath":"/foo","binPath":"/usr/local/bin/foo","versionKind":"exact","binDirKind":"system","updatedAt":"2025-01-01T00:00:00Z"}`
+		var got ToolState
+		require.NoError(t, json.Unmarshal([]byte(blob), &got))
+		assert.Equal(t, BinDirKindSystem, got.BinDirKind)
+		assert.Equal(t, BinDirKindSystem, got.BinDirKindOrDefault())
+	})
+
+	t.Run("empty BinDirKind is omitted on marshal", func(t *testing.T) {
+		t.Parallel()
+		st := &ToolState{
+			InstallerRef: "aqua",
+			Version:      "2.0.0",
+			VersionKind:  VersionExact,
+			UpdatedAt:    time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		}
+		data, err := json.Marshal(st)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), "binDirKind")
+	})
+
+	t.Run("explicit BinDirKindSystem is present on marshal", func(t *testing.T) {
+		t.Parallel()
+		st := &ToolState{
+			InstallerRef: "aqua",
+			Version:      "2.0.0",
+			VersionKind:  VersionExact,
+			BinDirKind:   BinDirKindSystem,
+			UpdatedAt:    time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		}
+		data, err := json.Marshal(st)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"binDirKind":"system"`)
+	})
+
+	t.Run("round-trip preserves user and system", func(t *testing.T) {
+		t.Parallel()
+		for _, kind := range []BinDirKind{BinDirKindUser, BinDirKindSystem} {
+			original := &ToolState{
+				InstallerRef: "aqua",
+				Version:      "2.0.0",
+				VersionKind:  VersionExact,
+				BinDirKind:   kind,
+				UpdatedAt:    time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			}
+			data, err := json.Marshal(original)
+			require.NoError(t, err)
+			var got ToolState
+			require.NoError(t, json.Unmarshal(data, &got))
+			assert.Equal(t, kind, got.BinDirKind)
+		}
+	})
+}
+
 func TestBuildToolFromSetItem(t *testing.T) {
 	t.Parallel()
 

--- a/internal/resource/types.go
+++ b/internal/resource/types.go
@@ -257,6 +257,23 @@ const (
 	TaintReasonUpdateRequested TaintReason = "update_requested"
 )
 
+// BinDirKind classifies which bin directory a tool's symlink lives in.
+// Persisted in ToolState so removal/reconciliation can locate the symlink
+// even when the manifest is absent. Empty in pre-SUB6 state files; treated
+// as BinDirKindUser via ToolState.BinDirKindOrDefault.
+type BinDirKind string
+
+const (
+	// BinDirKindUser indicates the symlink lives in the user's bin directory
+	// (e.g., ~/.local/bin). This is the default for tools that lack the field
+	// in older state files.
+	BinDirKindUser BinDirKind = "user"
+
+	// BinDirKindSystem indicates the symlink lives in the system bin directory
+	// (e.g., /usr/local/bin). Used by privileged download/registry tools.
+	BinDirKindSystem BinDirKind = "system"
+)
+
 // CommandSet defines a set of shell commands for install/check/remove operations.
 // This is the common type used by BootstrapSpec, CommandsSpec, and RuntimeBootstrapSpec.
 // Each command is a string slice; multiple entries are joined with " && " at execution time.


### PR DESCRIPTION
Add a BinDirKind classification ("user" or "system") to ToolState so removal
and reconciliation can locate a tool's symlink even when the manifest is no
longer present. Empty in pre-SUB6 state files; treated as user via the nil-safe
ToolState.BinDirKindOrDefault getter. The download/registry install path
(buildState) stamps BinDirKindUser so the gap closes on next apply.

The field is set independently of Privileged: SUB5 (#228) will route privileged
download/registry tools to the system bin dir and stamp BinDirKindSystem; SUB7
(#230) will gate on --system. SUB6 deliberately does not write "system" from
the installer and does not migrate filesystem layout.

Design choices argued: a getter over a custom UnmarshalJSON (ToolState has no
custom marshaling today; an alias-shim would be a maintenance hazard, and
defaulting-on-unmarshal would invisibly mutate loaded data); a named string
type BinDirKind over the issue's literal `string` (matches the existing
VersionKind / TaintReason enums in internal/resource/types.go).

Verified inert for reconciliation: ToolComparator (reconciler/tool.go) and
state.compareTools (state/diff.go) field-compare specific fields and do not
deep-equal the whole struct; `grep -rn reflect.DeepEqual internal/` → 0 hits.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
