### PR TITLE
feat(apply): explain privileged-skip reasons for both modes (#230)

### DIFF
--- a/cmd/tomei/apply.go
+++ b/cmd/tomei/apply.go
@@ -151,14 +151,7 @@ func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 
 	// Filter out privileged resources when --system is not set
 	if !system {
-		normal, privileged := resource.FilterPrivileged(userResources)
-		if len(privileged) > 0 {
-			for _, r := range privileged {
-				slog.Info("skipping privileged resource (use --system)", "kind", r.Kind(), "name", r.Name())
-			}
-			fmt.Fprintf(w, "%d privileged resource(s) skipped. Use 'tomei apply --system' to install.\n\n", len(privileged))
-		}
-		userResources = normal
+		userResources = filterPrivilegedWithLog(w, userResources)
 	}
 
 	// Load config from fixed path (~/.config/tomei/config.cue)
@@ -332,7 +325,7 @@ func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 	// can otherwise be misrepresented here as removals (they're absent from
 	// the desired resource list but still intended to be installed).
 	if n := eng.SkippedPrivileged(); n > 0 && !cfg.quiet {
-		fmt.Fprintf(w, "\n%d privileged resource action(s) skipped. Use 'tomei apply --system' to manage privileged resources.\n", n)
+		fmt.Fprintf(w, "\n%d privileged resource action(s) skipped (privileged tools require sudo for cached shell commands or for placing binaries in the system bin directory). Use 'tomei apply --system' to manage privileged resources.\n", n)
 	}
 
 	return applyErr
@@ -603,4 +596,25 @@ func (h *sudoHandler) Release() error {
 		err = exec.CommandContext(releaseCtx, "sudo", "-k").Run()
 	})
 	return err
+}
+
+// filterPrivilegedWithLog filters out privileged resources, emitting a
+// per-resource slog.Info with a `reason` attribute and a summary line to w.
+// Returns the non-privileged subset. The predicate (resource.IsPrivileged via
+// FilterPrivileged) auto-extends post-SUB4 to both Commands and download/
+// registry privileged tools; the slog reason distinguishes the two modes via
+// resource.PrivilegedReason.
+func filterPrivilegedWithLog(w io.Writer, resources []resource.Resource) []resource.Resource {
+	normal, privileged := resource.FilterPrivileged(resources)
+	if len(privileged) == 0 {
+		return normal
+	}
+	for _, r := range privileged {
+		slog.Info("skipping privileged resource (use --system)",
+			"kind", r.Kind(),
+			"name", r.Name(),
+			"reason", resource.PrivilegedReason(r))
+	}
+	fmt.Fprintf(w, "%d privileged resource(s) skipped (privileged tools require sudo for cached shell commands or for placing binaries in the system bin directory). Use 'tomei apply --system' to install.\n\n", len(privileged))
+	return normal
 }

--- a/cmd/tomei/apply.go
+++ b/cmd/tomei/apply.go
@@ -603,7 +603,7 @@ func (h *sudoHandler) Release() error {
 // modes. Centralized so the two summaries (and their tests) cannot drift.
 // Wording: "symlinks" (not "binaries") — tomei places the binary itself in
 // ~/.local/share/tomei/tools/, and only the symlink lives in SystemBinDir.
-const privilegedSkipReasonsFragment = "privileged tools require sudo for cached shell commands or for placing symlinks in the system bin directory"
+const privilegedSkipReasonsFragment = "privileged tools require a sudo cache for shell commands or for placing symlinks in the system bin directory"
 
 // filterPrivilegedWithLog filters out privileged resources, emitting a
 // per-resource slog.Info with a `reason` attribute and a summary line to w.

--- a/cmd/tomei/apply.go
+++ b/cmd/tomei/apply.go
@@ -601,7 +601,9 @@ func (h *sudoHandler) Release() error {
 // privilegedSkipReasonsFragment is the parenthetical shared by both the
 // install-time and post-apply summaries that mentions both privileged-tool
 // modes. Centralized so the two summaries (and their tests) cannot drift.
-const privilegedSkipReasonsFragment = "privileged tools require sudo for cached shell commands or for placing binaries in the system bin directory"
+// Wording: "symlinks" (not "binaries") — tomei places the binary itself in
+// ~/.local/share/tomei/tools/, and only the symlink lives in SystemBinDir.
+const privilegedSkipReasonsFragment = "privileged tools require sudo for cached shell commands or for placing symlinks in the system bin directory"
 
 // filterPrivilegedWithLog filters out privileged resources, emitting a
 // per-resource slog.Info with a `reason` attribute and a summary line to w.

--- a/cmd/tomei/apply.go
+++ b/cmd/tomei/apply.go
@@ -325,7 +325,7 @@ func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 	// can otherwise be misrepresented here as removals (they're absent from
 	// the desired resource list but still intended to be installed).
 	if n := eng.SkippedPrivileged(); n > 0 && !cfg.quiet {
-		fmt.Fprintf(w, "\n%d privileged resource action(s) skipped (privileged tools require sudo for cached shell commands or for placing binaries in the system bin directory). Use 'tomei apply --system' to manage privileged resources.\n", n)
+		fmt.Fprintf(w, "\n%d privileged resource action(s) skipped (%s). Use 'tomei apply --system' to manage privileged resources.\n", n, privilegedSkipReasonsFragment)
 	}
 
 	return applyErr
@@ -598,6 +598,11 @@ func (h *sudoHandler) Release() error {
 	return err
 }
 
+// privilegedSkipReasonsFragment is the parenthetical shared by both the
+// install-time and post-apply summaries that mentions both privileged-tool
+// modes. Centralized so the two summaries (and their tests) cannot drift.
+const privilegedSkipReasonsFragment = "privileged tools require sudo for cached shell commands or for placing binaries in the system bin directory"
+
 // filterPrivilegedWithLog filters out privileged resources, emitting a
 // per-resource slog.Info with a `reason` attribute and a summary line to w.
 // Returns the non-privileged subset. The predicate (resource.IsPrivileged via
@@ -615,6 +620,6 @@ func filterPrivilegedWithLog(w io.Writer, resources []resource.Resource) []resou
 			"name", r.Name(),
 			"reason", resource.PrivilegedReason(r))
 	}
-	fmt.Fprintf(w, "%d privileged resource(s) skipped (privileged tools require sudo for cached shell commands or for placing binaries in the system bin directory). Use 'tomei apply --system' to install.\n\n", len(privileged))
+	fmt.Fprintf(w, "%d privileged resource(s) skipped (%s). Use 'tomei apply --system' to install.\n\n", len(privileged), privilegedSkipReasonsFragment)
 	return normal
 }

--- a/cmd/tomei/apply_test.go
+++ b/cmd/tomei/apply_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/terassyi/tomei/internal/resource"
+)
+
+// TestFilterPrivilegedWithLog covers the --system gate that filters privileged
+// resources from `tomei apply` input. Post-SUB4 the predicate auto-extends to
+// both Commands and download/registry privileged tools; this test pins the
+// per-resource slog `reason` attribute and the summary text.
+//
+// Cannot t.Parallel(): slog.SetDefault mutates global state.
+// Subtests below run sequentially for the same reason — DO NOT add
+// t.Parallel() inside the subtests; capture-then-cleanup breaks because
+// parallel siblings would race on the same process-global default logger.
+func TestFilterPrivilegedWithLog(t *testing.T) {
+	capture := func(t *testing.T) *bytes.Buffer {
+		t.Helper()
+		// Pattern mirrors cmd/tomei/system_engine_test.go:68-77; LevelInfo
+		// here because apply.go's per-resource skip log is slog.Info.
+		var buf bytes.Buffer
+		handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+		oldLogger := slog.Default()
+		slog.SetDefault(slog.New(handler))
+		t.Cleanup(func() { slog.SetDefault(oldLogger) })
+		return &buf
+	}
+
+	commandsTool := func(name string, priv bool) *resource.Tool {
+		return &resource.Tool{
+			BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: name}},
+			ToolSpec: &resource.ToolSpec{
+				Commands:   &resource.ToolCommandSet{CommandSet: resource.CommandSet{Install: []string{"echo " + name}}},
+				Privileged: priv,
+			},
+		}
+	}
+	downloadTool := func(name string, priv bool) *resource.Tool {
+		return &resource.Tool{
+			BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: name}},
+			ToolSpec: &resource.ToolSpec{
+				InstallerRef: "aqua",
+				Version:      "1.0.0",
+				Source:       &resource.DownloadSource{URL: "https://example.com/" + name + ".tar.gz"},
+				Privileged:   priv,
+			},
+		}
+	}
+	registryTool := func(name string, priv bool) *resource.Tool {
+		return &resource.Tool{
+			BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: name}},
+			ToolSpec: &resource.ToolSpec{
+				InstallerRef: "aqua",
+				Package:      &resource.Package{Owner: "owner", Repo: name},
+				Privileged:   priv,
+			},
+		}
+	}
+
+	const cmdsReason = "requires sudo cache for shell commands"
+	const placeReason = "places a symlink in the system bin directory requiring sudo"
+	const summaryFragment = "privileged tools require sudo for cached shell commands or for placing binaries in the system bin directory"
+
+	t.Run("privileged commands tool is filtered with commands reason", func(t *testing.T) {
+		buf := capture(t)
+		var w bytes.Buffer
+		got := filterPrivilegedWithLog(&w, []resource.Resource{commandsTool("priv-cmds", true)})
+		assert.Empty(t, got, "privileged tool must be filtered out")
+		assert.Contains(t, buf.String(), "reason="+`"`+cmdsReason+`"`, "slog must carry the commands reason")
+		assert.Contains(t, buf.String(), "name=priv-cmds")
+		assert.Contains(t, w.String(), "1 privileged resource(s) skipped")
+		assert.Contains(t, w.String(), summaryFragment)
+		assert.Contains(t, w.String(), "tomei apply --system")
+	})
+
+	t.Run("privileged download tool is filtered with placement reason", func(t *testing.T) {
+		buf := capture(t)
+		var w bytes.Buffer
+		got := filterPrivilegedWithLog(&w, []resource.Resource{downloadTool("priv-dl", true)})
+		assert.Empty(t, got)
+		assert.Contains(t, buf.String(), "reason="+`"`+placeReason+`"`)
+		assert.Contains(t, buf.String(), "name=priv-dl")
+		assert.Contains(t, w.String(), "1 privileged resource(s) skipped")
+		assert.Contains(t, w.String(), summaryFragment)
+	})
+
+	t.Run("privileged registry tool uses the same placement reason as download", func(t *testing.T) {
+		buf := capture(t)
+		var w bytes.Buffer
+		got := filterPrivilegedWithLog(&w, []resource.Resource{registryTool("priv-reg", true)})
+		assert.Empty(t, got)
+		assert.Contains(t, buf.String(), "reason="+`"`+placeReason+`"`)
+		assert.Contains(t, buf.String(), "name=priv-reg")
+	})
+
+	t.Run("mixed privileged and non-privileged: non-privileged passes through", func(t *testing.T) {
+		buf := capture(t)
+		var w bytes.Buffer
+		input := []resource.Resource{
+			commandsTool("priv-cmds", true),
+			commandsTool("plain-cmds", false),
+			downloadTool("priv-dl", true),
+		}
+		got := filterPrivilegedWithLog(&w, input)
+		assert.Len(t, got, 1)
+		assert.Equal(t, "plain-cmds", got[0].Name())
+		assert.Contains(t, buf.String(), "name=priv-cmds")
+		assert.Contains(t, buf.String(), "name=priv-dl")
+		assert.NotContains(t, buf.String(), "name=plain-cmds")
+		assert.Contains(t, w.String(), "2 privileged resource(s) skipped")
+	})
+
+	t.Run("empty input emits no log and no summary", func(t *testing.T) {
+		buf := capture(t)
+		var w bytes.Buffer
+		got := filterPrivilegedWithLog(&w, nil)
+		assert.Empty(t, got)
+		assert.Empty(t, buf.String())
+		assert.Empty(t, w.String())
+	})
+
+	t.Run("no privileged resources emits no log and no summary", func(t *testing.T) {
+		buf := capture(t)
+		var w bytes.Buffer
+		input := []resource.Resource{commandsTool("plain-a", false), commandsTool("plain-b", false)}
+		got := filterPrivilegedWithLog(&w, input)
+		assert.Len(t, got, 2)
+		assert.Empty(t, buf.String(), "no slog emission expected when nothing is filtered")
+		assert.Empty(t, w.String())
+	})
+}

--- a/cmd/tomei/apply_test.go
+++ b/cmd/tomei/apply_test.go
@@ -64,7 +64,7 @@ func TestFilterPrivilegedWithLog(t *testing.T) {
 
 	const cmdsReason = "requires sudo cache for shell commands"
 	const placeReason = "places a symlink in the system bin directory requiring sudo"
-	const summaryFragment = "privileged tools require sudo for cached shell commands or for placing binaries in the system bin directory"
+	const summaryFragment = "privileged tools require sudo for cached shell commands or for placing symlinks in the system bin directory"
 
 	t.Run("privileged commands tool is filtered with commands reason", func(t *testing.T) {
 		buf := capture(t)

--- a/cmd/tomei/apply_test.go
+++ b/cmd/tomei/apply_test.go
@@ -64,7 +64,7 @@ func TestFilterPrivilegedWithLog(t *testing.T) {
 
 	const cmdsReason = "requires sudo cache for shell commands"
 	const placeReason = "places a symlink in the system bin directory requiring sudo"
-	const summaryFragment = "privileged tools require sudo for cached shell commands or for placing symlinks in the system bin directory"
+	const summaryFragment = "privileged tools require a sudo cache for shell commands or for placing symlinks in the system bin directory"
 
 	t.Run("privileged commands tool is filtered with commands reason", func(t *testing.T) {
 		buf := capture(t)

--- a/cmd/tomei/apply_test.go
+++ b/cmd/tomei/apply_test.go
@@ -115,12 +115,18 @@ func TestFilterPrivilegedWithLog(t *testing.T) {
 		assert.Contains(t, w.String(), "2 privileged resource(s) skipped")
 	})
 
+	// skipMsg is the literal log message emitted by filterPrivilegedWithLog
+	// per-resource. The negative-path subtests assert it's absent from the
+	// captured buffer (rather than asserting buf is fully empty), so unrelated
+	// concurrent slog emissions cannot induce a false failure.
+	const skipMsg = "skipping privileged resource"
+
 	t.Run("empty input emits no log and no summary", func(t *testing.T) {
 		buf := capture(t)
 		var w bytes.Buffer
 		got := filterPrivilegedWithLog(&w, nil)
 		assert.Empty(t, got)
-		assert.Empty(t, buf.String())
+		assert.NotContains(t, buf.String(), skipMsg, "no privileged-skip emission expected")
 		assert.Empty(t, w.String())
 	})
 
@@ -130,7 +136,7 @@ func TestFilterPrivilegedWithLog(t *testing.T) {
 		input := []resource.Resource{commandsTool("plain-a", false), commandsTool("plain-b", false)}
 		got := filterPrivilegedWithLog(&w, input)
 		assert.Len(t, got, 2)
-		assert.Empty(t, buf.String(), "no slog emission expected when nothing is filtered")
+		assert.NotContains(t, buf.String(), skipMsg, "no privileged-skip emission expected when nothing is filtered")
 		assert.Empty(t, w.String())
 	})
 }

--- a/cmd/tomei/plan.go
+++ b/cmd/tomei/plan.go
@@ -232,10 +232,9 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 			}
 		}
 
-		// Mark privileged tools as skip when --system is not set
-		if !system && resource.IsPrivileged(res) {
-			resInfo.Action = resource.ActionSkip
-		}
+		// Mark privileged tools as skip when --system is not set.
+		// Consistent with the system-kind skip pattern at lines 246-258.
+		markPrivilegedAsSkip(&resInfo, res, system)
 
 		info[nodeID] = resInfo
 	}
@@ -539,6 +538,17 @@ func markAllSystemAsInstall(info map[graph.NodeID]graph.ResourceInfo, resources 
 				Action: resource.ActionInstall,
 			}
 		}
+	}
+}
+
+// markPrivilegedAsSkip sets info.Action to ActionSkip when the resource is
+// privileged and --system is not enabled. The predicate (resource.IsPrivileged)
+// auto-extends to both Commands and download/registry-pattern privileged
+// tools post-SUB4; the plan output mark is therefore consistent with the
+// install-time skip in cmd/tomei/apply.go's filterPrivilegedWithLog.
+func markPrivilegedAsSkip(info *graph.ResourceInfo, res resource.Resource, system bool) {
+	if !system && resource.IsPrivileged(res) {
+		info.Action = resource.ActionSkip
 	}
 }
 

--- a/cmd/tomei/plan_test.go
+++ b/cmd/tomei/plan_test.go
@@ -226,6 +226,71 @@ func TestMarkAllSystemAsInstall(t *testing.T) {
 	})
 }
 
+func TestMarkPrivilegedAsSkip(t *testing.T) {
+	t.Parallel()
+
+	commandsPrivTool := &resource.Tool{
+		BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "cmds-priv"}},
+		ToolSpec: &resource.ToolSpec{
+			Commands:   &resource.ToolCommandSet{CommandSet: resource.CommandSet{Install: []string{"echo x"}}},
+			Privileged: true,
+		},
+	}
+	downloadPrivTool := &resource.Tool{
+		BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "dl-priv"}},
+		ToolSpec: &resource.ToolSpec{
+			InstallerRef: "aqua",
+			Version:      "1.0.0",
+			Source:       &resource.DownloadSource{URL: "https://example.com/x.tar.gz"},
+			Privileged:   true,
+		},
+	}
+	registryPrivTool := &resource.Tool{
+		BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "reg-priv"}},
+		ToolSpec: &resource.ToolSpec{
+			InstallerRef: "aqua",
+			Package:      &resource.Package{Owner: "owner", Repo: "reg-priv"},
+			Privileged:   true,
+		},
+	}
+	plainTool := &resource.Tool{
+		BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "plain"}},
+		ToolSpec: &resource.ToolSpec{
+			Commands: &resource.ToolCommandSet{CommandSet: resource.CommandSet{Install: []string{"echo y"}}},
+		},
+	}
+
+	tests := []struct {
+		name   string
+		res    resource.Resource
+		system bool
+		// Initial action before the helper runs (simulating the rest of
+		// buildResourceInfo). The helper must only flip to Skip when both
+		// privileged AND !system; otherwise leave alone.
+		initial    resource.ActionType
+		wantAction resource.ActionType
+	}{
+		{name: "commands-privileged without --system → skip", res: commandsPrivTool, system: false, initial: resource.ActionInstall, wantAction: resource.ActionSkip},
+		{name: "download-privileged without --system → skip (auto-extends via SUB4)", res: downloadPrivTool, system: false, initial: resource.ActionInstall, wantAction: resource.ActionSkip},
+		{name: "registry-privileged without --system → skip (auto-extends via SUB4)", res: registryPrivTool, system: false, initial: resource.ActionInstall, wantAction: resource.ActionSkip},
+		{name: "privileged with --system stays put", res: commandsPrivTool, system: true, initial: resource.ActionInstall, wantAction: resource.ActionInstall},
+		{name: "non-privileged tool unaffected", res: plainTool, system: false, initial: resource.ActionInstall, wantAction: resource.ActionInstall},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			info := graph.ResourceInfo{
+				Kind:   tt.res.Kind(),
+				Name:   tt.res.Name(),
+				Action: tt.initial,
+			}
+			markPrivilegedAsSkip(&info, tt.res, tt.system)
+			assert.Equal(t, tt.wantAction, info.Action)
+		})
+	}
+}
+
 func TestAddSystemResourceInfo(t *testing.T) {
 	t.Parallel()
 

--- a/internal/installer/engine/engine.go
+++ b/internal/installer/engine/engine.go
@@ -1270,13 +1270,9 @@ func (e *Engine) handleRemovals(ctx context.Context, resources []resource.Resour
 		filtered := make([]ToolAction, 0, len(toolActions))
 		for _, action := range toolActions {
 			if action.Type == resource.ActionRemove && action.State != nil && action.State.Privileged {
-				// SUB7: constant reason — pre-SUB5, only Commands tools can
-				// reach this state-driven removal path (the install-time gate
-				// filters privileged download/registry tools out before they
-				// enter state). SUB5 will replace this with a derived reason.
 				slog.Warn("skipping removal of privileged tool (use --system)",
 					"name", action.Name,
-					"reason", "shell command removal")
+					"reason", action.State.PrivilegedRemovalReason())
 				e.skippedPrivileged++
 				continue
 			}

--- a/internal/installer/engine/engine.go
+++ b/internal/installer/engine/engine.go
@@ -1270,7 +1270,13 @@ func (e *Engine) handleRemovals(ctx context.Context, resources []resource.Resour
 		filtered := make([]ToolAction, 0, len(toolActions))
 		for _, action := range toolActions {
 			if action.Type == resource.ActionRemove && action.State != nil && action.State.Privileged {
-				slog.Warn("skipping removal of privileged tool (use --system)", "name", action.Name)
+				// SUB7: constant reason — pre-SUB5, only Commands tools can
+				// reach this state-driven removal path (the install-time gate
+				// filters privileged download/registry tools out before they
+				// enter state). SUB5 will replace this with a derived reason.
+				slog.Warn("skipping removal of privileged tool (use --system)",
+					"name", action.Name,
+					"reason", "shell command removal")
 				e.skippedPrivileged++
 				continue
 			}

--- a/internal/installer/reconciler/tool.go
+++ b/internal/installer/reconciler/tool.go
@@ -36,10 +36,15 @@ func ToolComparator() Comparator[*resource.Tool, *resource.ToolState] {
 		if res.ToolSpec.BinaryName != state.BinaryName {
 			return true, "binaryName changed: " + state.BinaryName + " -> " + res.ToolSpec.BinaryName
 		}
-		// Detect privileged change only for commands-based tools. The flag
-		// is a spec-vs-state drift signal (it gates --system and is persisted
-		// in state). Other install patterns ignore the privileged flag and do
-		// not persist it.
+		// Detect privileged change only for commands-based tools.
+		// Privileged is persisted on all install patterns that flow through
+		// the user-visible apply path (#230: buildState also stamps it for
+		// download/registry to pre-wire the state-driven removal-skip gate),
+		// but the comparator only treats a privileged-flip as a *reinstall*
+		// signal when Commands is involved — for download/registry the flag
+		// itself does not change what gets installed (binary contents are
+		// identical), and SUB5's BinDirKind routing will handle relocations
+		// via the install/update path, not via this comparator.
 		if (res.ToolSpec.Commands != nil || state.Commands != nil) && res.ToolSpec.Privileged != state.Privileged {
 			return true, "privileged changed"
 		}

--- a/internal/installer/tool/installer.go
+++ b/internal/installer/tool/installer.go
@@ -560,12 +560,13 @@ func (i *Installer) buildState(spec *resource.ToolSpec, target place.Target, dig
 		BinPath:      i.placer.LinkPath(target, i.userBinDir),
 		BinDirKind:   resource.BinDirKindUser,
 		// Privileged is persisted on the download/registry write path too,
-		// mirroring installByCommands. Pre-SUB5, only Commands tools can
-		// actually be installed under --system (the install-time gate
-		// filters privileged download/registry out), so this is inert today
-		// — but it pre-wires the state-driven removal gate at
-		// engine.go:1267 and plan.go's privileged-removal branch so SUB5's
-		// privileged install will Just Work on the removal side.
+		// mirroring installByCommands. Pre-SUB5, a privileged download or
+		// registry tool installed under --system still lands in the user
+		// bin directory (the actual SystemBinDir routing arrives in SUB5),
+		// but stamping state.Privileged=true now pre-wires the state-driven
+		// removal-skip gate (engine.go) and plan.go's privileged-removal
+		// branch — so once SUB5 routes installs to SystemBinDir, the
+		// removal side already works.
 		// ToolComparator (reconciler/tool.go:43) only compares Privileged
 		// when Commands is involved, so persisting it here cannot trigger
 		// spurious reinstalls for download/registry tools.

--- a/internal/installer/tool/installer.go
+++ b/internal/installer/tool/installer.go
@@ -559,6 +559,7 @@ func (i *Installer) buildState(spec *resource.ToolSpec, target place.Target, dig
 		InstallPath:  i.placer.BinaryPath(target),
 		BinPath:      i.placer.LinkPath(target, i.userBinDir),
 		BinDirKind:   resource.BinDirKindUser,
+		Privileged:   spec.Privileged,
 		Source:       spec.Source,
 		RuntimeRef:   spec.RuntimeRef,
 		Package:      spec.Package,

--- a/internal/installer/tool/installer.go
+++ b/internal/installer/tool/installer.go
@@ -559,12 +559,22 @@ func (i *Installer) buildState(spec *resource.ToolSpec, target place.Target, dig
 		InstallPath:  i.placer.BinaryPath(target),
 		BinPath:      i.placer.LinkPath(target, i.userBinDir),
 		BinDirKind:   resource.BinDirKindUser,
-		Privileged:   spec.Privileged,
-		Source:       spec.Source,
-		RuntimeRef:   spec.RuntimeRef,
-		Package:      spec.Package,
-		BinaryName:   spec.BinaryName,
-		UpdatedAt:    time.Now(),
+		// Privileged is persisted on the download/registry write path too,
+		// mirroring installByCommands. Pre-SUB5, only Commands tools can
+		// actually be installed under --system (the install-time gate
+		// filters privileged download/registry out), so this is inert today
+		// — but it pre-wires the state-driven removal gate at
+		// engine.go:1267 and plan.go's privileged-removal branch so SUB5's
+		// privileged install will Just Work on the removal side.
+		// ToolComparator (reconciler/tool.go:43) only compares Privileged
+		// when Commands is involved, so persisting it here cannot trigger
+		// spurious reinstalls for download/registry tools.
+		Privileged: spec.Privileged,
+		Source:     spec.Source,
+		RuntimeRef: spec.RuntimeRef,
+		Package:    spec.Package,
+		BinaryName: spec.BinaryName,
+		UpdatedAt:  time.Now(),
 	}
 }
 

--- a/internal/installer/tool/installer_test.go
+++ b/internal/installer/tool/installer_test.go
@@ -66,6 +66,27 @@ func TestToolInstaller_Install(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "privileged download install propagates Privileged to state",
+			tool: &resource.Tool{
+				BaseResource: resource.BaseResource{
+					Metadata: resource.Metadata{Name: "ripgrep-priv"},
+				},
+				ToolSpec: &resource.ToolSpec{
+					InstallerRef: "download",
+					Version:      "14.1.1",
+					Source: &resource.DownloadSource{
+						URL: "https://example.com/ripgrep.tar.gz",
+						Checksum: &resource.Checksum{
+							Value: "sha256:" + archiveHash,
+						},
+						ArchiveType: "tar.gz",
+					},
+					Privileged: true,
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "missing source",
 			tool: &resource.Tool{
 				BaseResource: resource.BaseResource{
@@ -106,6 +127,8 @@ func TestToolInstaller_Install(t *testing.T) {
 			assert.NotEmpty(t, state.BinPath)
 			assert.Equal(t, resource.BinDirKindUser, state.BinDirKind,
 				"download/registry install should stamp BinDirKindUser so the gap closes on next apply (SUB6 #229)")
+			assert.Equal(t, tt.tool.ToolSpec.Privileged, state.Privileged,
+				"buildState should propagate spec.Privileged so the state-side gate works after SUB5 (SUB7 #230)")
 		})
 	}
 }

--- a/internal/resource/expand.go
+++ b/internal/resource/expand.go
@@ -86,6 +86,16 @@ func IsPrivileged(res Resource) bool {
 	return false
 }
 
+// PrivilegedReason returns a short reason a resource requires --system, or
+// "" if it does not. Currently only Tool resources are privileged; see
+// Tool.PrivilegedReason for the per-pattern wording.
+func PrivilegedReason(res Resource) string {
+	if t, ok := res.(*Tool); ok {
+		return t.PrivilegedReason()
+	}
+	return ""
+}
+
 // FilterSystemKinds partitions resources into user-kind and system-kind groups.
 // User-kind resources are returned first, system-kind second.
 func FilterSystemKinds(resources []Resource) (user, system []Resource) {

--- a/internal/resource/expand_test.go
+++ b/internal/resource/expand_test.go
@@ -681,6 +681,30 @@ func TestIsPrivileged(t *testing.T) {
 	}
 }
 
+func TestPrivilegedReason(t *testing.T) {
+	t.Parallel()
+
+	t.Run("delegates to Tool.PrivilegedReason for privileged download tool", func(t *testing.T) {
+		t.Parallel()
+		res := &Tool{
+			BaseResource: BaseResource{Metadata: Metadata{Name: "dl"}},
+			ToolSpec: &ToolSpec{
+				InstallerRef: "aqua",
+				Version:      "1.0.0",
+				Source:       &DownloadSource{URL: "https://example.com/x.tar.gz"},
+				Privileged:   true,
+			},
+		}
+		assert.Equal(t, "places a symlink in the system bin directory requiring sudo", PrivilegedReason(res))
+	})
+
+	t.Run("non-Tool resource returns empty", func(t *testing.T) {
+		t.Parallel()
+		res := &Runtime{BaseResource: BaseResource{Metadata: Metadata{Name: "go"}}}
+		assert.Empty(t, PrivilegedReason(res))
+	})
+}
+
 func TestFilterPrivileged(t *testing.T) {
 	t.Parallel()
 	resources := []Resource{

--- a/internal/resource/tool.go
+++ b/internal/resource/tool.go
@@ -755,6 +755,29 @@ func (t *ToolState) BinDirKindOrDefault() BinDirKind {
 	return t.BinDirKind
 }
 
+// PrivilegedRemovalReason returns a short reason a privileged removal needs
+// --system, derived from persisted state (the manifest may be absent). Used
+// at the engine-side state-driven removal-skip log site.
+//
+// State-side counterpart to Tool.PrivilegedReason (which works from the spec).
+// Commands takes precedence when both are set: the sudo cache for shell
+// commands is the more concrete user-visible action.
+//
+// Returns "" if the state does not look privileged (defensive — the caller
+// guards on state.Privileged before invoking this).
+func (t *ToolState) PrivilegedRemovalReason() string {
+	if t == nil {
+		return ""
+	}
+	if t.Commands != nil {
+		return "shell command removal"
+	}
+	if t.BinDirKindOrDefault() == BinDirKindSystem {
+		return "system bin directory cleanup"
+	}
+	return ""
+}
+
 // IsTainted returns true if the tool needs reinstallation.
 func (t *ToolState) IsTainted() bool {
 	return t.TaintReason != ""

--- a/internal/resource/tool.go
+++ b/internal/resource/tool.go
@@ -420,6 +420,10 @@ func (t *Tool) IsEnabled() bool {
 // placement patterns, download (Source) and registry (aqua / owner-repo
 // Package). For installer- or runtime-delegation the installer/runtime owns
 // the destination directory, so privileged is ignored.
+//
+// Keep in sync with Tool.PrivilegedReason: any new privileged arm added here
+// MUST also be wired into that method (or the per-resource skip-warning will
+// emit an empty reason).
 func (t *Tool) IsPrivileged() bool {
 	if t.ToolSpec == nil || !t.ToolSpec.Privileged {
 		return false
@@ -446,6 +450,25 @@ func (t *Tool) IsPrivileged() bool {
 		// destination dir, so privileged is ignored.
 		return false
 	}
+}
+
+// PrivilegedReason returns a short human-readable reason this tool requires
+// --system, or "" if the tool is not privileged. Mirrors IsPrivileged's
+// pattern arms: Commands → sudo-cached shell commands; download/registry →
+// system bin directory placement. Installer-/runtime-delegation never
+// returns a non-empty reason since IsPrivileged returns false for them.
+//
+// The returned string is user-facing; treat as opaque (do not switch on it
+// in callers). Keep in sync with Tool.IsPrivileged: any new privileged arm
+// added there MUST also be wired into this method.
+func (t *Tool) PrivilegedReason() string {
+	if !t.IsPrivileged() {
+		return ""
+	}
+	if t.ToolSpec.Commands != nil {
+		return "requires sudo cache for shell commands"
+	}
+	return "places a symlink in the system bin directory requiring sudo"
 }
 
 // IsEnabled returns whether the tool spec is enabled.

--- a/internal/resource/tool.go
+++ b/internal/resource/tool.go
@@ -773,13 +773,28 @@ func (t *ToolState) PrivilegedRemovalReason() string {
 		return ""
 	}
 	if t.Commands != nil {
-		return "shell command removal"
+		return PrivilegedRemovalReasonCommands
 	}
 	if t.BinDirKindOrDefault() == BinDirKindSystem {
-		return "system bin directory cleanup"
+		return PrivilegedRemovalReasonSystemBinDir
 	}
-	return "privileged tool removal"
+	return PrivilegedRemovalReasonGeneric
 }
+
+// Reason strings returned by ToolState.PrivilegedRemovalReason. Exported so
+// tests and downstream slog consumers can reference them without duplication.
+const (
+	// PrivilegedRemovalReasonCommands: state carries Commands (Commands-pattern
+	// privileged tool); removal will run sudo-backed shell commands.
+	PrivilegedRemovalReasonCommands = "shell command removal"
+	// PrivilegedRemovalReasonSystemBinDir: state's BinDirKind is system
+	// (download/registry tool placed in SystemBinDir, SUB5+).
+	PrivilegedRemovalReasonSystemBinDir = "system bin directory cleanup"
+	// PrivilegedRemovalReasonGeneric: state.Privileged is true but neither
+	// indicator pinpoints the cause (e.g., a pre-SUB5 privileged download or
+	// registry install — Privileged is stamped but BinDirKind is still user).
+	PrivilegedRemovalReasonGeneric = "privileged tool removal"
+)
 
 // IsTainted returns true if the tool needs reinstallation.
 func (t *ToolState) IsTainted() bool {

--- a/internal/resource/tool.go
+++ b/internal/resource/tool.go
@@ -757,14 +757,17 @@ func (t *ToolState) BinDirKindOrDefault() BinDirKind {
 
 // PrivilegedRemovalReason returns a short reason a privileged removal needs
 // --system, derived from persisted state (the manifest may be absent). Used
-// at the engine-side state-driven removal-skip log site.
+// at the engine-side state-driven removal-skip log site, which guards on
+// state.Privileged before invoking this method.
 //
 // State-side counterpart to Tool.PrivilegedReason (which works from the spec).
-// Commands takes precedence when both are set: the sudo cache for shell
-// commands is the more concrete user-visible action.
-//
-// Returns "" if the state does not look privileged (defensive — the caller
-// guards on state.Privileged before invoking this).
+// Commands takes precedence: the sudo cache for shell commands is the more
+// concrete user-visible action. Otherwise, BinDirKindSystem indicates the
+// system-bin-dir cleanup case (SUB5+). When state.Privileged is true but
+// neither indicator pinpoints the cause (e.g., a pre-SUB5 privileged
+// download/registry install — Privileged is stamped but BinDirKind is still
+// user), fall back to a generic non-empty reason so the log never carries
+// reason="".
 func (t *ToolState) PrivilegedRemovalReason() string {
 	if t == nil {
 		return ""
@@ -775,7 +778,7 @@ func (t *ToolState) PrivilegedRemovalReason() string {
 	if t.BinDirKindOrDefault() == BinDirKindSystem {
 		return "system bin directory cleanup"
 	}
-	return ""
+	return "privileged tool removal"
 }
 
 // IsTainted returns true if the tool needs reinstallation.

--- a/internal/resource/tool.go
+++ b/internal/resource/tool.go
@@ -422,8 +422,10 @@ func (t *Tool) IsEnabled() bool {
 // the destination directory, so privileged is ignored.
 //
 // Keep in sync with Tool.PrivilegedReason: any new privileged arm added here
-// MUST also be wired into that method (or the per-resource skip-warning will
-// emit an empty reason).
+// MUST also be wired into that method. PrivilegedReason returns the
+// commands reason when Commands != nil and the placement reason otherwise,
+// so a new non-commands arm that goes unwired here would silently emit the
+// placement reason — misleading rather than obviously broken.
 func (t *Tool) IsPrivileged() bool {
 	if t.ToolSpec == nil || !t.ToolSpec.Privileged {
 		return false

--- a/internal/resource/tool_test.go
+++ b/internal/resource/tool_test.go
@@ -376,6 +376,74 @@ func TestTool_IsPrivileged(t *testing.T) {
 	}
 }
 
+func TestTool_PrivilegedReason(t *testing.T) {
+	t.Parallel()
+	const cmdsReason = "requires sudo cache for shell commands"
+	const placeReason = "places a symlink in the system bin directory requiring sudo"
+
+	tests := []struct {
+		name string
+		tool *Tool
+		want string
+	}{
+		{
+			name: "nil spec returns empty",
+			tool: &Tool{ToolSpec: nil},
+			want: "",
+		},
+		{
+			name: "non-privileged commands returns empty (short-circuit via IsPrivileged)",
+			tool: &Tool{ToolSpec: &ToolSpec{
+				Commands:   &ToolCommandSet{CommandSet: CommandSet{Install: []string{"x"}}},
+				Privileged: false,
+			}},
+			want: "",
+		},
+		{
+			name: "privileged commands",
+			tool: &Tool{ToolSpec: &ToolSpec{
+				Commands:   &ToolCommandSet{CommandSet: CommandSet{Install: []string{"x"}}},
+				Privileged: true,
+			}},
+			want: cmdsReason,
+		},
+		{
+			name: "privileged download (installerRef + source)",
+			tool: &Tool{ToolSpec: &ToolSpec{
+				InstallerRef: "aqua",
+				Version:      "1.0.0",
+				Source:       &DownloadSource{URL: "https://example.com/tool.tar.gz"},
+				Privileged:   true,
+			}},
+			want: placeReason,
+		},
+		{
+			name: "privileged registry (installerRef=aqua + owner/repo)",
+			tool: &Tool{ToolSpec: &ToolSpec{
+				InstallerRef: "aqua",
+				Package:      &Package{Owner: "cli", Repo: "cli"},
+				Privileged:   true,
+			}},
+			want: placeReason,
+		},
+		{
+			name: "privileged runtime delegation returns empty (IsPrivileged is false)",
+			tool: &Tool{ToolSpec: &ToolSpec{
+				RuntimeRef: "go",
+				Package:    &Package{Name: "golang.org/x/tools/gopls"},
+				Privileged: true,
+			}},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.tool.PrivilegedReason())
+		})
+	}
+}
+
 func TestPackage_Validate(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/resource/tool_test.go
+++ b/internal/resource/tool_test.go
@@ -454,9 +454,9 @@ func TestToolState_PrivilegedRemovalReason(t *testing.T) {
 	}{
 		{name: "nil receiver returns empty", state: nil, want: ""},
 		{
-			name:  "non-privileged-looking state returns empty (defensive)",
-			state: &ToolState{}, // no Commands, BinDirKind empty (→ user)
-			want:  "",
+			name:  "ambiguous privileged state (no Commands, BinDirKind=user) → generic fallback",
+			state: &ToolState{}, // no Commands, BinDirKind empty (→ user); models the pre-SUB5 privileged download/registry state shape
+			want:  "privileged tool removal",
 		},
 		{
 			name:  "Commands set → shell command removal",
@@ -477,9 +477,9 @@ func TestToolState_PrivilegedRemovalReason(t *testing.T) {
 			want: "shell command removal",
 		},
 		{
-			name:  "explicit BinDirKindUser without Commands → empty (no privileged action)",
+			name:  "explicit BinDirKindUser without Commands → generic fallback (same as empty)",
 			state: &ToolState{BinDirKind: BinDirKindUser},
-			want:  "",
+			want:  "privileged tool removal",
 		},
 	}
 

--- a/internal/resource/tool_test.go
+++ b/internal/resource/tool_test.go
@@ -444,6 +444,53 @@ func TestTool_PrivilegedReason(t *testing.T) {
 	}
 }
 
+func TestToolState_PrivilegedRemovalReason(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		state *ToolState
+		want  string
+	}{
+		{name: "nil receiver returns empty", state: nil, want: ""},
+		{
+			name:  "non-privileged-looking state returns empty (defensive)",
+			state: &ToolState{}, // no Commands, BinDirKind empty (→ user)
+			want:  "",
+		},
+		{
+			name:  "Commands set → shell command removal",
+			state: &ToolState{Commands: &ToolCommandSet{CommandSet: CommandSet{Install: []string{"echo"}}}},
+			want:  "shell command removal",
+		},
+		{
+			name:  "system BinDirKind without Commands → system bin directory cleanup",
+			state: &ToolState{BinDirKind: BinDirKindSystem},
+			want:  "system bin directory cleanup",
+		},
+		{
+			name: "Commands takes precedence over system BinDirKind",
+			state: &ToolState{
+				Commands:   &ToolCommandSet{CommandSet: CommandSet{Install: []string{"echo"}}},
+				BinDirKind: BinDirKindSystem,
+			},
+			want: "shell command removal",
+		},
+		{
+			name:  "explicit BinDirKindUser without Commands → empty (no privileged action)",
+			state: &ToolState{BinDirKind: BinDirKindUser},
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.state.PrivilegedRemovalReason())
+		})
+	}
+}
+
 func TestPackage_Validate(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/resource/tool_test.go
+++ b/internal/resource/tool_test.go
@@ -456,17 +456,17 @@ func TestToolState_PrivilegedRemovalReason(t *testing.T) {
 		{
 			name:  "ambiguous privileged state (no Commands, BinDirKind=user) → generic fallback",
 			state: &ToolState{}, // no Commands, BinDirKind empty (→ user); models the pre-SUB5 privileged download/registry state shape
-			want:  "privileged tool removal",
+			want:  PrivilegedRemovalReasonGeneric,
 		},
 		{
 			name:  "Commands set → shell command removal",
 			state: &ToolState{Commands: &ToolCommandSet{CommandSet: CommandSet{Install: []string{"echo"}}}},
-			want:  "shell command removal",
+			want:  PrivilegedRemovalReasonCommands,
 		},
 		{
 			name:  "system BinDirKind without Commands → system bin directory cleanup",
 			state: &ToolState{BinDirKind: BinDirKindSystem},
-			want:  "system bin directory cleanup",
+			want:  PrivilegedRemovalReasonSystemBinDir,
 		},
 		{
 			name: "Commands takes precedence over system BinDirKind",
@@ -474,12 +474,12 @@ func TestToolState_PrivilegedRemovalReason(t *testing.T) {
 				Commands:   &ToolCommandSet{CommandSet: CommandSet{Install: []string{"echo"}}},
 				BinDirKind: BinDirKindSystem,
 			},
-			want: "shell command removal",
+			want: PrivilegedRemovalReasonCommands,
 		},
 		{
 			name:  "explicit BinDirKindUser without Commands → generic fallback (same as empty)",
 			state: &ToolState{BinDirKind: BinDirKindUser},
-			want:  "privileged tool removal",
+			want:  PrivilegedRemovalReasonGeneric,
 		},
 	}
 


### PR DESCRIPTION
The --system gate that skips privileged tools from `tomei apply` and marks
them as `skip` in `tomei plan` already auto-extends to download/registry-
pattern privileged tools post-SUB4 (#227). SUB7 updates the user-visible
skip-warning to name the actual reason for each mode and adds cmd-level
tests pinning the behavior.

Per-resource slog now carries a `reason` attribute populated via the new
Tool.PrivilegedReason() helper:
- Commands-privileged: "requires sudo cache for shell commands"
- Download/registry-privileged: "places a symlink in the system bin
  directory requiring sudo"

The apply summary at the install gate and the post-apply summary both
gain a one-line parenthetical mentioning both modes. The engine.go state-
driven removal slog gains a constant reason="shell command removal" (pre-
SUB5 only Commands tools can reach this path; SUB5 will derive it).

Also closes the buildState/installByCommands asymmetry by stamping
Privileged: spec.Privileged on the download/registry install path, so the
state-side removal gate works the moment SUB5 enables privileged install.

Refactored two helpers out of inline blocks for testability:
filterPrivilegedWithLog in cmd/tomei/apply.go and markPrivilegedAsSkip
in cmd/tomei/plan.go (mirrors markAllSystemAsInstall).

Out of scope: e2e for privileged download/registry (SUB8 #231); the SUB5
write path that actually routes privileged installs to the system bin
dir; docs/design.md updates (SUB9 #232).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
