### PR TITLE
feat(installer): route privileged download/registry tools through SystemBinDir (#228)

### DIFF
--- a/cmd/tomei/apply.go
+++ b/cmd/tomei/apply.go
@@ -233,7 +233,7 @@ func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 	runtimesDir := pathConfig.UserDataDir() + "/runtimes"
 
 	placer := place.NewPlacer(toolsDir)
-	toolInstaller := tool.NewInstaller(downloader, placer, pathConfig.UserBinDir())
+	toolInstaller := tool.NewInstaller(downloader, placer, pathConfig.UserBinDir(), pathConfig.SystemBinDir())
 	runtimeInstaller := runtime.NewInstaller(downloader, runtimesDir)
 	reposDir := pathConfig.UserDataDir() + "/repositories"
 	repoInstaller := repository.NewInstaller(reposDir)

--- a/internal/installer/executor/context.go
+++ b/internal/installer/executor/context.go
@@ -36,6 +36,28 @@ func OldBinPathFromContext(ctx context.Context) string {
 	return ""
 }
 
+type oldBinDirKindKey struct{}
+
+// WithOldBinDirKind returns a context carrying the old BinDirKind for
+// transition-aware symlink cleanup. Mirrors WithOldBinPath: the install
+// pipeline reads both to decide whether the old symlink lived in the user
+// bin dir (Placer.Cleanup) or the system bin dir (RemoveSymlink, sudo-
+// capable). Threaded by Executor[R, S].install via duck-typing on the
+// state's BinDirKindOrDefault method.
+func WithOldBinDirKind(ctx context.Context, kind resource.BinDirKind) context.Context {
+	return context.WithValue(ctx, oldBinDirKindKey{}, kind)
+}
+
+// OldBinDirKindFromContext returns the old BinDirKind, defaulting to
+// resource.BinDirKindUser when not set — matching ToolState.BinDirKindOrDefault's
+// pre-SUB6 backward-compat default.
+func OldBinDirKindFromContext(ctx context.Context) resource.BinDirKind {
+	if v, ok := ctx.Value(oldBinDirKindKey{}).(resource.BinDirKind); ok && v != "" {
+		return v
+	}
+	return resource.BinDirKindUser
+}
+
 type oldPackagesKey struct{}
 
 // WithOldPackages returns a context carrying the package list recorded in

--- a/internal/installer/executor/context_test.go
+++ b/internal/installer/executor/context_test.go
@@ -60,3 +60,29 @@ func TestOldBinPathContext_Empty(t *testing.T) {
 	got := OldBinPathFromContext(context.Background())
 	assert.Empty(t, got)
 }
+
+func TestOldBinDirKindContext(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		kind resource.BinDirKind
+		want resource.BinDirKind
+	}{
+		{name: "user", kind: resource.BinDirKindUser, want: resource.BinDirKindUser},
+		{name: "system", kind: resource.BinDirKindSystem, want: resource.BinDirKindSystem},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := WithOldBinDirKind(context.Background(), tt.kind)
+			assert.Equal(t, tt.want, OldBinDirKindFromContext(ctx))
+		})
+	}
+}
+
+func TestOldBinDirKindContext_Empty(t *testing.T) {
+	t.Parallel()
+	// When not set, the getter returns BinDirKindUser — the same default the
+	// state-side ToolState.BinDirKindOrDefault uses for pre-SUB6 state files.
+	assert.Equal(t, resource.BinDirKindUser, OldBinDirKindFromContext(context.Background()))
+}

--- a/internal/installer/executor/executor.go
+++ b/internal/installer/executor/executor.go
@@ -71,6 +71,14 @@ func (e *Executor[R, S]) install(ctx context.Context, action reconciler.Action[R
 				ctx = WithOldBinPath(ctx, oldPath)
 			}
 		}
+		// SUB5 #228: also propagate the old BinDirKind so the install path's
+		// cleanupOldSymlink can pick the right remove helper when the kind
+		// changes (e.g., the user flips spec.Privileged across applies).
+		if bdk, ok := any(action.State).(interface {
+			BinDirKindOrDefault() resource.BinDirKind
+		}); ok {
+			ctx = WithOldBinDirKind(ctx, bdk.BinDirKindOrDefault())
+		}
 		// Pass old Packages for SystemPackageSet upgrade-time drainage.
 		// The generic install flow only re-runs Install with the new
 		// spec; without the old package list the installer has no way

--- a/internal/installer/place/placer.go
+++ b/internal/installer/place/placer.go
@@ -184,6 +184,12 @@ func (p *filePlacer) Place(srcDir string, target Target) (*Result, error) {
 }
 
 // Symlink creates a symlink in binDir pointing to the placed binary.
+//
+// For privileged installs that target the system bin directory, callers
+// should use place.InstallSymlink instead — it escalates via `sudo -n ln`
+// on permission error. The tool installer (SUB5 #228) routes through that
+// helper when Tool.IsPrivileged() is true; this method handles the user
+// arm only.
 func (p *filePlacer) Symlink(target Target, binDir string) (string, error) {
 	// Reject empty / relative / root binDir before any syscall — a relative
 	// linkPath would resolve against the cwd of `tomei apply`, silently

--- a/internal/installer/place/symlink.go
+++ b/internal/installer/place/symlink.go
@@ -54,7 +54,7 @@ func defaultSudoRun(ctx context.Context, args ...string) error {
 	return nil
 }
 
-// installSymlink creates linkPath -> target, escalating to `sudo -n ln -snf`
+// InstallSymlink creates linkPath -> target, escalating to `sudo -n ln -snf`
 // on permission error (-s symbolic, -n no-deref to avoid the symlink-to-dir
 // foot-gun, -f force-replace). Existing symlinks at linkPath are replaced;
 // existing non-symlinks (regular files, directories) are refused to avoid
@@ -62,7 +62,7 @@ func defaultSudoRun(ctx context.Context, args ...string) error {
 //
 // Assumes the caller has already cached a sudo ticket via sudoHandler
 // (cmd/tomei/apply.go); the -n flag never prompts.
-func installSymlink(ctx context.Context, target, linkPath string) error {
+func InstallSymlink(ctx context.Context, target, linkPath string) error {
 	if target == "" {
 		return errors.New("symlink: target is empty")
 	}
@@ -93,10 +93,10 @@ func installSymlink(ctx context.Context, target, linkPath string) error {
 	return nil
 }
 
-// removeSymlink removes linkPath, escalating to `sudo -n rm -f` on permission
+// RemoveSymlink removes linkPath, escalating to `sudo -n rm -f` on permission
 // error. A missing linkPath is a no-op (matches `rm -f`). Refuses to remove a
-// non-symlink at linkPath — the helper is named removeSymlink for a reason.
-func removeSymlink(ctx context.Context, linkPath string) error {
+// non-symlink at linkPath — the helper is named RemoveSymlink for a reason.
+func RemoveSymlink(ctx context.Context, linkPath string) error {
 	if err := validateLinkPath(linkPath); err != nil {
 		return err
 	}

--- a/internal/installer/place/symlink_test.go
+++ b/internal/installer/place/symlink_test.go
@@ -43,7 +43,7 @@ func TestInstallSymlink_DirectPath(t *testing.T) {
 	require.NoError(t, os.WriteFile(target, []byte("x"), 0o644))
 	linkPath := filepath.Join(dir, "link")
 
-	require.NoError(t, installSymlink(context.Background(), target, linkPath))
+	require.NoError(t, InstallSymlink(context.Background(), target, linkPath))
 
 	got, err := os.Readlink(linkPath)
 	require.NoError(t, err)
@@ -55,7 +55,7 @@ func TestInstallSymlink_ReplacesExisting(t *testing.T) {
 	linkPath := filepath.Join(dir, "link")
 	require.NoError(t, os.Symlink("/old", linkPath))
 
-	require.NoError(t, installSymlink(context.Background(), "/new", linkPath))
+	require.NoError(t, InstallSymlink(context.Background(), "/new", linkPath))
 
 	got, err := os.Readlink(linkPath)
 	require.NoError(t, err)
@@ -73,7 +73,7 @@ func TestInstallSymlink_RefusesToReplaceRegularFile(t *testing.T) {
 		return nil
 	})
 
-	err := installSymlink(context.Background(), "/some/target", linkPath)
+	err := InstallSymlink(context.Background(), "/some/target", linkPath)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "refusing to replace non-symlink")
 	assert.False(t, sudoCalled, "sudo must not be called")
@@ -98,7 +98,7 @@ func TestInstallSymlink_FallsBackOnPermissionError(t *testing.T) {
 	)
 
 	linkPath := filepath.Join(t.TempDir(), "foo")
-	err := installSymlink(context.Background(), "/some/target", linkPath)
+	err := InstallSymlink(context.Background(), "/some/target", linkPath)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ln", "-snf", "--", "/some/target", linkPath}, capturedArgs)
 }
@@ -115,7 +115,7 @@ func TestInstallSymlink_NonPermissionErrorNotEscalated(t *testing.T) {
 	)
 
 	dir := t.TempDir()
-	err := installSymlink(context.Background(), "/t", filepath.Join(dir, "link"))
+	err := InstallSymlink(context.Background(), "/t", filepath.Join(dir, "link"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "disk full")
 	require.NotErrorIs(t, err, errSudoFallback)
@@ -134,7 +134,7 @@ func TestInstallSymlink_SudoFallbackFailurePropagates(t *testing.T) {
 	)
 
 	linkPath := filepath.Join(t.TempDir(), "foo")
-	err := installSymlink(context.Background(), "/t", linkPath)
+	err := InstallSymlink(context.Background(), "/t", linkPath)
 	require.Error(t, err)
 	require.ErrorIs(t, err, errSudoFallback)
 	assert.Contains(t, err.Error(), linkPath)
@@ -164,7 +164,7 @@ func TestInstallSymlink_RejectsBadInput(t *testing.T) {
 				return nil
 			})
 
-			err := installSymlink(context.Background(), tt.target, tt.linkPath)
+			err := InstallSymlink(context.Background(), tt.target, tt.linkPath)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantMsg)
 			assert.False(t, sudoCalled)
@@ -200,7 +200,7 @@ func TestInstallSymlink_LstatFailureNotEscalated(t *testing.T) {
 		return nil
 	})
 
-	err := installSymlink(context.Background(), "/some/target", filepath.Join(locked, "link"))
+	err := InstallSymlink(context.Background(), "/some/target", filepath.Join(locked, "link"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "lstat:")
 	assert.False(t, sudoCalled)
@@ -223,7 +223,7 @@ func TestInstallSymlink_ExistingSymlinkRemoveEACCESFallsBack(t *testing.T) {
 		},
 	)
 
-	err := installSymlink(context.Background(), "/new", linkPath)
+	err := InstallSymlink(context.Background(), "/new", linkPath)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ln", "-snf", "--", "/new", linkPath}, capturedArgs)
 }
@@ -233,7 +233,7 @@ func TestRemoveSymlink_DirectPath(t *testing.T) {
 	linkPath := filepath.Join(dir, "link")
 	require.NoError(t, os.Symlink("/anywhere", linkPath))
 
-	require.NoError(t, removeSymlink(context.Background(), linkPath))
+	require.NoError(t, RemoveSymlink(context.Background(), linkPath))
 
 	_, err := os.Lstat(linkPath)
 	assert.ErrorIs(t, err, fs.ErrNotExist)
@@ -242,7 +242,7 @@ func TestRemoveSymlink_DirectPath(t *testing.T) {
 func TestRemoveSymlink_MissingIsNoOp(t *testing.T) {
 	dir := t.TempDir()
 	linkPath := filepath.Join(dir, "absent")
-	assert.NoError(t, removeSymlink(context.Background(), linkPath))
+	assert.NoError(t, RemoveSymlink(context.Background(), linkPath))
 }
 
 func TestRemoveSymlink_RefusesNonSymlink(t *testing.T) {
@@ -256,7 +256,7 @@ func TestRemoveSymlink_RefusesNonSymlink(t *testing.T) {
 		return nil
 	})
 
-	err := removeSymlink(context.Background(), linkPath)
+	err := RemoveSymlink(context.Background(), linkPath)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "refusing to remove non-symlink")
 	assert.False(t, sudoCalled)
@@ -282,7 +282,7 @@ func TestRemoveSymlink_FallsBackOnPermissionError(t *testing.T) {
 		},
 	)
 
-	err := removeSymlink(context.Background(), linkPath)
+	err := RemoveSymlink(context.Background(), linkPath)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"rm", "-f", "--", linkPath}, capturedArgs)
 }
@@ -296,7 +296,7 @@ func TestRemoveSymlink_LstatFailureNotEscalated(t *testing.T) {
 		return nil
 	})
 
-	err := removeSymlink(context.Background(), filepath.Join(locked, "link"))
+	err := RemoveSymlink(context.Background(), filepath.Join(locked, "link"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "lstat:")
 	assert.False(t, sudoCalled)
@@ -317,7 +317,7 @@ func TestRemoveSymlink_SudoFallbackFailurePropagates(t *testing.T) {
 		},
 	)
 
-	err := removeSymlink(context.Background(), linkPath)
+	err := RemoveSymlink(context.Background(), linkPath)
 	require.Error(t, err)
 	require.ErrorIs(t, err, errSudoFallback)
 	assert.Contains(t, err.Error(), linkPath)
@@ -345,7 +345,7 @@ func TestRemoveSymlink_RejectsBadLinkPath(t *testing.T) {
 				return nil
 			})
 
-			err := removeSymlink(context.Background(), tt.linkPath)
+			err := RemoveSymlink(context.Background(), tt.linkPath)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantMsg)
 			assert.False(t, sudoCalled)

--- a/internal/installer/tool/installer.go
+++ b/internal/installer/tool/installer.go
@@ -446,18 +446,8 @@ func (i *Installer) installFromRegistry(ctx context.Context, res *resource.Tool,
 		}
 	}
 
-	// Create a modified tool with resolved source for download
-	resolvedTool := &resource.Tool{
-		BaseResource: res.BaseResource,
-		ToolSpec: &resource.ToolSpec{
-			InstallerRef: spec.InstallerRef,
-			Version:      version,
-			Enabled:      spec.Enabled,
-			Source:       source,
-			Package:      spec.Package,
-			BinaryName:   spec.BinaryName,
-		},
-	}
+	// Create a modified tool with resolved source for download.
+	resolvedTool := buildResolvedTool(res, source, version)
 
 	// Build install config from resolved files
 	cfg := extractBinaryMapping(name, resolved.Files)
@@ -478,6 +468,28 @@ func (i *Installer) installFromRegistry(ctx context.Context, res *resource.Tool,
 	state.SpecVersion = spec.Version // preserve original spec version (e.g., "" for latest)
 
 	return state, nil
+}
+
+// buildResolvedTool produces the download-shaped Tool that installFromRegistry
+// hands to installByDownload. SUB5 #228: Privileged MUST be preserved on the
+// resolved spec — createSymlink reads Tool.IsPrivileged() to route the symlink
+// to SystemBinDir, and buildState persists state.Privileged from spec. Dropping
+// the field would route privileged registry installs to the user bin dir (the
+// exact bug SUB5 fixes) and break the state-driven removal-skip gate.
+func buildResolvedTool(orig *resource.Tool, source *resource.DownloadSource, version string) *resource.Tool {
+	spec := orig.ToolSpec
+	return &resource.Tool{
+		BaseResource: orig.BaseResource,
+		ToolSpec: &resource.ToolSpec{
+			InstallerRef: spec.InstallerRef,
+			Version:      version,
+			Enabled:      spec.Enabled,
+			Source:       source,
+			Package:      spec.Package,
+			BinaryName:   spec.BinaryName,
+			Privileged:   spec.Privileged,
+		},
+	}
 }
 
 // extractBinaryMapping builds an InstallConfig from aqua registry files metadata.

--- a/internal/installer/tool/installer.go
+++ b/internal/installer/tool/installer.go
@@ -555,10 +555,16 @@ func (i *Installer) cleanupOldSymlink(ctx context.Context, newLinkPath string) {
 	// from context. The defensive guard validates the old symlink is in
 	// the dir its kind claims — independent of the new symlink's location,
 	// which may legitimately be in a different bin dir on a transition.
+	//
+	// filepath.Clean both sides: filepath.Dir already normalizes its result,
+	// but the Installer's userBinDir/systemBinDir fields come from config and
+	// may carry a trailing slash or other non-canonical form. Without
+	// normalization the comparison fails on semantically-equal dirs and
+	// cleanup is skipped, leaving stale symlinks across transitions.
 	oldKind := executor.OldBinDirKindFromContext(ctx)
-	expectedOldDir := i.userBinDir
+	expectedOldDir := filepath.Clean(i.userBinDir)
 	if oldKind == resource.BinDirKindSystem {
-		expectedOldDir = i.systemBinDir
+		expectedOldDir = filepath.Clean(i.systemBinDir)
 	}
 	if filepath.Dir(oldBinPath) != expectedOldDir {
 		slog.Warn("skipping old symlink cleanup: old bin path is outside expected directory for its BinDirKind",

--- a/internal/installer/tool/installer.go
+++ b/internal/installer/tool/installer.go
@@ -730,31 +730,24 @@ func (i *Installer) Remove(ctx context.Context, st *resource.ToolState, name str
 		}
 	}
 
-	// Remove the symlink. SUB5 #228: state.BinDirKindOrDefault picks the
-	// cleanup helper — system goes through place.RemoveSymlink (sudo-capable),
-	// user (or pre-SUB6 empty) keeps Placer.Cleanup.
-	//
-	// Defense in depth: validate state.BinPath actually lives under the dir
-	// its BinDirKind claims before invoking the remove helper. A corrupted
-	// or stale state.json could otherwise persuade tomei to `sudo rm -f` an
-	// arbitrary symlink elsewhere on the filesystem. Mirrors the guard in
-	// cleanupOldSymlink. filepath.Clean is applied to userBinDir/systemBinDir
-	// since they come from config and may carry a trailing slash.
+	// Remove the symlink. SUB5 #228: only escalate to the sudo-capable
+	// place.RemoveSymlink when BOTH (a) state declares BinDirKindSystem,
+	// AND (b) state.BinPath is actually under the configured systemBinDir.
+	// Any other shape — runtime-delegated tools whose BinPath lives in the
+	// runtime's bin dir (e.g., ~/go/bin/gopls), pre-SUB6 state with empty
+	// BinDirKind, or a corrupted/stale state.json with an off-dir BinPath —
+	// falls back to the unprivileged Placer.Cleanup. Defense in depth:
+	// no path can trigger `sudo rm -f` unless it's verifiably one of ours.
+	// filepath.Clean is applied because userBinDir/systemBinDir come from
+	// config and may carry a trailing slash.
 	if st.BinPath != "" {
-		isSystem := st.BinDirKindOrDefault() == resource.BinDirKindSystem
-		expectedDir := filepath.Clean(i.userBinDir)
-		if isSystem {
-			expectedDir = filepath.Clean(i.systemBinDir)
-		}
-		switch {
-		case filepath.Dir(st.BinPath) != expectedDir:
-			slog.Warn("skipping symlink removal: state.BinPath is outside expected directory for its BinDirKind",
-				"name", name, "binPath", st.BinPath, "binDirKind", st.BinDirKindOrDefault(), "expected_dir", expectedDir)
-		case isSystem:
+		useSudoHelper := st.BinDirKindOrDefault() == resource.BinDirKindSystem &&
+			filepath.Dir(st.BinPath) == filepath.Clean(i.systemBinDir)
+		if useSudoHelper {
 			if err := place.RemoveSymlink(ctx, st.BinPath); err != nil {
 				slog.Debug("failed to remove system symlink", "path", st.BinPath, "error", err)
 			}
-		default:
+		} else {
 			if err := i.placer.Cleanup(st.BinPath); err != nil {
 				slog.Debug("failed to remove symlink", "path", st.BinPath, "error", err)
 			}

--- a/internal/installer/tool/installer.go
+++ b/internal/installer/tool/installer.go
@@ -54,7 +54,8 @@ type CommandRunner interface {
 type Installer struct {
 	downloader       download.Downloader
 	placer           place.Placer
-	userBinDir       string // bin directory passed to placer for non-privileged installs
+	userBinDir       string // bin directory for non-privileged tool symlinks (e.g., ~/.local/bin)
+	systemBinDir     string // bin directory for privileged tool symlinks (e.g., /usr/local/bin); SUB5 #228
 	cmdExecutor      CommandRunner
 	versionResolver  *resolve.Resolver         // shared version resolver (optional)
 	runtimes         map[string]*RuntimeInfo   // name -> RuntimeInfo
@@ -67,12 +68,13 @@ type Installer struct {
 }
 
 // NewInstaller creates a new tool Installer.
-func NewInstaller(downloader download.Downloader, placer place.Placer, userBinDir string) *Installer {
+func NewInstaller(downloader download.Downloader, placer place.Placer, userBinDir, systemBinDir string) *Installer {
 	cmdExec := command.NewExecutor("")
 	return &Installer{
 		downloader:      downloader,
 		placer:          placer,
 		userBinDir:      userBinDir,
+		systemBinDir:    systemBinDir,
 		cmdExecutor:     cmdExec,
 		versionResolver: resolve.NewResolver(cmdExec, http.DefaultClient),
 		runtimes:        make(map[string]*RuntimeInfo),
@@ -81,14 +83,15 @@ func NewInstaller(downloader download.Downloader, placer place.Placer, userBinDi
 }
 
 // NewInstallerWithRunner creates a new tool Installer with a custom CommandRunner (for testing).
-func NewInstallerWithRunner(downloader download.Downloader, placer place.Placer, userBinDir string, runner CommandRunner) *Installer {
+func NewInstallerWithRunner(downloader download.Downloader, placer place.Placer, userBinDir, systemBinDir string, runner CommandRunner) *Installer {
 	return &Installer{
-		downloader:  downloader,
-		placer:      placer,
-		userBinDir:  userBinDir,
-		cmdExecutor: runner,
-		runtimes:    make(map[string]*RuntimeInfo),
-		installers:  make(map[string]*InstallerInfo),
+		downloader:   downloader,
+		placer:       placer,
+		userBinDir:   userBinDir,
+		systemBinDir: systemBinDir,
+		cmdExecutor:  runner,
+		runtimes:     make(map[string]*RuntimeInfo),
+		installers:   make(map[string]*InstallerInfo),
 	}
 }
 
@@ -274,14 +277,15 @@ func (i *Installer) installByDownload(ctx context.Context, res *resource.Tool, n
 	switch action {
 	case place.ValidateActionSkip:
 		slog.Debug("tool already installed, skipping", "name", name, "version", spec.Version)
-		// Even if binary exists, ensure symlink points to correct version
-		linkPath, err := i.placer.Symlink(target, i.userBinDir)
+		// Even if binary exists, ensure symlink points to correct version.
+		// SUB5 #228: privileged tools route through the system bin dir.
+		linkPath, binDirKind, err := i.createSymlink(ctx, res, target)
 		if err != nil {
 			return nil, fmt.Errorf("failed to update symlink: %w", err)
 		}
 		// Clean up old symlink if binaryName changed (e.g., upgrade with same binary but new name)
 		i.cleanupOldSymlink(ctx, linkPath)
-		return i.buildState(spec, target, expectedHash), nil
+		return i.buildState(spec, target, expectedHash, binDirKind, linkPath), nil
 
 	case place.ValidateActionReplace:
 		if !cfg.Force {
@@ -362,8 +366,8 @@ func (i *Installer) installByDownload(ctx context.Context, res *resource.Tool, n
 		return nil, fmt.Errorf("failed to place binary: %w", err)
 	}
 
-	// Create symlink
-	linkPath, err := i.placer.Symlink(target, i.userBinDir)
+	// Create symlink. SUB5 #228: privileged tools route through the system bin dir.
+	linkPath, binDirKind, err := i.createSymlink(ctx, res, target)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create symlink: %w", err)
 	}
@@ -374,7 +378,7 @@ func (i *Installer) installByDownload(ctx context.Context, res *resource.Tool, n
 
 	slog.Debug("tool installed successfully", "name", name, "version", spec.Version, "path", result.BinaryPath)
 
-	return i.buildState(spec, target, expectedHash), nil
+	return i.buildState(spec, target, expectedHash, binDirKind, linkPath), nil
 }
 
 // installFromRegistry installs a tool using aqua-registry to resolve the download URL.
@@ -496,23 +500,61 @@ func extractBinaryMapping(defaultName string, files []aqua.FileSpec) *installer.
 	return cfg
 }
 
-// cleanupOldSymlink removes the old symlink and its target binary if the binary name has changed.
-// It compares the old BinPath from context with the new link path.
-// Safety: only removes files within the expected bin and tools directories.
+// createSymlink resolves the bin directory based on Tool.IsPrivileged() and
+// creates the symlink via the appropriate path: Placer.Symlink for the user
+// arm (~/.local/bin), or place.InstallSymlink (sudo-capable) for the system
+// arm (/usr/local/bin). Returns the link path and the BinDirKind to persist.
+//
+// SUB5 #228 — keeping the branch in one place avoids drift across the
+// cached-skip and fresh-install call sites.
+func (i *Installer) createSymlink(ctx context.Context, tool *resource.Tool, target place.Target) (string, resource.BinDirKind, error) {
+	binDir, binDirKind := i.userBinDir, resource.BinDirKindUser
+	if tool.IsPrivileged() {
+		binDir, binDirKind = i.systemBinDir, resource.BinDirKindSystem
+	}
+	linkPath := i.placer.LinkPath(target, binDir)
+	if binDirKind == resource.BinDirKindSystem {
+		if err := place.InstallSymlink(ctx, i.placer.BinaryPath(target), linkPath); err != nil {
+			return "", "", fmt.Errorf("create system symlink: %w", err)
+		}
+		return linkPath, binDirKind, nil
+	}
+	if _, err := i.placer.Symlink(target, binDir); err != nil {
+		return "", "", fmt.Errorf("create user symlink: %w", err)
+	}
+	return linkPath, binDirKind, nil
+}
+
+// cleanupOldSymlink removes the old symlink and its target binary if the
+// binary name has changed OR if the BinDirKind transitioned across applies.
+// It compares the old BinPath from context with the new link path; the
+// cleanup helper is picked from the OLD BinDirKind (also from context).
+//
+// SUB5 #228: a BinDirKind transition (user↔system) is the expected case —
+// the old and new symlinks live in different directories, and we want the
+// old one cleaned up via the helper that matches its prior location.
 func (i *Installer) cleanupOldSymlink(ctx context.Context, newLinkPath string) {
 	oldBinPath := executor.OldBinPathFromContext(ctx)
 	if oldBinPath == "" || oldBinPath == newLinkPath {
 		return
 	}
 
-	// Safety check: old symlink must be in the same directory as the new one (bin dir)
-	if filepath.Dir(oldBinPath) != filepath.Dir(newLinkPath) {
-		slog.Warn("skipping old symlink cleanup: old bin path is outside expected directory",
-			"old", oldBinPath, "expected_dir", filepath.Dir(newLinkPath))
+	// SUB5 #228: the cleanup helper is chosen by the OLD BinDirKind read
+	// from context. The defensive guard validates the old symlink is in
+	// the dir its kind claims — independent of the new symlink's location,
+	// which may legitimately be in a different bin dir on a transition.
+	oldKind := executor.OldBinDirKindFromContext(ctx)
+	expectedOldDir := i.userBinDir
+	if oldKind == resource.BinDirKindSystem {
+		expectedOldDir = i.systemBinDir
+	}
+	if filepath.Dir(oldBinPath) != expectedOldDir {
+		slog.Warn("skipping old symlink cleanup: old bin path is outside expected directory for its BinDirKind",
+			"old", oldBinPath, "oldKind", oldKind, "expected_dir", expectedOldDir)
 		return
 	}
 
-	slog.Debug("cleaning up old symlink", "old", oldBinPath, "new", newLinkPath)
+	slog.Debug("cleaning up old symlink", "old", oldBinPath, "new", newLinkPath, "oldKind", oldKind)
 
 	// Resolve symlink target before removing the symlink itself,
 	// so we can also clean up the old binary file
@@ -530,7 +572,12 @@ func (i *Installer) cleanupOldSymlink(ctx context.Context, newLinkPath string) {
 		}
 	}
 
-	_ = i.placer.Cleanup(oldBinPath) // best-effort
+	// SUB5: pick the remove helper based on the OLD BinDirKind.
+	if oldKind == resource.BinDirKindSystem {
+		_ = place.RemoveSymlink(ctx, oldBinPath) // best-effort
+	} else {
+		_ = i.placer.Cleanup(oldBinPath) // best-effort
+	}
 }
 
 // isUnderDir checks whether path is strictly under dir (not equal to dir).
@@ -549,7 +596,14 @@ func isUnderDir(path, dir string) bool {
 }
 
 // buildState creates a ToolState from the installation result.
-func (i *Installer) buildState(spec *resource.ToolSpec, target place.Target, digest checksum.Digest) *resource.ToolState {
+// buildState assembles a ToolState for the download/registry install path.
+// binPath and binDirKind are passed in (rather than re-derived from spec)
+// so the caller's createSymlink result is the single source of truth.
+// Privileged is propagated from spec on both arms (mirroring installByCommands);
+// ToolComparator (reconciler/tool.go:43) only compares Privileged when
+// Commands is involved, so persisting it here cannot trigger spurious
+// reinstalls for download/registry tools.
+func (i *Installer) buildState(spec *resource.ToolSpec, target place.Target, digest checksum.Digest, binDirKind resource.BinDirKind, binPath string) *resource.ToolState {
 	return &resource.ToolState{
 		InstallerRef: spec.InstallerRef,
 		Version:      spec.Version,
@@ -557,25 +611,14 @@ func (i *Installer) buildState(spec *resource.ToolSpec, target place.Target, dig
 		SpecVersion:  spec.Version,
 		Digest:       digest,
 		InstallPath:  i.placer.BinaryPath(target),
-		BinPath:      i.placer.LinkPath(target, i.userBinDir),
-		BinDirKind:   resource.BinDirKindUser,
-		// Privileged is persisted on the download/registry write path too,
-		// mirroring installByCommands. Pre-SUB5, a privileged download or
-		// registry tool installed under --system still lands in the user
-		// bin directory (the actual SystemBinDir routing arrives in SUB5),
-		// but stamping state.Privileged=true now pre-wires the state-driven
-		// removal-skip gate (engine.go) and plan.go's privileged-removal
-		// branch — so once SUB5 routes installs to SystemBinDir, the
-		// removal side already works.
-		// ToolComparator (reconciler/tool.go:43) only compares Privileged
-		// when Commands is involved, so persisting it here cannot trigger
-		// spurious reinstalls for download/registry tools.
-		Privileged: spec.Privileged,
-		Source:     spec.Source,
-		RuntimeRef: spec.RuntimeRef,
-		Package:    spec.Package,
-		BinaryName: spec.BinaryName,
-		UpdatedAt:  time.Now(),
+		BinPath:      binPath,
+		BinDirKind:   binDirKind,
+		Privileged:   spec.Privileged,
+		Source:       spec.Source,
+		RuntimeRef:   spec.RuntimeRef,
+		Package:      spec.Package,
+		BinaryName:   spec.BinaryName,
+		UpdatedAt:    time.Now(),
 	}
 }
 
@@ -669,10 +712,18 @@ func (i *Installer) Remove(ctx context.Context, st *resource.ToolState, name str
 		}
 	}
 
-	// Remove the symlink
+	// Remove the symlink. SUB5 #228: state.BinDirKindOrDefault picks the
+	// cleanup helper — system goes through place.RemoveSymlink (sudo-capable),
+	// user (or pre-SUB6 empty) keeps Placer.Cleanup.
 	if st.BinPath != "" {
-		if err := i.placer.Cleanup(st.BinPath); err != nil {
-			slog.Debug("failed to remove symlink", "path", st.BinPath, "error", err)
+		if st.BinDirKindOrDefault() == resource.BinDirKindSystem {
+			if err := place.RemoveSymlink(ctx, st.BinPath); err != nil {
+				slog.Debug("failed to remove system symlink", "path", st.BinPath, "error", err)
+			}
+		} else {
+			if err := i.placer.Cleanup(st.BinPath); err != nil {
+				slog.Debug("failed to remove symlink", "path", st.BinPath, "error", err)
+			}
 		}
 	}
 

--- a/internal/installer/tool/installer.go
+++ b/internal/installer/tool/installer.go
@@ -733,12 +733,28 @@ func (i *Installer) Remove(ctx context.Context, st *resource.ToolState, name str
 	// Remove the symlink. SUB5 #228: state.BinDirKindOrDefault picks the
 	// cleanup helper — system goes through place.RemoveSymlink (sudo-capable),
 	// user (or pre-SUB6 empty) keeps Placer.Cleanup.
+	//
+	// Defense in depth: validate state.BinPath actually lives under the dir
+	// its BinDirKind claims before invoking the remove helper. A corrupted
+	// or stale state.json could otherwise persuade tomei to `sudo rm -f` an
+	// arbitrary symlink elsewhere on the filesystem. Mirrors the guard in
+	// cleanupOldSymlink. filepath.Clean is applied to userBinDir/systemBinDir
+	// since they come from config and may carry a trailing slash.
 	if st.BinPath != "" {
-		if st.BinDirKindOrDefault() == resource.BinDirKindSystem {
+		isSystem := st.BinDirKindOrDefault() == resource.BinDirKindSystem
+		expectedDir := filepath.Clean(i.userBinDir)
+		if isSystem {
+			expectedDir = filepath.Clean(i.systemBinDir)
+		}
+		switch {
+		case filepath.Dir(st.BinPath) != expectedDir:
+			slog.Warn("skipping symlink removal: state.BinPath is outside expected directory for its BinDirKind",
+				"name", name, "binPath", st.BinPath, "binDirKind", st.BinDirKindOrDefault(), "expected_dir", expectedDir)
+		case isSystem:
 			if err := place.RemoveSymlink(ctx, st.BinPath); err != nil {
 				slog.Debug("failed to remove system symlink", "path", st.BinPath, "error", err)
 			}
-		} else {
+		default:
 			if err := i.placer.Cleanup(st.BinPath); err != nil {
 				slog.Debug("failed to remove symlink", "path", st.BinPath, "error", err)
 			}

--- a/internal/installer/tool/installer_test.go
+++ b/internal/installer/tool/installer_test.go
@@ -369,6 +369,54 @@ func TestToolInstaller_Update_BinDirKindTransition(t *testing.T) {
 	}
 }
 
+// TestToolInstaller_Remove_OffDirBinPath_Skipped pins SUB5 #228's
+// defense-in-depth guard: when state.BinPath is NOT under the dir that its
+// BinDirKind claims (e.g., a corrupted state.json or stale state from a
+// different host config), Remove must skip the symlink-removal helper rather
+// than `sudo rm -f` an arbitrary path. The InstallPath cleanup still runs
+// (the binary's location is internal to tomei and unaffected).
+func TestToolInstaller_Remove_OffDirBinPath_Skipped(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		binDirKind resource.BinDirKind
+		binPath    string // intentionally outside both userBinDir and systemBinDir
+	}{
+		{
+			name:       "system kind with off-dir BinPath does not invoke RemoveSymlink",
+			binDirKind: resource.BinDirKindSystem,
+			binPath:    "/etc/some-other-link",
+		},
+		{
+			name:       "user kind with off-dir BinPath does not invoke Placer.Cleanup",
+			binDirKind: resource.BinDirKindUser,
+			binPath:    "/etc/some-other-link",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mp := &mockPlacer{}
+			inst := NewInstaller(&mockDownloader{}, mp, "/user-bin", "/system-bin")
+
+			st := &resource.ToolState{
+				InstallPath: "/install/path",
+				BinPath:     tt.binPath,
+				BinDirKind:  tt.binDirKind,
+			}
+			require.NoError(t, inst.Remove(context.Background(), st, "tool"))
+
+			assert.NotContains(t, mp.gotCleanupPaths, tt.binPath,
+				"off-dir BinPath must NOT reach Placer.Cleanup")
+			// RemoveSymlink's effect (real syscall) is not exercised here because
+			// the guard returns before reaching it; the absence of a panic /
+			// rm-of-/etc/some-other-link is the assertion.
+		})
+	}
+}
+
 // TestToolInstaller_Remove_BinDirKind pins SUB5 #228's remove-path routing:
 // the symlink cleanup helper is chosen by state.BinDirKindOrDefault — system
 // state uses place.RemoveSymlink (sudo-capable, t.TempDir() exercises the

--- a/internal/installer/tool/installer_test.go
+++ b/internal/installer/tool/installer_test.go
@@ -155,6 +155,40 @@ func TestToolInstaller_Install(t *testing.T) {
 	}
 }
 
+// TestBuildResolvedTool_PreservesPrivileged pins SUB5 #228: the registry
+// install path (installFromRegistry) hands a re-shaped Tool to installByDownload,
+// and Privileged MUST flow through that re-shaping. Dropping it would route
+// privileged registry installs to the user bin dir AND persist
+// state.Privileged=false — silently breaking the SUB5 contract for registry
+// tools (the download path was already covered by the install test, but the
+// registry path's spec-massaging is the bug-prone seam).
+func TestBuildResolvedTool_PreservesPrivileged(t *testing.T) {
+	t.Parallel()
+	for _, priv := range []bool{false, true} {
+		t.Run(fmt.Sprintf("privileged=%v", priv), func(t *testing.T) {
+			t.Parallel()
+			orig := &resource.Tool{
+				BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "tool"}},
+				ToolSpec: &resource.ToolSpec{
+					InstallerRef: "aqua",
+					Package:      &resource.Package{Owner: "owner", Repo: "repo"},
+					BinaryName:   "tool",
+					Privileged:   priv,
+				},
+			}
+			src := &resource.DownloadSource{URL: "https://example.com/x.tar.gz", ArchiveType: "tar.gz"}
+			got := buildResolvedTool(orig, src, "1.2.3")
+			assert.Equal(t, priv, got.ToolSpec.Privileged,
+				"buildResolvedTool must preserve Privileged so registry priv tools route through createSymlink correctly")
+			// Sanity: the re-shape preserves other identity fields too.
+			assert.Equal(t, "aqua", got.ToolSpec.InstallerRef)
+			assert.Equal(t, "1.2.3", got.ToolSpec.Version)
+			assert.Same(t, src, got.ToolSpec.Source)
+			assert.Same(t, orig.ToolSpec.Package, got.ToolSpec.Package)
+		})
+	}
+}
+
 // TestToolInstaller_Install_SystemSymlinkErrorWrap verifies that when
 // place.InstallSymlink fails on the privileged install path, the error is
 // wrapped via createSymlink with the "create system symlink" prefix. Pins
@@ -287,9 +321,8 @@ func TestToolInstaller_Update_BinDirKindTransition(t *testing.T) {
 // TestToolInstaller_Remove_BinDirKind pins SUB5 #228's remove-path routing:
 // the symlink cleanup helper is chosen by state.BinDirKindOrDefault — system
 // state uses place.RemoveSymlink (sudo-capable, t.TempDir() exercises the
-// direct path), user state uses Placer.Cleanup (existing behavior).
-// Cannot t.Parallel(): each subtest stamps a real symlink in its own TempDir,
-// which is fine, but mockPlacer state is per-test.
+// direct path), user state uses Placer.Cleanup (existing behavior). Subtests
+// run in parallel — each owns its own TempDir + mockPlacer, no shared state.
 func TestToolInstaller_Remove_BinDirKind(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/installer/tool/installer_test.go
+++ b/internal/installer/tool/installer_test.go
@@ -29,7 +29,7 @@ func TestNewInstaller(t *testing.T) {
 	downloader := download.NewDownloader()
 	placer := place.NewPlacer("/tools")
 
-	installer := NewInstaller(downloader, placer, "/bin")
+	installer := NewInstaller(downloader, placer, "/bin", "/system-bin")
 	assert.NotNil(t, installer)
 }
 
@@ -44,6 +44,10 @@ func TestToolInstaller_Install(t *testing.T) {
 		tool       *resource.Tool
 		wantErr    bool
 		errContain string
+		// wantBinDirKind is the expected state.BinDirKind on a successful install.
+		// For privileged download/registry installs SUB5 #228 routes the symlink
+		// to systemBinDir and stamps BinDirKindSystem; otherwise user.
+		wantBinDirKind resource.BinDirKind
 	}{
 		{
 			name: "successful install",
@@ -63,10 +67,11 @@ func TestToolInstaller_Install(t *testing.T) {
 					},
 				},
 			},
-			wantErr: false,
+			wantErr:        false,
+			wantBinDirKind: resource.BinDirKindUser,
 		},
 		{
-			name: "privileged download install propagates Privileged to state",
+			name: "privileged download install routes through system bin dir",
 			tool: &resource.Tool{
 				BaseResource: resource.BaseResource{
 					Metadata: resource.Metadata{Name: "ripgrep-priv"},
@@ -84,7 +89,8 @@ func TestToolInstaller_Install(t *testing.T) {
 					Privileged: true,
 				},
 			},
-			wantErr: false,
+			wantErr:        false,
+			wantBinDirKind: resource.BinDirKindSystem,
 		},
 		{
 			name: "missing source",
@@ -107,7 +113,10 @@ func TestToolInstaller_Install(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := &mockDownloader{archiveData: tarGzContent}
-			installer := NewInstaller(dl, &mockPlacer{}, "/bin")
+			// Privileged installs hit the real filesystem via place.InstallSymlink,
+			// so the system bin dir must be an actual directory.
+			userBinDir, systemBinDir := "/bin", t.TempDir()
+			installer := NewInstaller(dl, &mockPlacer{}, userBinDir, systemBinDir)
 
 			state, err := installer.Install(context.Background(), tt.tool, tt.tool.Name())
 
@@ -125,10 +134,228 @@ func TestToolInstaller_Install(t *testing.T) {
 			assert.Equal(t, tt.tool.ToolSpec.Version, state.Version)
 			assert.NotEmpty(t, state.InstallPath)
 			assert.NotEmpty(t, state.BinPath)
-			assert.Equal(t, resource.BinDirKindUser, state.BinDirKind,
-				"download/registry install should stamp BinDirKindUser so the gap closes on next apply (SUB6 #229)")
+			assert.Equal(t, tt.wantBinDirKind, state.BinDirKind,
+				"SUB5 #228: privileged → system; else user")
 			assert.Equal(t, tt.tool.ToolSpec.Privileged, state.Privileged,
-				"buildState should propagate spec.Privileged so the state-side gate works after SUB5 (SUB7 #230)")
+				"buildState should propagate spec.Privileged (SUB7 #230)")
+
+			// Privileged installs must place the symlink under systemBinDir
+			// (real filesystem); non-privileged go through mockPlacer.Symlink
+			// which records the user dir but doesn't touch disk.
+			if tt.tool.ToolSpec.Privileged {
+				assert.True(t, strings.HasPrefix(state.BinPath, systemBinDir),
+					"state.BinPath must be under systemBinDir for privileged installs; got %q", state.BinPath)
+				_, lerr := os.Lstat(state.BinPath)
+				assert.NoError(t, lerr, "system symlink should actually exist at state.BinPath")
+			} else {
+				assert.True(t, strings.HasPrefix(state.BinPath, userBinDir),
+					"state.BinPath must be under userBinDir for non-privileged installs; got %q", state.BinPath)
+			}
+		})
+	}
+}
+
+// TestToolInstaller_Install_SystemSymlinkErrorWrap verifies that when
+// place.InstallSymlink fails on the privileged install path, the error is
+// wrapped via createSymlink with the "create system symlink" prefix. Pins
+// the production wrap string so future maintainers don't drift it.
+//
+// Setup: pre-plant a regular (non-symlink) file at the link location.
+// place.InstallSymlink refuses to replace a non-symlink, surfacing an error
+// through createSymlink.
+func TestToolInstaller_Install_SystemSymlinkErrorWrap(t *testing.T) {
+	t.Parallel()
+	binaryContent := []byte("#!/bin/sh\necho hello")
+	tarGzContent := createTarGzContent(t, "tool", binaryContent)
+	archiveHash := sha256Hash(tarGzContent)
+
+	sysBinDir := t.TempDir()
+	// Pre-plant a regular file where the symlink would land.
+	require.NoError(t, os.WriteFile(filepath.Join(sysBinDir, "tool"), []byte("blocker"), 0o644))
+
+	dl := &mockDownloader{archiveData: tarGzContent}
+	inst := NewInstaller(dl, &mockPlacer{}, "/user-bin", sysBinDir)
+
+	tool := &resource.Tool{
+		BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "tool"}},
+		ToolSpec: &resource.ToolSpec{
+			InstallerRef: "download",
+			Version:      "1.0.0",
+			Source: &resource.DownloadSource{
+				URL:         "https://example.com/tool.tar.gz",
+				Checksum:    &resource.Checksum{Value: "sha256:" + archiveHash},
+				ArchiveType: "tar.gz",
+			},
+			Privileged: true,
+		},
+	}
+
+	state, err := inst.Install(context.Background(), tool, tool.Name())
+	require.Error(t, err)
+	assert.Nil(t, state)
+	assert.Contains(t, err.Error(), "create system symlink",
+		"createSymlink must wrap InstallSymlink errors with the system-arm prefix")
+}
+
+// TestToolInstaller_Update_BinDirKindTransition pins SUB5 #228's update-path
+// cleanup routing: when an upgrade flips between user and system bin dirs
+// (e.g., spec.Privileged toggled across applies), cleanupOldSymlink must
+// pick the right remove helper for the OLD kind read from context.
+//
+// The matrix covers all four user/system × priv-true/false combinations.
+// For "system" old kind we pre-seed a real symlink in t.TempDir() to verify
+// place.RemoveSymlink actually removes it. For "user" old kind we assert
+// mockPlacer.Cleanup recorded the path.
+func TestToolInstaller_Update_BinDirKindTransition(t *testing.T) {
+	t.Parallel()
+
+	binaryContent := []byte("#!/bin/sh\necho hello")
+	tarGzContent := createTarGzContent(t, "tool", binaryContent)
+	archiveHash := sha256Hash(tarGzContent)
+
+	tests := []struct {
+		name           string
+		oldKind        resource.BinDirKind
+		newPrivileged  bool
+		wantOldRemoved string // "placer" | "system" — which cleanup helper handled the old symlink
+	}{
+		{name: "user→user", oldKind: resource.BinDirKindUser, newPrivileged: false, wantOldRemoved: "placer"},
+		{name: "user→system", oldKind: resource.BinDirKindUser, newPrivileged: true, wantOldRemoved: "placer"},
+		{name: "system→user", oldKind: resource.BinDirKindSystem, newPrivileged: false, wantOldRemoved: "system"},
+		{name: "system→system", oldKind: resource.BinDirKindSystem, newPrivileged: true, wantOldRemoved: "system"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			userBinDir, systemBinDir := "/user-bin", t.TempDir()
+
+			// Seed an old symlink for the system arm so RemoveSymlink has
+			// something to remove (else it's a silent no-op on missing paths).
+			var oldBinPath string
+			if tt.oldKind == resource.BinDirKindSystem {
+				target := filepath.Join(t.TempDir(), "old-binary")
+				require.NoError(t, os.WriteFile(target, []byte("x"), 0o755))
+				oldBinPath = filepath.Join(systemBinDir, "tool-old-name")
+				require.NoError(t, os.Symlink(target, oldBinPath))
+			} else {
+				oldBinPath = filepath.Join(userBinDir, "tool-old-name")
+			}
+
+			mp := &mockPlacer{}
+			dl := &mockDownloader{archiveData: tarGzContent}
+			inst := NewInstaller(dl, mp, userBinDir, systemBinDir)
+
+			// Build a tool spec whose binaryName differs from oldBinPath so
+			// cleanupOldSymlink's "old != new" check fires.
+			toolRes := &resource.Tool{
+				BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "tool"}},
+				ToolSpec: &resource.ToolSpec{
+					InstallerRef: "download",
+					Version:      "1.0.0",
+					Source: &resource.DownloadSource{
+						URL:         "https://example.com/tool.tar.gz",
+						Checksum:    &resource.Checksum{Value: "sha256:" + archiveHash},
+						ArchiveType: "tar.gz",
+					},
+					Privileged: tt.newPrivileged,
+				},
+			}
+
+			ctx := executor.WithOldBinPath(context.Background(), oldBinPath)
+			ctx = executor.WithOldBinDirKind(ctx, tt.oldKind)
+
+			_, err := inst.Install(ctx, toolRes, toolRes.Name())
+			require.NoError(t, err)
+
+			switch tt.wantOldRemoved {
+			case "placer":
+				assert.Contains(t, mp.gotCleanupPaths, oldBinPath,
+					"user-kind old symlink should be removed via Placer.Cleanup")
+			case "system":
+				_, lerr := os.Lstat(oldBinPath)
+				assert.True(t, os.IsNotExist(lerr),
+					"system-kind old symlink should be removed via place.RemoveSymlink; lstat err: %v", lerr)
+				assert.NotContains(t, mp.gotCleanupPaths, oldBinPath,
+					"system-kind old symlink must NOT also be passed to Placer.Cleanup")
+			}
+		})
+	}
+}
+
+// TestToolInstaller_Remove_BinDirKind pins SUB5 #228's remove-path routing:
+// the symlink cleanup helper is chosen by state.BinDirKindOrDefault — system
+// state uses place.RemoveSymlink (sudo-capable, t.TempDir() exercises the
+// direct path), user state uses Placer.Cleanup (existing behavior).
+// Cannot t.Parallel(): each subtest stamps a real symlink in its own TempDir,
+// which is fine, but mockPlacer state is per-test.
+func TestToolInstaller_Remove_BinDirKind(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name              string
+		binDirKind        resource.BinDirKind
+		wantPlacerCleanup bool // whether mockPlacer.Cleanup should record st.BinPath
+		wantSystemRemoval bool // whether the real symlink in t.TempDir() should be removed
+	}{
+		{
+			name:              "user kind goes through Placer.Cleanup",
+			binDirKind:        resource.BinDirKindUser,
+			wantPlacerCleanup: true,
+			wantSystemRemoval: false,
+		},
+		{
+			name:              "empty kind defaults to user (pre-SUB6 backward-compat)",
+			binDirKind:        "",
+			wantPlacerCleanup: true,
+			wantSystemRemoval: false,
+		},
+		{
+			name:              "system kind goes through place.RemoveSymlink",
+			binDirKind:        resource.BinDirKindSystem,
+			wantPlacerCleanup: false,
+			wantSystemRemoval: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sysBinDir := t.TempDir()
+			mp := &mockPlacer{}
+			inst := NewInstaller(&mockDownloader{}, mp, "/user-bin", sysBinDir)
+
+			// Set up a real symlink in sysBinDir for the system case; otherwise
+			// RemoveSymlink is a no-op (missing path → matches `rm -f` semantics).
+			var binPath string
+			if tt.binDirKind == resource.BinDirKindSystem {
+				target := filepath.Join(t.TempDir(), "tool-binary")
+				require.NoError(t, os.WriteFile(target, []byte("x"), 0o755))
+				binPath = filepath.Join(sysBinDir, "tool")
+				require.NoError(t, os.Symlink(target, binPath))
+			} else {
+				binPath = "/user-bin/tool"
+			}
+
+			st := &resource.ToolState{
+				InstallPath: "/install/path",
+				BinPath:     binPath,
+				BinDirKind:  tt.binDirKind,
+			}
+
+			require.NoError(t, inst.Remove(context.Background(), st, "tool"))
+
+			if tt.wantPlacerCleanup {
+				assert.Contains(t, mp.gotCleanupPaths, binPath,
+					"user/empty kind must call Placer.Cleanup on st.BinPath")
+			} else {
+				assert.NotContains(t, mp.gotCleanupPaths, binPath,
+					"system kind must NOT call Placer.Cleanup on st.BinPath (RemoveSymlink handles it)")
+			}
+			if tt.wantSystemRemoval {
+				_, err := os.Lstat(binPath)
+				assert.True(t, os.IsNotExist(err), "system symlink should be removed; lstat err: %v", err)
+			}
 		})
 	}
 }
@@ -148,7 +375,7 @@ func TestToolInstaller_PassesUserBinDirToPlacer(t *testing.T) {
 
 	dl := &mockDownloader{archiveData: tarGzContent}
 	mp := &mockPlacer{}
-	installer := NewInstaller(dl, mp, sentinel)
+	installer := NewInstaller(dl, mp, sentinel, "/system-bin")
 
 	tool := &resource.Tool{
 		BaseResource: resource.BaseResource{
@@ -193,7 +420,7 @@ func TestToolInstaller_Install_Skip(t *testing.T) {
 
 	downloader := download.NewDownloader()
 	placer := place.NewPlacer(toolsDir)
-	inst := NewInstaller(downloader, placer, binDir)
+	inst := NewInstaller(downloader, placer, binDir, "/system-bin")
 
 	// No checksum - will skip if binary exists
 	tool := &resource.Tool{
@@ -227,7 +454,7 @@ func TestToolInstaller_InstallFromRegistry_NoResolver(t *testing.T) {
 
 	downloader := download.NewDownloader()
 	placer := place.NewPlacer(toolsDir)
-	installer := NewInstaller(downloader, placer, binDir)
+	installer := NewInstaller(downloader, placer, binDir, "/system-bin")
 
 	// No resolver set - should fail
 
@@ -259,7 +486,7 @@ func TestToolInstaller_InstallFromRegistry_NoRegistryRef(t *testing.T) {
 
 	downloader := download.NewDownloader()
 	placer := place.NewPlacer(toolsDir)
-	installer := NewInstaller(downloader, placer, binDir)
+	installer := NewInstaller(downloader, placer, binDir, "/system-bin")
 
 	// Set resolver but no registry ref
 	resolver := createMockResolver(t, cacheDir, "http://example.com")
@@ -356,6 +583,7 @@ func (m *mockDownloader) Verify(_ context.Context, _ string, cs *resource.Checks
 type mockPlacer struct {
 	gotSymlinkBinDirs []string
 	gotLinkPathBinDir string
+	gotCleanupPaths   []string // records Cleanup calls; SUB5 #228 remove-side assertions
 }
 
 func (m *mockPlacer) BinaryPath(target place.Target) string {
@@ -382,7 +610,8 @@ func (m *mockPlacer) Symlink(target place.Target, binDir string) (string, error)
 	return binDir + "/" + target.BinaryName, nil
 }
 
-func (m *mockPlacer) Cleanup(_ string) error {
+func (m *mockPlacer) Cleanup(path string) error {
+	m.gotCleanupPaths = append(m.gotCleanupPaths, path)
 	return nil
 }
 
@@ -458,7 +687,7 @@ func TestToolInstaller_Install_Args(t *testing.T) {
 			tmpDir := t.TempDir()
 			captureFile := filepath.Join(tmpDir, "captured_cmd.txt")
 
-			inst := NewInstaller(download.NewDownloader(), place.NewPlacer(filepath.Join(tmpDir, "tools")), filepath.Join(tmpDir, "bin"))
+			inst := NewInstaller(download.NewDownloader(), place.NewPlacer(filepath.Join(tmpDir, "tools")), filepath.Join(tmpDir, "bin"), filepath.Join(tmpDir, "system-bin"))
 			tt.setup(inst, captureFile)
 
 			tool := tt.tool(captureFile)
@@ -528,7 +757,7 @@ func TestToolInstaller_ProgressCallback_Priority(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := &mockDownloader{archiveData: archiveData}
-			installer := NewInstaller(dl, &mockPlacer{}, "/bin")
+			installer := NewInstaller(dl, &mockPlacer{}, "/bin", "/system-bin")
 
 			var fieldCalled, ctxCalled bool
 
@@ -841,7 +1070,7 @@ func TestInstallByCommands(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			runner := &mockCommandRunner{checkResult: tt.checkResult, executeErr: tt.executeErr}
-			inst := NewInstallerWithRunner(download.NewDownloader(), &mockPlacer{}, "/bin", runner)
+			inst := NewInstallerWithRunner(download.NewDownloader(), &mockPlacer{}, "/bin", "/system-bin", runner)
 
 			if tt.resolver != nil {
 				inst.SetVersionResolver(resolve.NewResolver(tt.resolver, nil))
@@ -934,7 +1163,7 @@ func TestRemoveByCommands(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			runner := &mockCommandRunner{checkResult: true, executeErr: tt.executeErr}
-			inst := NewInstallerWithRunner(download.NewDownloader(), &mockPlacer{}, "/bin", runner)
+			inst := NewInstallerWithRunner(download.NewDownloader(), &mockPlacer{}, "/bin", "/system-bin", runner)
 
 			err := inst.Remove(context.Background(), tt.state, "mytool")
 
@@ -981,7 +1210,7 @@ func TestInstallFromRegistry_ChecksumAlgorithmPropagation(t *testing.T) {
 	require.NoError(t, os.WriteFile(cacheFile, []byte(registryYAML), 0o644))
 
 	dl := &mockDownloader{archiveData: tarGzContent}
-	inst := NewInstaller(dl, &mockPlacer{}, "/bin")
+	inst := NewInstaller(dl, &mockPlacer{}, "/bin", "/system-bin")
 
 	resolver := aqua.NewResolver(cacheDir, nil)
 	inst.SetResolver(resolver, ref)

--- a/internal/installer/tool/installer_test.go
+++ b/internal/installer/tool/installer_test.go
@@ -189,6 +189,57 @@ func TestBuildResolvedTool_PreservesPrivileged(t *testing.T) {
 	}
 }
 
+// TestCleanupOldSymlink_TrailingSlashBinDir pins the SUB5 cleanup guard
+// against bin-dir strings that carry a trailing slash (or are otherwise not
+// filepath.Clean-canonical). filepath.Dir always returns a Cleaned path, so
+// without normalizing the Installer's userBinDir/systemBinDir on the
+// comparison side, the guard would reject equality and skip cleanup —
+// leaving a stale symlink behind on every transition.
+func TestCleanupOldSymlink_TrailingSlashBinDir(t *testing.T) {
+	t.Parallel()
+	binaryContent := []byte("#!/bin/sh\necho hello")
+	tarGzContent := createTarGzContent(t, "tool", binaryContent)
+	archiveHash := sha256Hash(tarGzContent)
+
+	systemBinDir := t.TempDir()
+	// Seed an old system-arm symlink and feed the Installer a trailing-slash
+	// systemBinDir. The seeded link's parent (Cleaned) must match the
+	// Installer's normalized expectedOldDir for cleanup to fire.
+	target := filepath.Join(t.TempDir(), "old-binary")
+	require.NoError(t, os.WriteFile(target, []byte("x"), 0o755))
+	oldBinPath := filepath.Join(systemBinDir, "tool-old")
+	require.NoError(t, os.Symlink(target, oldBinPath))
+
+	mp := &mockPlacer{}
+	dl := &mockDownloader{archiveData: tarGzContent}
+	// Pass the system dir WITH a trailing slash — the dirty form that an
+	// operator could supply via WithSystemBinDir from config.
+	inst := NewInstaller(dl, mp, "/user-bin", systemBinDir+"/")
+
+	toolRes := &resource.Tool{
+		BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "tool"}},
+		ToolSpec: &resource.ToolSpec{
+			InstallerRef: "download",
+			Version:      "1.0.0",
+			Source: &resource.DownloadSource{
+				URL:         "https://example.com/tool.tar.gz",
+				Checksum:    &resource.Checksum{Value: "sha256:" + archiveHash},
+				ArchiveType: "tar.gz",
+			},
+			Privileged: true, // system→system transition; old was system, new is system
+		},
+	}
+
+	ctx := executor.WithOldBinPath(context.Background(), oldBinPath)
+	ctx = executor.WithOldBinDirKind(ctx, resource.BinDirKindSystem)
+	_, err := inst.Install(ctx, toolRes, toolRes.Name())
+	require.NoError(t, err)
+
+	_, lerr := os.Lstat(oldBinPath)
+	assert.True(t, os.IsNotExist(lerr),
+		"old system symlink must be removed even when systemBinDir has a trailing slash; lstat err: %v", lerr)
+}
+
 // TestToolInstaller_Install_SystemSymlinkErrorWrap verifies that when
 // place.InstallSymlink fails on the privileged install path, the error is
 // wrapped via createSymlink with the "create system symlink" prefix. Pins

--- a/internal/installer/tool/installer_test.go
+++ b/internal/installer/tool/installer_test.go
@@ -369,27 +369,41 @@ func TestToolInstaller_Update_BinDirKindTransition(t *testing.T) {
 	}
 }
 
-// TestToolInstaller_Remove_OffDirBinPath_Skipped pins SUB5 #228's
-// defense-in-depth guard: when state.BinPath is NOT under the dir that its
-// BinDirKind claims (e.g., a corrupted state.json or stale state from a
-// different host config), Remove must skip the symlink-removal helper rather
-// than `sudo rm -f` an arbitrary path. The InstallPath cleanup still runs
-// (the binary's location is internal to tomei and unaffected).
-func TestToolInstaller_Remove_OffDirBinPath_Skipped(t *testing.T) {
+// TestToolInstaller_Remove_NonSystemPath_NoSudoEscalation pins SUB5 #228's
+// defense-in-depth gate on the sudo-capable removal helper: place.RemoveSymlink
+// is invoked ONLY when state declares BinDirKindSystem AND state.BinPath is
+// actually under the configured systemBinDir. Any other shape falls back to
+// the unprivileged Placer.Cleanup — so a tampered state.json cannot persuade
+// tomei to `sudo rm -f` an arbitrary symlink, and runtime-delegated tools
+// (BinPath in ~/go/bin, no BinDirKind) clean up correctly without escalation.
+func TestToolInstaller_Remove_NonSystemPath_NoSudoEscalation(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name       string
 		binDirKind resource.BinDirKind
-		binPath    string // intentionally outside both userBinDir and systemBinDir
+		binPath    string
 	}{
 		{
-			name:       "system kind with off-dir BinPath does not invoke RemoveSymlink",
+			// Corrupted state: declares system, but path is elsewhere → MUST NOT
+			// reach the sudo helper. Fallback to unprivileged Cleanup.
+			name:       "system kind with off-dir BinPath falls back to unprivileged Cleanup",
 			binDirKind: resource.BinDirKindSystem,
 			binPath:    "/etc/some-other-link",
 		},
 		{
-			name:       "user kind with off-dir BinPath does not invoke Placer.Cleanup",
+			// Runtime-delegated tools (e.g., gopls via `go install`) have
+			// BinPath in the runtime's bin dir, not tomei's user bin. Empty
+			// BinDirKind defaults to user; the fallback handles it cleanly.
+			name:       "runtime-delegated BinPath (empty BinDirKind, ~/go/bin) uses Cleanup",
+			binDirKind: "",
+			binPath:    "/home/user/go/bin/gopls",
+		},
+		{
+			// User kind under a different dir from configured userBinDir
+			// (e.g., state from a different host config). Unprivileged
+			// Cleanup is best-effort and bounded by the user's perms.
+			name:       "user kind with off-dir BinPath uses Cleanup (already unprivileged)",
 			binDirKind: resource.BinDirKindUser,
 			binPath:    "/etc/some-other-link",
 		},
@@ -408,11 +422,10 @@ func TestToolInstaller_Remove_OffDirBinPath_Skipped(t *testing.T) {
 			}
 			require.NoError(t, inst.Remove(context.Background(), st, "tool"))
 
-			assert.NotContains(t, mp.gotCleanupPaths, tt.binPath,
-				"off-dir BinPath must NOT reach Placer.Cleanup")
-			// RemoveSymlink's effect (real syscall) is not exercised here because
-			// the guard returns before reaching it; the absence of a panic /
-			// rm-of-/etc/some-other-link is the assertion.
+			// Every non-system-path case must reach Placer.Cleanup (unprivileged)
+			// rather than the sudo-capable RemoveSymlink.
+			assert.Contains(t, mp.gotCleanupPaths, tt.binPath,
+				"non-system path must fall back to unprivileged Placer.Cleanup")
 		})
 	}
 }

--- a/tests/tool_installer_test.go
+++ b/tests/tool_installer_test.go
@@ -50,7 +50,7 @@ func TestToolInstaller_Install_HTTP(t *testing.T) {
 
 	dl := download.NewDownloader()
 	placer := place.NewPlacer(toolsDir)
-	installer := toolpkg.NewInstaller(dl, placer, binDir)
+	installer := toolpkg.NewInstaller(dl, placer, binDir, filepath.Join(tmpDir, "system-bin"))
 
 	tool := &resource.Tool{
 		BaseResource: resource.BaseResource{
@@ -122,7 +122,7 @@ func TestToolInstaller_InstallFromRegistry_HTTP(t *testing.T) {
 
 	dl := download.NewDownloader()
 	placer := place.NewPlacer(toolsDir)
-	installer := toolpkg.NewInstaller(dl, placer, binDir)
+	installer := toolpkg.NewInstaller(dl, placer, binDir, filepath.Join(tmpDir, "system-bin"))
 
 	resolver := aqua.NewResolverWithBaseURL(cacheDir, server.URL)
 	installer.SetResolver(resolver, "v4.465.0")
@@ -180,7 +180,7 @@ func TestToolInstaller_Install_HTTP_BinaryName(t *testing.T) {
 
 	dl := download.NewDownloader()
 	placer := place.NewPlacer(toolsDir)
-	installer := toolpkg.NewInstaller(dl, placer, binDir)
+	installer := toolpkg.NewInstaller(dl, placer, binDir, filepath.Join(tmpDir, "system-bin"))
 
 	tool := &resource.Tool{
 		BaseResource: resource.BaseResource{
@@ -252,7 +252,7 @@ func TestToolInstaller_InstallFromRegistry_HTTP_BinaryName(t *testing.T) {
 
 	dl := download.NewDownloader()
 	placer := place.NewPlacer(toolsDir)
-	installer := toolpkg.NewInstaller(dl, placer, binDir)
+	installer := toolpkg.NewInstaller(dl, placer, binDir, filepath.Join(tmpDir, "system-bin"))
 
 	resolver := aqua.NewResolverWithBaseURL(cacheDir, server.URL)
 	installer.SetResolver(resolver, "v4.465.0")
@@ -303,7 +303,7 @@ func TestToolInstaller_Install_HTTP_BinaryName_OldSymlinkCleanup(t *testing.T) {
 
 	dl := download.NewDownloader()
 	placer := place.NewPlacer(toolsDir)
-	installer := toolpkg.NewInstaller(dl, placer, binDir)
+	installer := toolpkg.NewInstaller(dl, placer, binDir, filepath.Join(tmpDir, "system-bin"))
 
 	// First install: no binaryName override → symlink at binDir/krew
 	tool1 := &resource.Tool{


### PR DESCRIPTION
The keystone of umbrella #223 Phase 2. SUB4 (#237) extended
Tool.IsPrivileged() to recognize download/registry-privileged tools.
SUB6 (#238) added ToolState.BinDirKind. SUB7 (#239) wired the
user-facing skip messaging and persisted state.Privileged on the
download/registry write path. SUB5 finally routes the install / update /
remove flows so privileged download/registry tools' symlinks land in
SystemBinDir (/usr/local/bin) via SUB3's portable helpers, while
non-privileged installs keep using the user-binDir Placer path.

Install path (createSymlink helper): Tool.IsPrivileged() picks the
arm — system uses place.InstallSymlink (sudo-n fallback), user keeps
Placer.Symlink. Applied at both cached-skip and fresh-install call
sites so a privileged tool with binary already cached doesn't
silently re-create a user-dir symlink. buildState now takes
(binDirKind, binPath) as parameters for atomic state construction.

Update path: OldBinDirKind is plumbed through executor context
(mirroring OldBinPath). cleanupOldSymlink reads it to pick the right
remove helper for the prior location, regardless of where the new
symlink lands. Defensive guard rewritten: validates oldBinPath
against the dir expected for OldBinDirKind (rather than requiring
old and new dirs to match) — so user↔system transitions clean up
correctly.

Remove path: Installer.Remove branches on state.BinDirKindOrDefault()
— system → place.RemoveSymlink (sudo-n fallback), user (or
pre-SUB6 empty) → Placer.Cleanup. The InstallPath cleanup is
unchanged: the binary lives under the user data dir regardless of
where its symlink points.

Constructor: tool.NewInstaller now takes a 4th arg `systemBinDir`;
apply.go passes pathConfig.SystemBinDir(). InstallSymlink and
RemoveSymlink are exported (rename of the SUB3 helpers, no behavior
change).

Tests cover: priv install via download/registry (system routing),
remove BinDirKind branch (user/empty/system), 4-case update-path
transition matrix (user↔system × priv true/false), and a
createSymlink error-wrap regression guard.

Out of scope: e2e (SUB8 #231), docs/design.md (SUB9 #232),
unifying Placer.Symlink through InstallSymlink (would touch the
runtime installer — separate cleanup task).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
