### PR TITLE
fix(apply): silence spurious warnings and TUI panic on cross-engine apply

### DIFF
--- a/internal/installer/command/executor.go
+++ b/internal/installer/command/executor.go
@@ -211,7 +211,14 @@ func (e *Executor) ExecuteCapture(ctx context.Context, cmds []string, vars Vars,
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		slog.Error("command failed", "command", expanded, "error", err, "stderr", stderr.String())
+		// ExecuteCapture is commonly used for check/query commands where a
+		// non-zero exit is a normal "negative result" (e.g., `dpkg-query` exit
+		// 1 = "package not installed yet" — apt's installer maps it to
+		// `(false, nil)` and proceeds with install). Log at Debug so the
+		// engine doesn't spam ERROR for routine negatives; callers that need
+		// to surface a real failure already wrap and re-log the returned
+		// error themselves.
+		slog.Debug("capture command failed", "command", expanded, "error", err, "stderr", stderr.String())
 		return "", fmt.Errorf("command failed: %s: %w", expanded, err)
 	}
 

--- a/internal/state/validator.go
+++ b/internal/state/validator.go
@@ -32,11 +32,12 @@ func (r *ValidationResult) warn(field, message string) {
 	r.Warnings = append(r.Warnings, ValidationError{Field: field, Message: message})
 }
 
-// validateVersion checks the state file format version.
+// validateVersion checks the state file format version. An empty version
+// means the state has not been persisted yet (freshly initialized state on
+// first --system apply, before any Save) and is not a user-actionable
+// warning. Only an explicitly-set wrong version warrants surfacing.
 func (r *ValidationResult) validateVersion(version string) {
-	if version == "" {
-		r.warn("version", "version is empty")
-	} else if version != Version {
+	if version != "" && version != Version {
 		r.warn("version", fmt.Sprintf("unknown version %q (expected %q)", version, Version))
 	}
 }

--- a/internal/state/validator_test.go
+++ b/internal/state/validator_test.go
@@ -30,10 +30,12 @@ func TestValidateUserState(t *testing.T) {
 			wantWarnings: 0,
 		},
 		{
-			name:         "empty version",
+			// Empty version means the state hasn't been persisted yet (first
+			// --system apply before any Save). Not a user-actionable warning.
+			name:         "empty version is not a warning (fresh state)",
 			state:        &UserState{},
 			wantValid:    true,
-			wantWarnings: 1,
+			wantWarnings: 0,
 		},
 		{
 			name: "unknown version",
@@ -104,7 +106,7 @@ func TestValidateUserState(t *testing.T) {
 				},
 			},
 			wantValid:    true,
-			wantWarnings: 4, // version + tools.gh.version + runtimes.go.version + runtimes.go.installPath
+			wantWarnings: 3, // tools.gh.version + runtimes.go.version + runtimes.go.installPath (empty top-level version no longer warns)
 		},
 		{
 			name: "nil maps are valid",
@@ -141,10 +143,12 @@ func TestValidateSystemState(t *testing.T) {
 			wantWarnings: 0,
 		},
 		{
-			name:         "empty version",
+			// Empty version means freshly-initialized state (first --system
+			// apply before any Save). Not a user-actionable warning.
+			name:         "empty version is not a warning (fresh state)",
 			state:        &SystemState{},
 			wantValid:    true,
-			wantWarnings: 1,
+			wantWarnings: 0,
 		},
 		{
 			name:         "unknown version",

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -60,9 +60,19 @@ type layerState struct {
 
 // ApplyModel is the Bubble Tea model for the apply TUI.
 type ApplyModel struct {
-	// All layer information (set from first EventLayerStart.AllLayerNodes)
+	// All layer information (set from first EventLayerStart.AllLayerNodes).
+	// When --system runs, the system engine and user engine each emit their
+	// own EventLayerStart streams; allLayerNodes / totalLayers are extended
+	// when the second engine starts so the combined timeline indexes cleanly.
 	allLayerNodes [][]string
 	totalLayers   int
+
+	// layerOffset is the index in allLayerNodes where the current engine's
+	// layers start. Zero when only one engine has fired events; jumps to
+	// len(allLayerNodes) at the moment a second engine begins emitting.
+	// Used to translate engine-local event.Layer indices into our combined
+	// timeline (currentLayer = layerOffset + event.Layer for DAG events).
+	layerOffset int
 
 	// Current layer index and phase
 	currentLayer int

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -69,8 +69,11 @@ func (m *ApplyModel) handleEngineEvent(event engine.Event) (tea.Model, tea.Cmd) 
 func (m *ApplyModel) handleLayerStart(event engine.Event) (tea.Model, tea.Cmd) {
 	now := time.Now()
 
-	// First EventLayerStart: initialize all-layer info and start timing
-	if m.applyStart.IsZero() {
+	// First EventLayerStart of the apply run: initialize all-layer info and
+	// start timing. Snapshot the prior value so the engine-boundary check
+	// below can distinguish "first event ever" from "second engine, layer 0".
+	isFirstEvent := m.applyStart.IsZero()
+	if isFirstEvent {
 		m.applyStart = now
 		m.allLayerNodes = event.AllLayerNodes
 		m.totalLayers = event.TotalLayers
@@ -84,14 +87,18 @@ func (m *ApplyModel) handleLayerStart(event engine.Event) (tea.Model, tea.Cmd) {
 		m.allLayerNodes = append(m.allLayerNodes, event.LayerNodes)
 		m.currentLayer = len(m.allLayerNodes) - 1
 	} else {
-		// Detect a new engine starting: PhaseDAG Layer 0 after we've already
-		// passed layer 0 means the system engine has finished and the user
-		// engine is emitting now (or vice versa). Snapshot the previous
-		// engine's final layer, then extend allLayerNodes / totalLayers with
-		// the new engine's AllLayerNodes so subsequent Layer indices stay in
-		// bounds (without this, the combined snapshotCount can exceed
-		// len(allLayerNodes) and View() panics with index out of range).
-		if event.Layer == 0 && m.currentLayer > 0 {
+		// Detect a new engine starting: any PhaseDAG Layer 0 that ISN'T the
+		// very first event of the run means a second engine is emitting (the
+		// system and user engines each emit their own EventLayerStart stream
+		// under --system). Snapshot the previous engine's final layer, then
+		// extend allLayerNodes / totalLayers with the new engine's
+		// AllLayerNodes so subsequent Layer indices stay in bounds (without
+		// this, the combined snapshotCount can exceed len(allLayerNodes) and
+		// View() panics with index out of range). Keying on isFirstEvent
+		// rather than currentLayer > 0 also covers the case where the prior
+		// engine emitted only a single PhaseDAG Layer 0 — currentLayer would
+		// still be 0 there but it's still a boundary.
+		if event.Layer == 0 && !isFirstEvent {
 			m.snapshotCurrentLayer()
 			m.layerOffset = len(m.allLayerNodes)
 			m.allLayerNodes = append(m.allLayerNodes, event.AllLayerNodes...)

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -84,11 +84,23 @@ func (m *ApplyModel) handleLayerStart(event engine.Event) (tea.Model, tea.Cmd) {
 		m.allLayerNodes = append(m.allLayerNodes, event.LayerNodes)
 		m.currentLayer = len(m.allLayerNodes) - 1
 	} else {
-		// Snapshot previous layer (if not the first DAG layer)
-		if event.Layer > 0 {
+		// Detect a new engine starting: PhaseDAG Layer 0 after we've already
+		// passed layer 0 means the system engine has finished and the user
+		// engine is emitting now (or vice versa). Snapshot the previous
+		// engine's final layer, then extend allLayerNodes / totalLayers with
+		// the new engine's AllLayerNodes so subsequent Layer indices stay in
+		// bounds (without this, the combined snapshotCount can exceed
+		// len(allLayerNodes) and View() panics with index out of range).
+		if event.Layer == 0 && m.currentLayer > 0 {
+			m.snapshotCurrentLayer()
+			m.layerOffset = len(m.allLayerNodes)
+			m.allLayerNodes = append(m.allLayerNodes, event.AllLayerNodes...)
+			m.totalLayers = m.layerOffset + event.TotalLayers
+		} else if event.Layer > 0 {
+			// Snapshot previous layer (within the same engine's stream).
 			m.snapshotCurrentLayer()
 		}
-		m.currentLayer = event.Layer
+		m.currentLayer = m.layerOffset + event.Layer
 	}
 
 	// Reset for new layer

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -494,3 +494,94 @@ func TestUpdate_KeyCtrlC_SetsInterruptedAndQuits(t *testing.T) {
 	assert.True(t, model.Interrupted(), "Interrupted() should be true after Ctrl+C")
 	assert.NotNil(t, cmd, "should return a quit command")
 }
+
+// TestUpdate_EventLayerStart_SecondEngineBoundary locks in the fix for the
+// cross-engine TUI panic. When --system runs, the SystemEngine and Engine
+// each emit their own EventLayerStart streams; the second engine's PhaseDAG
+// Layer 0 must be recognized as a NEW engine boundary, not as a re-entry
+// into slot 0 of the first engine's timeline. The boundary check keys on
+// isFirstEvent (was applyStart zero before this event?) rather than
+// currentLayer > 0, which would miss the case where the prior engine
+// emitted only a single PhaseDAG Layer 0.
+func TestUpdate_EventLayerStart_SecondEngineBoundary(t *testing.T) {
+	t.Parallel()
+
+	// Helper to feed one EventLayerStart and return the updated model.
+	step := func(m *ApplyModel, ev engine.Event) *ApplyModel {
+		updated, _ := m.Update(engineEventMsg{event: ev})
+		return updated.(*ApplyModel)
+	}
+
+	t.Run("two engines, first emits multiple layers", func(t *testing.T) {
+		t.Parallel()
+		m := NewApplyModel(&ApplyResults{})
+
+		// First engine: 2 PhaseDAG layers
+		m = step(m, engine.Event{
+			Type: engine.EventLayerStart, Phase: engine.PhaseDAG,
+			Layer: 0, TotalLayers: 2,
+			LayerNodes:    []string{"SystemInstaller/apt"},
+			AllLayerNodes: [][]string{{"SystemInstaller/apt"}, {"SystemPackageSet/build-deps"}},
+		})
+		m = step(m, engine.Event{
+			Type: engine.EventLayerStart, Phase: engine.PhaseDAG,
+			Layer: 1, TotalLayers: 2,
+			LayerNodes:    []string{"SystemPackageSet/build-deps"},
+			AllLayerNodes: [][]string{{"SystemInstaller/apt"}, {"SystemPackageSet/build-deps"}},
+		})
+
+		// Second engine kicks off with its own PhaseDAG Layer 0.
+		m = step(m, engine.Event{
+			Type: engine.EventLayerStart, Phase: engine.PhaseDAG,
+			Layer: 0, TotalLayers: 2,
+			LayerNodes:    []string{"Runtime/go"},
+			AllLayerNodes: [][]string{{"Runtime/go"}, {"Tool/cue"}},
+		})
+
+		assert.Equal(t, 2, m.layerOffset, "second engine's layers should be offset by the first engine's count")
+		assert.Equal(t, 2, m.currentLayer, "currentLayer should be layerOffset + event.Layer")
+		assert.Len(t, m.allLayerNodes, 4, "allLayerNodes must be extended, not re-used in place")
+		assert.Equal(t, 4, m.totalLayers, "totalLayers must be extended to cover the second engine")
+
+		// Drive the second engine's Layer 1 — without the fix it would
+		// crash later snapshot/render code; verify currentLayer translates.
+		m = step(m, engine.Event{
+			Type: engine.EventLayerStart, Phase: engine.PhaseDAG,
+			Layer: 1, TotalLayers: 2,
+			LayerNodes:    []string{"Tool/cue"},
+			AllLayerNodes: [][]string{{"Runtime/go"}, {"Tool/cue"}},
+		})
+		assert.Equal(t, 3, m.currentLayer, "Layer 1 of the second engine maps to combined index 3")
+	})
+
+	t.Run("first engine emits only one PhaseDAG Layer 0", func(t *testing.T) {
+		t.Parallel()
+		// This is the case the original check missed: currentLayer was still
+		// 0 when the second engine fired Layer 0, so the boundary branch was
+		// skipped. With the isFirstEvent gate, the boundary is detected.
+		m := NewApplyModel(&ApplyResults{})
+
+		m = step(m, engine.Event{
+			Type: engine.EventLayerStart, Phase: engine.PhaseDAG,
+			Layer: 0, TotalLayers: 1,
+			LayerNodes:    []string{"SystemInstaller/apt"},
+			AllLayerNodes: [][]string{{"SystemInstaller/apt"}},
+		})
+
+		require.Equal(t, 0, m.currentLayer)
+		require.Equal(t, 0, m.layerOffset)
+
+		// Second engine starts with its own PhaseDAG Layer 0.
+		m = step(m, engine.Event{
+			Type: engine.EventLayerStart, Phase: engine.PhaseDAG,
+			Layer: 0, TotalLayers: 2,
+			LayerNodes:    []string{"Runtime/go"},
+			AllLayerNodes: [][]string{{"Runtime/go"}, {"Tool/cue"}},
+		})
+
+		assert.Equal(t, 1, m.layerOffset, "boundary must be detected even though prior engine only had 1 layer")
+		assert.Equal(t, 1, m.currentLayer)
+		assert.Len(t, m.allLayerNodes, 3, "second engine's 2 layers should extend the timeline to 3 total")
+		assert.Equal(t, 3, m.totalLayers)
+	})
+}


### PR DESCRIPTION
- command/executor.go: demote ExecuteCapture failure log from Error to Debug —
  dpkg-query returning exit 1 ("package not installed") is a normal probe
  outcome on Phase 4 SystemPackage idempotence checks, not a user-facing error
- state/validator.go: drop the empty-version warning for fresh UserState /
  SystemState. The first --system apply runs validation before any Save, so
  an empty top-level version is expected, not an actionable warning
- internal/ui: when both SystemEngine and Engine fire EventLayerStart streams
  on --system, the user-engine's Layer 0 used to collide with the
  system-engine's slot, panicking View() with index out of range. Track a
  layerOffset and translate engine-local layer indices into the combined
  timeline so allLayerNodes grows cleanly across the engine boundary

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
