### PR TITLE
feat(examples): extend real-world with Phase 2 privileged + Phase 4 system packages

### DIFF
--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -4,9 +4,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
     build-essential \
+    sudo \
     vim
 
-RUN useradd -m -s /bin/bash lipnoise
+# NOPASSWD sudo so `tomei apply --system` (Phase 2 privileged tools + Phase 4
+# SystemPackage*) works inside the example container without an interactive
+# prompt. Same configuration as the e2e test container at
+# e2e/containers/ubuntu/Dockerfile.
+RUN useradd -m -s /bin/bash lipnoise && \
+    echo "lipnoise ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/lipnoise && \
+    chown root:root /etc/sudoers.d/lipnoise && \
+    chmod 0440 /etc/sudoers.d/lipnoise
 
 COPY tomei /usr/local/bin/tomei
 RUN chmod +x /usr/local/bin/tomei

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -18,13 +18,14 @@ build: ## Build tomei binary and example container
 	docker build -t $(IMAGE_NAME) .
 
 run: ## Run interactive shell in example container
-	# Pass GITHUB_TOKEN / GH_TOKEN through if set on the host. tomei init's
-	# aqua-registry fetch goes through api.github.com (to resolve the
-	# latest ref) and raw.githubusercontent.com (to fetch registry content).
-	# Anonymous traffic from a fresh container is rate-limited to the point
-	# that fresh containers reliably hit HTTP 403 within seconds. Without a
-	# token, the aqua-based tools in real-world/ (k8s, utility, privileged)
-	# all fail with "aqua-registry resolver not configured".
+	# Pass GITHUB_TOKEN / GH_TOKEN through if set on the host. tomei init
+	# resolves the latest aqua-registry ref via api.github.com; the
+	# actual registry content is fetched later from raw.githubusercontent.com
+	# when aqua-based tools are installed. Both endpoints are rate-limited
+	# for anonymous traffic, so fresh containers reliably hit HTTP 403
+	# within seconds. Without a token, the aqua-based tools in real-world/
+	# (k8s, utility, privileged) all fail with
+	# "aqua-registry resolver not configured".
 	# `-e VAR` (no =value) forwards the host env var without putting its
 	# value on the docker argv, so the token can't leak via `ps`/shell
 	# history. If neither var is set on the host, both are simply absent

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -25,9 +25,13 @@ run: ## Run interactive shell in example container
 	# that fresh containers reliably hit HTTP 403 within seconds. Without a
 	# token, the aqua-based tools in real-world/ (k8s, utility, privileged)
 	# all fail with "aqua-registry resolver not configured".
+	# `-e VAR` (no =value) forwards the host env var without putting its
+	# value on the docker argv, so the token can't leak via `ps`/shell
+	# history. If neither var is set on the host, both are simply absent
+	# inside the container — which is the same as the previous behavior.
 	docker run --rm -it --name $(CONTAINER_NAME) \
-		-e GITHUB_TOKEN="$${GITHUB_TOKEN:-}" \
-		-e GH_TOKEN="$${GH_TOKEN:-}" \
+		-e GITHUB_TOKEN \
+		-e GH_TOKEN \
 		$(IMAGE_NAME)
 
 clean: ## Clean up

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -8,11 +8,26 @@ GOARCH ?= $(shell go env GOARCH)
 
 build: ## Build tomei binary and example container
 	$(MAKE) -C .. vendor-cue
-	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o tomei ../cmd/tomei
+	# CGO_ENABLED=0 produces a statically-linked binary so the container
+	# (ubuntu:24.04, glibc) can execute the binary regardless of the
+	# host's libc / dynamic linker. Without this, Nix / Alpine hosts
+	# bake in an absolute interp path (e.g., /nix/store/.../ld-linux.so)
+	# that the container cannot resolve, producing the famously cryptic
+	# `bash: ./tomei: cannot execute: required file not found`.
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o tomei ../cmd/tomei
 	docker build -t $(IMAGE_NAME) .
 
 run: ## Run interactive shell in example container
-	docker run --rm -it --name $(CONTAINER_NAME) $(IMAGE_NAME)
+	# Pass GITHUB_TOKEN / GH_TOKEN through if set on the host. tomei init's
+	# aqua-registry fetch goes through GitHub's API and the OCI registry —
+	# anonymous traffic from ghcr.io / api.github.com is rate-limited to
+	# the point that fresh containers reliably hit HTTP 403 within seconds.
+	# Without a token, the aqua-based tools in real-world/ (k8s, utility,
+	# privileged) all fail with "aqua-registry resolver not configured".
+	docker run --rm -it --name $(CONTAINER_NAME) \
+		-e GITHUB_TOKEN="$${GITHUB_TOKEN:-}" \
+		-e GH_TOKEN="$${GH_TOKEN:-}" \
+		$(IMAGE_NAME)
 
 clean: ## Clean up
 	rm -f tomei

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -19,11 +19,12 @@ build: ## Build tomei binary and example container
 
 run: ## Run interactive shell in example container
 	# Pass GITHUB_TOKEN / GH_TOKEN through if set on the host. tomei init's
-	# aqua-registry fetch goes through GitHub's API and the OCI registry —
-	# anonymous traffic from ghcr.io / api.github.com is rate-limited to
-	# the point that fresh containers reliably hit HTTP 403 within seconds.
-	# Without a token, the aqua-based tools in real-world/ (k8s, utility,
-	# privileged) all fail with "aqua-registry resolver not configured".
+	# aqua-registry fetch goes through api.github.com (to resolve the
+	# latest ref) and raw.githubusercontent.com (to fetch registry content).
+	# Anonymous traffic from a fresh container is rate-limited to the point
+	# that fresh containers reliably hit HTTP 403 within seconds. Without a
+	# token, the aqua-based tools in real-world/ (k8s, utility, privileged)
+	# all fail with "aqua-registry resolver not configured".
 	docker run --rm -it --name $(CONTAINER_NAME) \
 		-e GITHUB_TOKEN="$${GITHUB_TOKEN:-}" \
 		-e GH_TOKEN="$${GH_TOKEN:-}" \

--- a/examples/real-world/README.md
+++ b/examples/real-world/README.md
@@ -20,7 +20,10 @@ real-world/
 ├── rust.cue                # cargo-binstall + binstall installer
 ├── uv.cue                  # ruff, mypy, httpie, black (via uv)
 ├── node.cue                # prettier, ts-node, typescript, npm-check-updates (via pnpm)
-└── krew.cue                # ctx, ns, neat, node-shell (via krew)
+├── krew.cue                # ctx, ns, neat, node-shell (via krew)
+├── brew.cue                # Darwin/arm64-only (Homebrew formulae)
+├── system_packages.cue     # apt SystemInstaller + build-deps (Phase 4, Linux only)
+└── privileged.cue          # lazygit via aqua + privileged: true (Phase 2)
 ```
 
 ## Runtimes (4)
@@ -45,6 +48,24 @@ real-world/
 | `node.cue` | pnpm (delegation) | prettier, ts-node, typescript, npm-check-updates |
 | `krew.cue` | krew (delegation) | ctx, ns, neat, node-shell |
 
+## Privileged Tools (1, `--system`)
+
+These tools are symlinked into the system bin directory (default `/usr/local/bin`) instead of `~/.local/bin`. Requires `tomei apply --system`.
+
+| File | Installer | Tools |
+|------|-----------|-------|
+| `privileged.cue` | aqua | lazygit |
+
+Apple Silicon macOS uses `/opt/homebrew` by default; tomei currently routes privileged symlinks to `/usr/local/bin` regardless. Overriding requires a recompile via `path.WithSystemBinDir` — there is no end-user knob today.
+
+## System Packages (3, Linux only)
+
+Apt-managed packages installed under `tomei apply --system`. The file is gated with `@if(linux)` so non-Linux platforms ignore it cleanly.
+
+| File | Installer | Packages |
+|------|-----------|----------|
+| `system_packages.cue` | apt (inline `SystemInstaller`) | pkg-config, libssl-dev, tree |
+
 ## Usage
 
 ```bash
@@ -54,6 +75,47 @@ tomei cue init --force examples/real-world/
 # Apply manifests (CUE modules pulled from OCI registry + cosign verified)
 tomei apply examples/real-world/
 ```
+
+## Running in a container
+
+The Phase 4 SystemPackage example mutates apt and the Phase 2 privileged tool writes to `/usr/local/bin` — both are host-global operations. Use the bundled Ubuntu container at `examples/Dockerfile` to try them safely without touching your host.
+
+```bash
+# From the repo root: build the tomei binary + container image
+make -C examples build
+
+# Open an interactive shell as the `lipnoise` user inside the container.
+# The Dockerfile copies examples/real-world/ to /home/lipnoise/examples/real-world/
+# and grants NOPASSWD sudo so `--system` works without prompting.
+make -C examples run
+
+# Inside the container:
+tomei cue init --force examples/real-world/
+
+# User-mode apply: symlinks land in ~/.local/bin; privileged tools and
+# system packages are skipped with a warning.
+tomei apply examples/real-world/
+
+# System-mode apply: lazygit lands in /usr/local/bin and build-deps is
+# installed via apt-get. State stays per-user under ~/.local/share/tomei/.
+tomei apply --system examples/real-world/
+```
+
+Notes:
+- The container is ephemeral — exit the shell and `docker rm` runs automatically (`--rm`). Re-running `make run` starts a fresh container.
+- Network egress is needed to download tools from GitHub Releases / apt repositories.
+- `make -C examples clean` removes the built binary and the container image.
+
+### GitHub token required for aqua tools
+
+`tomei init` fetches the aqua-registry from GitHub Container Registry. Anonymous traffic from a fresh container reliably hits HTTP 403 within seconds because of GitHub's rate limits — without a token the aqua-based tools (k8s, utility, privileged) all fail with `aqua-registry resolver not configured`. `make run` already passes `GITHUB_TOKEN` / `GH_TOKEN` through if set on the host:
+
+```bash
+export GITHUB_TOKEN=ghp_...   # or use `gh auth token`
+make -C examples run
+```
+
+`go install`-based tools, `uv`-based tools, `pnpm`-based tools, and the Phase 4 apt SystemPackageSet do not need the token — only the aqua/registry path does.
 
 ## Patterns Demonstrated
 

--- a/examples/real-world/README.md
+++ b/examples/real-world/README.md
@@ -68,6 +68,9 @@ Apt-managed packages installed under `tomei apply --system`. The file is gated w
 ## Usage
 
 ```bash
+# Initialize tomei state directory (~/.local/share/tomei)
+tomei init
+
 # Initialize module dependencies (resolves latest versions from OCI registry)
 tomei cue init --force examples/real-world/
 

--- a/examples/real-world/README.md
+++ b/examples/real-world/README.md
@@ -49,7 +49,7 @@ real-world/
 | `node.cue` | pnpm (delegation) | prettier, ts-node, typescript, npm-check-updates |
 | `bun.cue` | bun (delegation) | biome |
 
-## Privileged Tools (1, `--system`)
+## Privileged Tools (`--system`)
 
 These tools are symlinked into the system bin directory (default `/usr/local/bin`) instead of `~/.local/bin`. Requires `tomei apply --system`.
 

--- a/examples/real-world/README.md
+++ b/examples/real-world/README.md
@@ -61,7 +61,7 @@ Apple Silicon macOS uses `/opt/homebrew` by default; tomei currently routes priv
 
 ## System Packages (Debian/Ubuntu only)
 
-Apt-managed packages installed under `tomei apply --system`. The manifest is gated with `@if(linux)` so non-Linux platforms ignore it cleanly, but the inline `SystemInstaller` shells out to `apt-get` — it only works on apt-based distros (Debian, Ubuntu). Other Linux distros (Fedora, Arch, Alpine, etc.) need a different installer stanza.
+Apt-managed packages installed under `tomei apply --system`. The manifest is gated with `@if(linux)` so non-Linux platforms ignore it cleanly, but the actual install runs through tomei's built-in APT backend (`internal/installer/apt`) — which only works on apt-based distros (Debian, Ubuntu). Other Linux distros (Fedora, Arch, Alpine, etc.) need a SystemInstaller bound to a different backend. The `spec.commands` block on the inline SystemInstaller is descriptive metadata; the backend owns the actual invocation.
 
 | File | Installer | Packages |
 |------|-----------|----------|

--- a/examples/real-world/README.md
+++ b/examples/real-world/README.md
@@ -13,7 +13,7 @@ This example uses **non-vendored** CUE modules — dependencies are resolved fro
 real-world/
 ├── cue.mod/module.cue      # CUE module with deps (OCI registry resolution)
 ├── tomei_platform.cue      # Platform @tag() declarations (generated)
-├── runtimes.cue            # Go, Rust, uv (Python), pnpm (Node.js)
+├── runtimes.cue            # Go, Rust, uv (Python), pnpm (Node.js), Deno, Bun
 ├── k8s.cue                 # kubectl, kustomize, helm, kind
 ├── utility.cue             # bat, rg, fd, jq, yq, fzf
 ├── go.cue                  # gopls, staticcheck, goimports, cue (via go install)
@@ -26,7 +26,7 @@ real-world/
 └── privileged.cue          # lazygit via aqua + privileged: true (Phase 2)
 ```
 
-## Runtimes (4)
+## Runtimes
 
 | Runtime | Type | Description |
 |---------|------|-------------|
@@ -34,6 +34,8 @@ real-world/
 | Rust | delegation (preset) | Bootstrapped via rustup |
 | uv | delegation | Python package manager (astral.sh installer) |
 | pnpm | delegation | Node.js package manager (standalone installer) |
+| Deno | download (preset) | Official binary from dl.deno.land |
+| Bun | download (preset) | Official binary from GitHub releases |
 
 ## Tools (30)
 

--- a/examples/real-world/README.md
+++ b/examples/real-world/README.md
@@ -14,13 +14,13 @@ real-world/
 ├── cue.mod/module.cue      # CUE module with deps (OCI registry resolution)
 ├── tomei_platform.cue      # Platform @tag() declarations (generated)
 ├── runtimes.cue            # Go, Rust, uv (Python), pnpm (Node.js)
-├── k8s.cue                 # kubectl, kustomize, helm, kind, krew + installer
+├── k8s.cue                 # kubectl, kustomize, helm, kind
 ├── utility.cue             # bat, rg, fd, jq, yq, fzf
 ├── go.cue                  # gopls, staticcheck, goimports, cue (via go install)
 ├── rust.cue                # cargo-binstall + binstall installer
-├── uv.cue                  # ruff, mypy, httpie, black (via uv)
+├── uv.cue                  # ruff, mypy, httpie, ansible (via uv)
 ├── node.cue                # prettier, ts-node, typescript, npm-check-updates (via pnpm)
-├── krew.cue                # ctx, ns, neat, node-shell (via krew)
+├── bun.cue                 # biome (via bun)
 ├── brew.cue                # Darwin/arm64-only (Homebrew formulae)
 ├── system_packages.cue     # apt SystemInstaller + build-deps (Phase 4, Linux only)
 └── privileged.cue          # lazygit via aqua + privileged: true (Phase 2)
@@ -40,13 +40,12 @@ real-world/
 | File | Installer | Tools |
 |------|-----------|-------|
 | `k8s.cue` | aqua | kubectl, kustomize, helm, kind |
-| `k8s.cue` | aqua + krew (delegation) | krew, ctx, ns, neat, node-shell |
 | `utility.cue` | aqua | bat, rg, fd, jq, yq, fzf |
 | `go.cue` | go install | gopls, staticcheck, goimports, cue |
 | `rust.cue` | rust (preset) | cargo-binstall + binstall installer |
 | `uv.cue` | uv (delegation) | ruff, mypy, httpie, ansible |
 | `node.cue` | pnpm (delegation) | prettier, ts-node, typescript, npm-check-updates |
-| `krew.cue` | krew (delegation) | ctx, ns, neat, node-shell |
+| `bun.cue` | bun (delegation) | biome |
 
 ## Privileged Tools (1, `--system`)
 
@@ -90,7 +89,8 @@ make -C examples build
 make -C examples run
 
 # Inside the container:
-tomei cue init --force examples/real-world/
+tomei init                                     # creates ~/.local/share/tomei state
+tomei cue init --force examples/real-world/    # resolves CUE module deps
 
 # User-mode apply: symlinks land in ~/.local/bin; privileged tools and
 # system packages are skipped with a warning.
@@ -108,7 +108,7 @@ Notes:
 
 ### GitHub token required for aqua tools
 
-`tomei init` fetches the aqua-registry from GitHub Container Registry. Anonymous traffic from a fresh container reliably hits HTTP 403 within seconds because of GitHub's rate limits — without a token the aqua-based tools (k8s, utility, privileged) all fail with `aqua-registry resolver not configured`. `make run` already passes `GITHUB_TOKEN` / `GH_TOKEN` through if set on the host:
+`tomei init` resolves the latest aqua-registry ref via `api.github.com` and then fetches registry content from `raw.githubusercontent.com`. Anonymous traffic from a fresh container reliably hits HTTP 403 within seconds because of GitHub's rate limits — without a token the aqua-based tools (k8s, utility, privileged) all fail with `aqua-registry resolver not configured`. `make run` already passes `GITHUB_TOKEN` / `GH_TOKEN` through if set on the host:
 
 ```bash
 export GITHUB_TOKEN=ghp_...   # or use `gh auth token`

--- a/examples/real-world/README.md
+++ b/examples/real-world/README.md
@@ -22,7 +22,7 @@ real-world/
 ├── node.cue                # prettier, ts-node, typescript, npm-check-updates (via pnpm)
 ├── bun.cue                 # biome (via bun)
 ├── brew.cue                # Darwin/arm64-only (Homebrew formulae)
-├── system_packages.cue     # apt SystemInstaller + build-deps (Phase 4, Linux only)
+├── system_packages.cue     # apt SystemInstaller + build-deps (Phase 4, Debian/Ubuntu only)
 └── privileged.cue          # lazygit via aqua + privileged: true (Phase 2)
 ```
 
@@ -37,7 +37,7 @@ real-world/
 | Deno | download (preset) | Official binary from dl.deno.land |
 | Bun | download (preset) | Official binary from GitHub releases |
 
-## Tools (30)
+## Tools
 
 | File | Installer | Tools |
 |------|-----------|-------|
@@ -59,9 +59,9 @@ These tools are symlinked into the system bin directory (default `/usr/local/bin
 
 Apple Silicon macOS uses `/opt/homebrew` by default; tomei currently routes privileged symlinks to `/usr/local/bin` regardless. Overriding requires a recompile via `path.WithSystemBinDir` — there is no end-user knob today.
 
-## System Packages (3, Linux only)
+## System Packages (Debian/Ubuntu only)
 
-Apt-managed packages installed under `tomei apply --system`. The file is gated with `@if(linux)` so non-Linux platforms ignore it cleanly.
+Apt-managed packages installed under `tomei apply --system`. The manifest is gated with `@if(linux)` so non-Linux platforms ignore it cleanly, but the inline `SystemInstaller` shells out to `apt-get` — it only works on apt-based distros (Debian, Ubuntu). Other Linux distros (Fedora, Arch, Alpine, etc.) need a different installer stanza.
 
 | File | Installer | Packages |
 |------|-----------|----------|
@@ -126,5 +126,6 @@ make -C examples run
 
 - **Preset import** — Go/Rust runtimes and aqua tools use `tomei.terassyi.net/presets/*`
 - **Delegation runtime** — uv and pnpm bootstrap via shell scripts, then serve as tool installers
-- **Delegation installer chain** — krew is installed via aqua, then used as an Installer for kubectl plugins
 - **Cargo-binstall chain** — Rust runtime → cargo-binstall tool → binstall installer (preset)
+- **Inline SystemInstaller** — apt is declared directly in `system_packages.cue` (Phase 4)
+- **Privileged tool routing** — lazygit in `privileged.cue` is installed via aqua but symlinked into the system bin directory under `--system` (Phase 2)

--- a/examples/real-world/README.md
+++ b/examples/real-world/README.md
@@ -113,7 +113,7 @@ Notes:
 
 ### GitHub token required for aqua tools
 
-`tomei init` resolves the latest aqua-registry ref via `api.github.com` and then fetches registry content from `raw.githubusercontent.com`. Anonymous traffic from a fresh container reliably hits HTTP 403 within seconds because of GitHub's rate limits — without a token the aqua-based tools (k8s, utility, privileged) all fail with `aqua-registry resolver not configured`. `make run` already passes `GITHUB_TOKEN` / `GH_TOKEN` through if set on the host:
+`tomei init` resolves the latest aqua-registry ref via `api.github.com`; the actual registry content is fetched later from `raw.githubusercontent.com` when aqua-based tools are installed. Both endpoints are rate-limited for anonymous traffic and a fresh container reliably hits HTTP 403 within seconds — without a token the aqua-based tools (k8s, utility, privileged) all fail with `aqua-registry resolver not configured`. `make run` already passes `GITHUB_TOKEN` / `GH_TOKEN` through if set on the host:
 
 ```bash
 export GITHUB_TOKEN=ghp_...   # or use `gh auth token`

--- a/examples/real-world/privileged.cue
+++ b/examples/real-world/privileged.cue
@@ -1,0 +1,18 @@
+package tomei
+
+import "tomei.terassyi.net/presets/aqua"
+
+// Phase 2 demo: privileged: true routes the symlink to /usr/local/bin
+// (default SystemBinDir) instead of ~/.local/bin. Requires `tomei apply --system`.
+// Apple Silicon macOS uses /opt/homebrew by default; tomei currently routes
+// privileged symlinks to /usr/local/bin regardless. Overriding requires a
+// recompile via path.WithSystemBinDir — there is no end-user knob today.
+privilegedTools: aqua.#AquaToolSet & {
+	metadata: {
+		name:        "privileged-tools"
+		description: "Tools symlinked into the system bin directory under --system"
+	}
+	spec: tools: {
+		lazygit: {package: "jesseduffield/lazygit", version: "v0.62.1", privileged: true}
+	}
+}

--- a/examples/real-world/system_packages.cue
+++ b/examples/real-world/system_packages.cue
@@ -14,8 +14,8 @@ apt: {
 		privileged: true
 		commands: {
 			install: {command: "sudo apt-get install -y"}
-			remove: {command:  "sudo apt-get remove -y"}
-			check: {command:   "dpkg -s"}
+			remove: {command: "sudo apt-get remove -y"}
+			check: {command: "dpkg -s"}
 		}
 	}
 }

--- a/examples/real-world/system_packages.cue
+++ b/examples/real-world/system_packages.cue
@@ -2,9 +2,12 @@
 
 package tomei
 
-// Phase 4 demo: SystemPackageSet via apt (Linux only). Requires
-// `tomei apply --system`. The apt SystemInstaller is declared inline —
-// no preset exists for it yet, so this stanza is the canonical form.
+// Phase 4 demo: SystemPackageSet via apt (Debian/Ubuntu only). Requires
+// `tomei apply --system`. The file is gated with `@if(linux)` so non-Linux
+// platforms ignore it cleanly, but the inline SystemInstaller shells out
+// to apt-get and only works on apt-based distros — Fedora/Arch/Alpine
+// users would need a different installer stanza. No preset exists for
+// apt yet, so this stanza is the canonical form.
 apt: {
 	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "SystemInstaller"

--- a/examples/real-world/system_packages.cue
+++ b/examples/real-world/system_packages.cue
@@ -9,8 +9,10 @@ package tomei
 // apt-based distros. Fedora/Arch/Alpine users would need a different
 // SystemInstaller name and a matching backend.
 //
-// NOTE: SystemInstaller is currently a named declaration that the
-// validator binds to a built-in backend (here "apt"). The spec.commands
+// NOTE: SystemInstaller is currently a named declaration. The system
+// engine's selectPackageInstaller (cmd/tomei/system_engine.go) picks the
+// concrete backend by name — "apt" wires the built-in APT installer.
+// The validator only checks host support/version. The spec.commands
 // strings below are descriptive — they are not what gets executed; the
 // backend owns the actual invocation. No preset exists for apt yet,
 // so this stanza is the canonical inline form.

--- a/examples/real-world/system_packages.cue
+++ b/examples/real-world/system_packages.cue
@@ -1,0 +1,35 @@
+@if(linux)
+
+package tomei
+
+// Phase 4 demo: SystemPackageSet via apt (Linux only). Requires
+// `tomei apply --system`. The apt SystemInstaller is declared inline —
+// no preset exists for it yet, so this stanza is the canonical form.
+apt: {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "SystemInstaller"
+	metadata: name: "apt"
+	spec: {
+		pattern:    "delegation"
+		privileged: true
+		commands: {
+			install: {command: "sudo apt-get install -y"}
+			remove: {command:  "sudo apt-get remove -y"}
+			check: {command:   "dpkg -s"}
+		}
+	}
+}
+
+// build-essential is pre-installed in the example container (see
+// examples/Dockerfile), so we leave it out and pick three packages
+// that actually install fresh — making the demo visually verifiable
+// (`tree --version` works after --system apply).
+buildDeps: {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind:       "SystemPackageSet"
+	metadata: name: "build-deps"
+	spec: {
+		installerRef: "apt"
+		packages: ["pkg-config", "libssl-dev", "tree"]
+	}
+}

--- a/examples/real-world/system_packages.cue
+++ b/examples/real-world/system_packages.cue
@@ -4,10 +4,16 @@ package tomei
 
 // Phase 4 demo: SystemPackageSet via apt (Debian/Ubuntu only). Requires
 // `tomei apply --system`. The file is gated with `@if(linux)` so non-Linux
-// platforms ignore it cleanly, but the inline SystemInstaller shells out
-// to apt-get and only works on apt-based distros — Fedora/Arch/Alpine
-// users would need a different installer stanza. No preset exists for
-// apt yet, so this stanza is the canonical form.
+// platforms ignore it cleanly, but the actual install runs through the
+// built-in APT backend (internal/installer/apt) — which only works on
+// apt-based distros. Fedora/Arch/Alpine users would need a different
+// SystemInstaller name and a matching backend.
+//
+// NOTE: SystemInstaller is currently a named declaration that the
+// validator binds to a built-in backend (here "apt"). The spec.commands
+// strings below are descriptive — they are not what gets executed; the
+// backend owns the actual invocation. No preset exists for apt yet,
+// so this stanza is the canonical inline form.
 apt: {
 	apiVersion: "tomei.terassyi.net/v1beta1"
 	kind:       "SystemInstaller"


### PR DESCRIPTION
- privileged.cue: lazygit via aqua with privileged:true (Phase 2 demo)
- system_packages.cue: inline apt SystemInstaller + SystemPackageSet (Phase 4 demo, @if(linux))
- Dockerfile: NOPASSWD sudo for lipnoise so --system works without prompting
- Makefile: CGO_ENABLED=0 static build (cross-distro), pass GITHUB_TOKEN through
- README: container-run guide, GH-token requirement for aqua-registry

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
