### PR TITLE
feat(apply): add --system-only flag for privileged + system reapply

### DIFF
--- a/cmd/tomei/apply.go
+++ b/cmd/tomei/apply.go
@@ -74,7 +74,15 @@ With --system, tomei prompts for sudo credentials once and keeps the
 timestamp refreshed. Privileged tool commands and system package operations
 run as the invoking user, using the cached sudo ticket without re-prompting
 (subject to sudoers policy). Without --system, privileged and system
-resources are skipped with a warning.`,
+resources are skipped with a warning.
+
+For privileged + system reapply WITHOUT touching user-level resources:
+  tomei apply --system-only .
+
+--system-only is the inverse half: privileged tools and system resources
+are applied, but non-privileged user-level resources (Runtime, non-priv
+Tool, Installer) are skipped. Useful for CI provisioning and cron-driven
+privileged reapply on servers. Mutually exclusive with --system.`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: runApply,
 }
@@ -92,15 +100,19 @@ func runApply(cmd *cobra.Command, args []string) error {
 		color.NoColor = true
 	}
 
-	if systemMode {
+	scope := scopeFromFlags()
+	switch scope {
+	case ScopeAll:
 		cmd.Printf("Applying resources (including privileged and system) from %v\n", args)
-	} else {
+	case ScopeSystemOnly:
+		cmd.Printf("Applying privileged and system resources only from %v\n", args)
+	default:
 		cmd.Printf("Applying user-level resources from %v\n", args)
 	}
-	return executeApply(cmd.Context(), args, cmd.OutOrStdout(), &applyCfg, systemMode)
+	return executeApply(cmd.Context(), args, cmd.OutOrStdout(), &applyCfg, scope)
 }
 
-func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyConfig, system bool) error {
+func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyConfig, scope ApplyScope) error {
 	// Load resources from paths (manifests)
 	loader := config.NewLoader(nil, cfg.verifierOpts()...)
 	resources, err := loader.LoadPaths(paths)
@@ -120,19 +132,19 @@ func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 	// Handle system resources: skip or prepare for execution
 	var sysEng *engine.SystemEngine
 	var supportedSystemResources []resource.Resource
-	if !system && len(systemResources) > 0 {
+	if !scope.IncludesSystemKinds() && len(systemResources) > 0 {
 		for _, r := range systemResources {
 			slog.Info("skipping system resource (use --system)", "kind", r.Kind(), "name", r.Name())
 		}
-		fmt.Fprintf(w, "%d system resource(s) skipped. Use 'tomei apply --system' to manage.\n\n", len(systemResources))
+		fmt.Fprintf(w, "%d system resource(s) skipped. Use 'tomei apply --system' or '--system-only' to manage.\n\n", len(systemResources))
 	}
-	if system && len(systemResources) > 0 {
+	if scope.IncludesSystemKinds() && len(systemResources) > 0 {
 		// Reject overlapping SystemPackageSet declarations before any
-		// host mutation. Gated on `system` because without --system the
-		// system resources are skipped entirely and overlap is moot.
-		// See resource.ValidateSystemPackageSetOverlap for the full
-		// rationale on why the apt installer's Remove / upgrade-drain
-		// paths are unsafe under multi-owner package state today.
+		// host mutation. Gated on IncludesSystemKinds() because outside
+		// --system / --system-only the system resources are skipped
+		// entirely and overlap is moot. See ValidateSystemPackageSetOverlap
+		// for the full rationale on why the apt installer's Remove /
+		// upgrade-drain paths are unsafe under multi-owner package state.
 		if err := resource.ValidateSystemPackageSetOverlap(systemResources); err != nil {
 			return fmt.Errorf("apply rejected: %w", err)
 		}
@@ -149,9 +161,23 @@ func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 		}
 	}
 
-	// Filter out privileged resources when --system is not set
-	if !system {
+	// Filter userResources by scope. The two branches are mutually
+	// exclusive by construction (IncludesPrivileged and IncludesUserKinds
+	// are simultaneously false only for an undefined scope value), so at
+	// most one filter runs per invocation:
+	//   ScopeUser:       filterPrivileged (strip priv-only)
+	//   ScopeAll:        no filter
+	//   ScopeSystemOnly: filterNonPrivileged (strip non-priv only)
+	if !scope.IncludesPrivileged() {
 		userResources = filterPrivilegedWithLog(w, userResources)
+	}
+	if !scope.IncludesUserKinds() {
+		// User Engine still runs in --system-only to handle privileged
+		// tools (which are a Tool attribute, not a kind). The non-priv
+		// strip here pairs with eng.SetSkipUserKindRemovals(true) below
+		// so the engine does not later tear down state for non-priv
+		// resources that were installed by an earlier plain `tomei apply`.
+		userResources = filterNonPrivilegedWithLog(w, userResources)
 	}
 
 	// Load config from fixed path (~/.config/tomei/config.cue)
@@ -211,7 +237,7 @@ func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 		UpdateRuntimes: cfg.updateRuntimes || cfg.updateAll,
 	}
 	// Show plan with all resources (system + user) for complete picture
-	hasChanges, err := planForResources(w, resources, cfg.noColor, updCfg, system)
+	hasChanges, err := planForResources(w, resources, cfg.noColor, updCfg, scope)
 	if err != nil {
 		return fmt.Errorf("failed to plan: %w", err)
 	}
@@ -242,6 +268,14 @@ func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 	eng := engine.NewEngine(toolInstaller, runtimeInstaller, repoInstaller, store)
 	eng.SetParallelism(cfg.parallel)
 	eng.SetUpdateConfig(updCfg)
+	// Under --system-only, filterNonPrivilegedWithLog stripped non-priv
+	// resources from userResources before the engine sees them, so the
+	// reconciler would otherwise emit ActionRemove for their state
+	// entries. Tell the engine to skip those removals so a prior plain
+	// `tomei apply` is preserved.
+	if !scope.IncludesUserKinds() {
+		eng.SetSkipUserKindRemovals(true)
+	}
 
 	// Track results for summary
 	results := &ui.ApplyResults{}
@@ -267,9 +301,10 @@ func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 		return nil
 	})
 
-	// Create SystemEngine when --system is set. Even with zero system resources
-	// in the manifest, state may contain entries that need removal.
-	if system {
+	// Create SystemEngine when system kinds are in scope (--system or
+	// --system-only). Even with zero system resources in the manifest,
+	// state may contain entries that need removal.
+	if scope.IncludesSystemKinds() {
 		// systemDownloader is an un-authenticated downloader (no GitHub token
 		// wrap) for SystemPackageRepository GPG-key fetches. It deliberately
 		// does NOT share dlClient with the user-tier downloader: dlClient
@@ -292,10 +327,12 @@ func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 		sysEng = se
 	}
 
-	// Acquire sudo credentials when --system is set (before TUI to allow interactive prompt).
-	// We always acquire when --system is given, not only when the manifest contains
-	// privileged tools, because privileged tools may exist only in state (removal case).
-	if system {
+	// Acquire sudo credentials when privileged work is in scope (--system
+	// or --system-only), before TUI starts to allow the interactive
+	// prompt. Always acquire when scope demands it, not only when the
+	// manifest contains privileged tools, because privileged tools may
+	// exist only in state (removal case).
+	if scope.IncludesPrivileged() {
 		handler := &sudoHandler{}
 		if err := handler.Acquire(ctx); err != nil {
 			return err
@@ -624,4 +661,28 @@ func filterPrivilegedWithLog(w io.Writer, resources []resource.Resource) []resou
 	}
 	fmt.Fprintf(w, "%d privileged resource(s) skipped (%s). Use 'tomei apply --system' to install.\n\n", len(privileged), privilegedSkipReasonsFragment)
 	return normal
+}
+
+// systemOnlySkipReasonsFragment explains why non-privileged user-level
+// resources are skipped under --system-only.
+const systemOnlySkipReasonsFragment = "--system-only restricts apply to privileged tools and system resources"
+
+// filterNonPrivilegedWithLog is the dual of filterPrivilegedWithLog: it
+// strips non-privileged user resources (Runtime, non-priv Tool,
+// Installer, InstallerRepository) and keeps only privileged ones, then
+// emits per-resource slog.Info plus a summary line to w. Used in
+// --system-only mode where the user Engine still runs (for privileged
+// tools) but should not touch non-privileged user-level resources.
+func filterNonPrivilegedWithLog(w io.Writer, resources []resource.Resource) []resource.Resource {
+	normal, privileged := resource.FilterPrivileged(resources)
+	if len(normal) == 0 {
+		return privileged
+	}
+	for _, r := range normal {
+		slog.Info("skipping non-privileged resource (--system-only)",
+			"kind", r.Kind(),
+			"name", r.Name())
+	}
+	fmt.Fprintf(w, "%d non-privileged resource(s) skipped (%s).\n\n", len(normal), systemOnlySkipReasonsFragment)
+	return privileged
 }

--- a/cmd/tomei/apply.go
+++ b/cmd/tomei/apply.go
@@ -81,8 +81,9 @@ For privileged + system reapply WITHOUT touching user-level resources:
 
 --system-only is the inverse half: privileged tools and system resources
 are applied, but non-privileged user-level resources (Runtime, non-priv
-Tool, Installer) are skipped. Useful for CI provisioning and cron-driven
-privileged reapply on servers. Mutually exclusive with --system.`,
+Tool, Installer, InstallerRepository) are skipped. Useful for CI
+provisioning and cron-driven privileged reapply on servers. Mutually
+exclusive with --system.`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: runApply,
 }
@@ -134,9 +135,9 @@ func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 	var supportedSystemResources []resource.Resource
 	if !scope.IncludesSystemKinds() && len(systemResources) > 0 {
 		for _, r := range systemResources {
-			slog.Info("skipping system resource (use --system)", "kind", r.Kind(), "name", r.Name())
+			slog.Info("skipping system resource (use --system or --system-only)", "kind", r.Kind(), "name", r.Name())
 		}
-		fmt.Fprintf(w, "%d system resource(s) skipped. Use 'tomei apply --system' or '--system-only' to manage.\n\n", len(systemResources))
+		fmt.Fprintf(w, "%d system resource(s) skipped. Use 'tomei apply --system' or 'tomei apply --system-only' to manage.\n\n", len(systemResources))
 	}
 	if scope.IncludesSystemKinds() && len(systemResources) > 0 {
 		// Reject overlapping SystemPackageSet declarations before any

--- a/cmd/tomei/apply.go
+++ b/cmd/tomei/apply.go
@@ -162,10 +162,8 @@ func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 		}
 	}
 
-	// Filter userResources by scope. The two branches are mutually
-	// exclusive by construction (IncludesPrivileged and IncludesUserKinds
-	// are simultaneously false only for an undefined scope value), so at
-	// most one filter runs per invocation:
+	// Filter userResources by scope. Exactly one of the two branches runs
+	// for each defined scope:
 	//   ScopeUser:       filterPrivileged (strip priv-only)
 	//   ScopeAll:        no filter
 	//   ScopeSystemOnly: filterNonPrivileged (strip non-priv only)

--- a/cmd/tomei/apply.go
+++ b/cmd/tomei/apply.go
@@ -655,12 +655,12 @@ func filterPrivilegedWithLog(w io.Writer, resources []resource.Resource) []resou
 		return normal
 	}
 	for _, r := range privileged {
-		slog.Info("skipping privileged resource (use --system)",
+		slog.Info("skipping privileged resource (use --system or --system-only)",
 			"kind", r.Kind(),
 			"name", r.Name(),
 			"reason", resource.PrivilegedReason(r))
 	}
-	fmt.Fprintf(w, "%d privileged resource(s) skipped (%s). Use 'tomei apply --system' to install.\n\n", len(privileged), privilegedSkipReasonsFragment)
+	fmt.Fprintf(w, "%d privileged resource(s) skipped (%s). Use 'tomei apply --system' or 'tomei apply --system-only' to install.\n\n", len(privileged), privilegedSkipReasonsFragment)
 	return normal
 }
 

--- a/cmd/tomei/apply.go
+++ b/cmd/tomei/apply.go
@@ -361,7 +361,7 @@ func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 	// can otherwise be misrepresented here as removals (they're absent from
 	// the desired resource list but still intended to be installed).
 	if n := eng.SkippedPrivileged(); n > 0 && !cfg.quiet {
-		fmt.Fprintf(w, "\n%d privileged resource action(s) skipped (%s). Use 'tomei apply --system' to manage privileged resources.\n", n, privilegedSkipReasonsFragment)
+		fmt.Fprintf(w, "\n%d privileged resource action(s) skipped (%s). Use 'tomei apply --system' or 'tomei apply --system-only' to manage privileged resources.\n", n, privilegedSkipReasonsFragment)
 	}
 
 	return applyErr

--- a/cmd/tomei/apply_test.go
+++ b/cmd/tomei/apply_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -166,16 +167,24 @@ func TestFilterNonPrivilegedWithLog(t *testing.T) {
 	}
 
 	t.Run("strips non-privileged, keeps privileged", func(t *testing.T) {
+		// Use disjoint names (alpha = non-priv, omega = priv) so the
+		// negative assertion below is not vulnerable to slog's
+		// end-of-line newline rendering: a trailing-space match like
+		// "name=priv " would miss "name=priv\n" and the priv tool could
+		// be silently logged without the test catching it. Substrings
+		// chosen here cannot prefix each other.
 		buf := capture(t)
 		var w bytes.Buffer
 		got := filterNonPrivilegedWithLog(&w, []resource.Resource{
-			tool("non-priv", false),
-			tool("priv", true),
+			tool("alpha", false),
+			tool("omega", true),
 		})
 		assert.Len(t, got, 1, "only the privileged tool should remain")
-		assert.Equal(t, "priv", got[0].Name())
-		assert.Contains(t, buf.String(), "name=non-priv")
-		assert.NotContains(t, buf.String(), "name=priv ")
+		assert.Equal(t, "omega", got[0].Name())
+		assert.Contains(t, buf.String(), "name=alpha")
+		assert.NotContains(t, buf.String(), "name=omega", "privileged tool must not be logged as skipped")
+		// Exactly one "skipping non-privileged" line should appear.
+		assert.Equal(t, 1, strings.Count(buf.String(), "skipping non-privileged resource"))
 		assert.Contains(t, w.String(), "1 non-privileged resource(s) skipped")
 		assert.Contains(t, w.String(), "--system-only restricts apply")
 	})

--- a/cmd/tomei/apply_test.go
+++ b/cmd/tomei/apply_test.go
@@ -140,3 +140,68 @@ func TestFilterPrivilegedWithLog(t *testing.T) {
 		assert.Empty(t, w.String())
 	})
 }
+
+// TestFilterNonPrivilegedWithLog covers --system-only's reverse filter:
+// strip non-privileged user resources, keep only privileged. Same slog
+// constraints as TestFilterPrivilegedWithLog — sequential subtests.
+func TestFilterNonPrivilegedWithLog(t *testing.T) {
+	capture := func(t *testing.T) *bytes.Buffer {
+		t.Helper()
+		var buf bytes.Buffer
+		handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+		oldLogger := slog.Default()
+		slog.SetDefault(slog.New(handler))
+		t.Cleanup(func() { slog.SetDefault(oldLogger) })
+		return &buf
+	}
+
+	tool := func(name string, priv bool) *resource.Tool {
+		return &resource.Tool{
+			BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: name}},
+			ToolSpec: &resource.ToolSpec{
+				Commands:   &resource.ToolCommandSet{CommandSet: resource.CommandSet{Install: []string{"echo " + name}}},
+				Privileged: priv,
+			},
+		}
+	}
+
+	t.Run("strips non-privileged, keeps privileged", func(t *testing.T) {
+		buf := capture(t)
+		var w bytes.Buffer
+		got := filterNonPrivilegedWithLog(&w, []resource.Resource{
+			tool("non-priv", false),
+			tool("priv", true),
+		})
+		assert.Len(t, got, 1, "only the privileged tool should remain")
+		assert.Equal(t, "priv", got[0].Name())
+		assert.Contains(t, buf.String(), "name=non-priv")
+		assert.NotContains(t, buf.String(), "name=priv ")
+		assert.Contains(t, w.String(), "1 non-privileged resource(s) skipped")
+		assert.Contains(t, w.String(), "--system-only restricts apply")
+	})
+
+	t.Run("all privileged: empty summary, returns unchanged set", func(t *testing.T) {
+		buf := capture(t)
+		var w bytes.Buffer
+		got := filterNonPrivilegedWithLog(&w, []resource.Resource{
+			tool("priv-1", true),
+			tool("priv-2", true),
+		})
+		assert.Len(t, got, 2)
+		assert.NotContains(t, buf.String(), "skipping non-privileged")
+		assert.Empty(t, w.String())
+	})
+
+	t.Run("all non-privileged: returns empty, logs all", func(t *testing.T) {
+		buf := capture(t)
+		var w bytes.Buffer
+		got := filterNonPrivilegedWithLog(&w, []resource.Resource{
+			tool("a", false),
+			tool("b", false),
+		})
+		assert.Empty(t, got)
+		assert.Contains(t, buf.String(), "name=a")
+		assert.Contains(t, buf.String(), "name=b")
+		assert.Contains(t, w.String(), "2 non-privileged resource(s) skipped")
+	})
+}

--- a/cmd/tomei/plan.go
+++ b/cmd/tomei/plan.go
@@ -99,12 +99,14 @@ func runPlan(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to expand sets: %w", err)
 	}
 
+	scope := scopeFromFlags()
+
 	// Reject overlapping SystemPackageSet declarations before plan emits
 	// an Upgrade/Remove that would tear down a multi-owner package.
-	// Gated on systemMode because without --system the system resources
-	// are forced to ActionSkip by buildResourceInfo and overlap is moot.
-	// See resource.ValidateSystemPackageSetOverlap for the rationale.
-	if systemMode {
+	// Gated on IncludesSystemKinds() because outside --system / --system-only
+	// the system resources are forced to ActionSkip by buildResourceInfo
+	// and overlap is moot. See resource.ValidateSystemPackageSetOverlap.
+	if scope.IncludesSystemKinds() {
 		if err := resource.ValidateSystemPackageSetOverlap(resources); err != nil {
 			return fmt.Errorf("plan rejected: %w", err)
 		}
@@ -115,7 +117,7 @@ func runPlan(cmd *cobra.Command, args []string) error {
 		UpdateTools:    planCfg.updateTools || planCfg.updateAll,
 		UpdateRuntimes: planCfg.updateRuntimes || planCfg.updateAll,
 	}
-	result, err := resolvePlan(resources, updateCfg, systemMode)
+	result, err := resolvePlan(resources, updateCfg, scope)
 	if err != nil {
 		return err
 	}
@@ -138,7 +140,7 @@ func runPlan(cmd *cobra.Command, args []string) error {
 	}
 }
 
-func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig, system bool) map[graph.NodeID]graph.ResourceInfo {
+func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig, scope ApplyScope) map[graph.NodeID]graph.ResourceInfo {
 	info := make(map[graph.NodeID]graph.ResourceInfo)
 
 	// Load config and state
@@ -204,6 +206,15 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 			}
 		}
 
+		// In --system-only mode, non-privileged user-level resources are
+		// out of scope. Mark them as skip and bypass state comparison so
+		// the plan reflects what apply will actually do.
+		if !scope.IncludesUserKinds() && !resInfo.Privileged {
+			resInfo.Action = resource.ActionSkip
+			info[nodeID] = resInfo
+			continue
+		}
+
 		// Determine action by comparing with state
 		if userState != nil {
 			switch res.Kind() {
@@ -233,18 +244,19 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 			}
 		}
 
-		// Mark privileged tools as skip when --system is not set.
-		// Consistent with the system-kind skip pattern at lines 246-258.
-		markPrivilegedAsSkip(&resInfo, res, system)
+		// Mark privileged tools as skip when privileged is not in scope
+		// (i.e., default user mode). Consistent with the system-kind skip
+		// pattern below.
+		markPrivilegedAsSkip(&resInfo, res, scope.IncludesPrivileged())
 
 		info[nodeID] = resInfo
 	}
 
 	// Handle system resources
-	if system && pathConfig != nil {
+	if scope.IncludesSystemKinds() && pathConfig != nil {
 		addSystemResourceInfo(info, resources, pathConfig)
 	} else {
-		// Without --system, mark all system resources as skip
+		// System kinds out of scope — mark them all as skip.
 		for _, res := range resources {
 			if resource.IsSystemKind(res.Kind()) {
 				nodeID := graph.NewNodeID(res.Kind(), res.Name())
@@ -262,11 +274,16 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 		for name, rt := range userState.Runtimes {
 			nodeID := graph.NewNodeID(resource.KindRuntime, name)
 			if _, exists := info[nodeID]; !exists {
+				action := resource.ActionRemove
+				// Runtimes are user-kind; --system-only skips their removal.
+				if !scope.IncludesUserKinds() {
+					action = resource.ActionSkip
+				}
 				info[nodeID] = graph.ResourceInfo{
 					Kind:    resource.KindRuntime,
 					Name:    name,
 					Version: rt.Version,
-					Action:  resource.ActionRemove,
+					Action:  action,
 				}
 			}
 		}
@@ -274,8 +291,14 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 			nodeID := graph.NewNodeID(resource.KindTool, name)
 			if _, exists := info[nodeID]; !exists {
 				action := resource.ActionRemove
-				// Privileged tool removals require --system; without it, skip.
-				if !system && tool.Privileged {
+				switch {
+				case tool.Privileged && !scope.IncludesPrivileged():
+					// Privileged tool removals require --system or
+					// --system-only; outside those, skip.
+					action = resource.ActionSkip
+				case !tool.Privileged && !scope.IncludesUserKinds():
+					// Non-priv tool removals require user kinds in scope;
+					// --system-only skips them.
 					action = resource.ActionSkip
 				}
 				info[nodeID] = graph.ResourceInfo{
@@ -360,7 +383,7 @@ type planResult struct {
 
 // resolvePlan builds the dependency graph, resolves execution layers, and
 // computes resource actions from the current state.
-func resolvePlan(resources []resource.Resource, updateCfg engine.UpdateConfig, system bool) (*planResult, error) {
+func resolvePlan(resources []resource.Resource, updateCfg engine.UpdateConfig, scope ApplyScope) (*planResult, error) {
 	definedResources := make(map[string]struct{})
 	for _, res := range resources {
 		id := graph.NewNodeID(res.Kind(), res.Name())
@@ -393,7 +416,7 @@ func resolvePlan(resources []resource.Resource, updateCfg engine.UpdateConfig, s
 		}
 	}
 
-	resourceInfo := buildResourceInfo(resources, updateCfg, system)
+	resourceInfo := buildResourceInfo(resources, updateCfg, scope)
 
 	return &planResult{
 		resolver:       resolver,
@@ -406,8 +429,8 @@ func resolvePlan(resources []resource.Resource, updateCfg engine.UpdateConfig, s
 // planForResources runs the plan logic on already-loaded resources and
 // writes the text plan to w. It returns true if there are any changes
 // (install, upgrade, reinstall, or remove).
-func planForResources(w io.Writer, resources []resource.Resource, disableColor bool, updateCfg engine.UpdateConfig, system bool) (bool, error) {
-	result, err := resolvePlan(resources, updateCfg, system)
+func planForResources(w io.Writer, resources []resource.Resource, disableColor bool, updateCfg engine.UpdateConfig, scope ApplyScope) (bool, error) {
+	result, err := resolvePlan(resources, updateCfg, scope)
 	if err != nil {
 		return false, err
 	}

--- a/cmd/tomei/plan.go
+++ b/cmd/tomei/plan.go
@@ -215,11 +215,16 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 			continue
 		}
 
-		// Determine action by comparing with state
+		// Determine action by comparing with state. LoadReadOnly skips
+		// validation, so guard against nil map entries (e.g.,
+		// `"runtimes":{"go":null}` in a corrupted state.json) before
+		// dereferencing — otherwise tomei plan panics. Treat nil as
+		// "state entry unusable, default to install" rather than skip,
+		// since the resource is still declared in the manifest.
 		if userState != nil {
 			switch res.Kind() {
 			case resource.KindRuntime:
-				if rt, ok := userState.Runtimes[res.Name()]; ok {
+				if rt, ok := userState.Runtimes[res.Name()]; ok && rt != nil {
 					if rt.IsTainted() {
 						resInfo.Action = resource.ActionReinstall
 					} else if rt.Version == resInfo.Version {
@@ -229,7 +234,7 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 					}
 				}
 			case resource.KindTool:
-				if tool, ok := userState.Tools[res.Name()]; ok {
+				if tool, ok := userState.Tools[res.Name()]; ok && tool != nil {
 					if tool.IsTainted() {
 						resInfo.Action = resource.ActionReinstall
 					} else if tool.Version == resInfo.Version {
@@ -349,6 +354,9 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 		}
 		if len(upgradedRuntimes) > 0 {
 			for name, toolState := range userState.Tools {
+				if toolState == nil {
+					continue
+				}
 				if toolState.RuntimeRef == "" || !upgradedRuntimes[toolState.RuntimeRef] {
 					continue
 				}

--- a/cmd/tomei/plan.go
+++ b/cmd/tomei/plan.go
@@ -274,6 +274,17 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 		for name, rt := range userState.Runtimes {
 			nodeID := graph.NewNodeID(resource.KindRuntime, name)
 			if _, exists := info[nodeID]; !exists {
+				// LoadReadOnly skips validation; defend against a nil
+				// entry from a corrupted state.json so plan stays robust.
+				if rt == nil {
+					slog.Warn("skipping nil runtime entry in state", "name", name)
+					info[nodeID] = graph.ResourceInfo{
+						Kind:   resource.KindRuntime,
+						Name:   name,
+						Action: resource.ActionSkip,
+					}
+					continue
+				}
 				action := resource.ActionRemove
 				// Runtimes are user-kind; --system-only skips their removal.
 				if !scope.IncludesUserKinds() {
@@ -290,6 +301,15 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 		for name, tool := range userState.Tools {
 			nodeID := graph.NewNodeID(resource.KindTool, name)
 			if _, exists := info[nodeID]; !exists {
+				if tool == nil {
+					slog.Warn("skipping nil tool entry in state", "name", name)
+					info[nodeID] = graph.ResourceInfo{
+						Kind:   resource.KindTool,
+						Name:   name,
+						Action: resource.ActionSkip,
+					}
+					continue
+				}
 				action := resource.ActionRemove
 				switch {
 				case tool.Privileged && !scope.IncludesPrivileged():

--- a/cmd/tomei/root.go
+++ b/cmd/tomei/root.go
@@ -47,8 +47,67 @@ func (f *logLevelFlag) Level() slog.Level { return f.level }
 
 var (
 	systemMode     bool
+	systemOnlyMode bool
 	globalLogLevel = &logLevelFlag{level: slog.LevelWarn}
 )
+
+// ApplyScope encodes the three apply/plan modes:
+//   - ScopeUser: default. Only non-privileged user-level resources run.
+//   - ScopeAll: --system. Both user-level and system-level resources run,
+//     including privileged tools.
+//   - ScopeSystemOnly: --system-only. Only privileged tools and system
+//     kinds run; non-privileged user-level resources are forced to skip.
+//
+// --system and --system-only are mutually exclusive; PersistentPreRunE
+// rejects the combination before any command body executes.
+type ApplyScope int
+
+const (
+	ScopeUser ApplyScope = iota
+	ScopeAll
+	ScopeSystemOnly
+)
+
+// IncludesUserKinds reports whether non-privileged user-level resources
+// (Runtime, non-privileged Tool, Installer, InstallerRepository) are in
+// scope for this apply. False in --system-only mode.
+func (s ApplyScope) IncludesUserKinds() bool { return s != ScopeSystemOnly }
+
+// IncludesPrivileged reports whether privileged tools are in scope.
+// True in --system and --system-only modes.
+func (s ApplyScope) IncludesPrivileged() bool { return s != ScopeUser }
+
+// IncludesSystemKinds reports whether system kinds (SystemInstaller,
+// SystemPackageRepository, SystemPackageSet) are in scope. True in
+// --system and --system-only modes.
+func (s ApplyScope) IncludesSystemKinds() bool { return s != ScopeUser }
+
+// String returns a short human-readable name for the scope. Used in log
+// fields and skip-summary lines.
+func (s ApplyScope) String() string {
+	switch s {
+	case ScopeAll:
+		return "system"
+	case ScopeSystemOnly:
+		return "system-only"
+	default:
+		return "user"
+	}
+}
+
+// scopeFromFlags fans the two persistent bool flags into the scope enum.
+// Mutual exclusion is enforced earlier in PersistentPreRunE; this only
+// dispatches the three valid combinations.
+func scopeFromFlags() ApplyScope {
+	switch {
+	case systemOnlyMode:
+		return ScopeSystemOnly
+	case systemMode:
+		return ScopeAll
+	default:
+		return ScopeUser
+	}
+}
 
 // loadConfig holds flags shared between apply and plan commands.
 type loadConfig struct {
@@ -107,17 +166,24 @@ For manifest writing guides (presets, platform tags, resource types),
 see "tomei cue --help".
 
 Commands are separated by privilege level:
-  tomei apply              Apply user-level resources (Runtime, Tool)
-  tomei apply --system     Also apply privileged tool operations; tomei
-                           prompts for sudo credentials once and keeps
-                           the timestamp cached so that "sudo ..." calls
-                           inside the tool's own commands can use it
-                           without re-prompting (subject to sudoers
-                           policy)`,
+  tomei apply               Apply user-level resources (Runtime, Tool)
+  tomei apply --system      Also apply privileged tool operations and
+                            system kinds; tomei prompts for sudo
+                            credentials once and keeps the timestamp
+                            cached so that "sudo ..." calls inside the
+                            tool's own commands can use it without
+                            re-prompting (subject to sudoers policy)
+  tomei apply --system-only Apply only the privileged + system half;
+                            non-privileged user-level resources are
+                            skipped. Useful for CI provisioning and
+                            cron-driven privileged reapply`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
 		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: globalLogLevel.Level()})))
+		if systemMode && systemOnlyMode {
+			return fmt.Errorf("--system and --system-only are mutually exclusive")
+		}
 		return nil
 	},
 }
@@ -125,6 +191,7 @@ Commands are separated by privilege level:
 func init() {
 	// Global flags
 	rootCmd.PersistentFlags().BoolVar(&systemMode, "system", false, "Enable system package management and privileged operations. System state is stored per-user (~/.local/share/tomei/system/). In multi-user environments, each user maintains an independent view of system package state. This tool is designed for personal dev environment setup and does not detect out-of-band system changes")
+	rootCmd.PersistentFlags().BoolVar(&systemOnlyMode, "system-only", false, "Apply only privileged tools and system resources; force non-privileged user-level resources to skip. Useful for CI provisioning and cron-driven privileged reapply. Mutually exclusive with --system")
 	rootCmd.PersistentFlags().Var(globalLogLevel, "log-level", "Log level (debug, info, warn, error)")
 	_ = rootCmd.RegisterFlagCompletionFunc("log-level", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"debug", "info", "warn", "error"}, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/tomei/root.go
+++ b/cmd/tomei/root.go
@@ -51,6 +51,14 @@ var (
 	globalLogLevel = &logLevelFlag{level: slog.LevelWarn}
 )
 
+// Persistent-flag names for the scope flags. Centralized so the flag
+// registration, mutual-exclusion error message, and ApplyScope.String()
+// share the same source of truth.
+const (
+	flagSystem     = "system"
+	flagSystemOnly = "system-only"
+)
+
 // ApplyScope encodes the three apply/plan modes:
 //   - ScopeUser: default. Only non-privileged user-level resources run.
 //   - ScopeAll: --system. Both user-level and system-level resources run,
@@ -87,9 +95,9 @@ func (s ApplyScope) IncludesSystemKinds() bool { return s != ScopeUser }
 func (s ApplyScope) String() string {
 	switch s {
 	case ScopeAll:
-		return "system"
+		return flagSystem
 	case ScopeSystemOnly:
-		return "system-only"
+		return flagSystemOnly
 	default:
 		return "user"
 	}
@@ -190,8 +198,8 @@ Commands are separated by privilege level:
 
 func init() {
 	// Global flags
-	rootCmd.PersistentFlags().BoolVar(&systemMode, "system", false, "Enable system package management and privileged operations. System state is stored per-user (~/.local/share/tomei/system/). In multi-user environments, each user maintains an independent view of system package state. This tool is designed for personal dev environment setup and does not detect out-of-band system changes")
-	rootCmd.PersistentFlags().BoolVar(&systemOnlyMode, "system-only", false, "Apply only privileged tools and system resources; force non-privileged user-level resources to skip. Useful for CI provisioning and cron-driven privileged reapply. Mutually exclusive with --system")
+	rootCmd.PersistentFlags().BoolVar(&systemMode, flagSystem, false, "Enable system package management and privileged operations. System state is stored per-user (~/.local/share/tomei/system/). In multi-user environments, each user maintains an independent view of system package state. This tool is designed for personal dev environment setup and does not detect out-of-band system changes")
+	rootCmd.PersistentFlags().BoolVar(&systemOnlyMode, flagSystemOnly, false, "Apply only privileged tools and system resources; force non-privileged user-level resources to skip. Useful for CI provisioning and cron-driven privileged reapply. Mutually exclusive with --system")
 	rootCmd.PersistentFlags().Var(globalLogLevel, "log-level", "Log level (debug, info, warn, error)")
 	_ = rootCmd.RegisterFlagCompletionFunc("log-level", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"debug", "info", "warn", "error"}, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/tomei/root_test.go
+++ b/cmd/tomei/root_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyScope_Predicates(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		scope          ApplyScope
+		wantUser       bool
+		wantPrivileged bool
+		wantSystem     bool
+		wantString     string
+	}{
+		{ScopeUser, true, false, false, "user"},
+		{ScopeAll, true, true, true, "system"},
+		{ScopeSystemOnly, false, true, true, "system-only"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.wantString, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.wantUser, tc.scope.IncludesUserKinds())
+			assert.Equal(t, tc.wantPrivileged, tc.scope.IncludesPrivileged())
+			assert.Equal(t, tc.wantSystem, tc.scope.IncludesSystemKinds())
+			assert.Equal(t, tc.wantString, tc.scope.String())
+		})
+	}
+}
+
+func TestScopeFromFlags(t *testing.T) {
+	// Not parallel: scopeFromFlags reads package globals.
+	cases := []struct {
+		name           string
+		systemMode     bool
+		systemOnlyMode bool
+		want           ApplyScope
+	}{
+		{"default", false, false, ScopeUser},
+		{"system", true, false, ScopeAll},
+		{"system-only", false, true, ScopeSystemOnly},
+	}
+	prevSystem, prevSystemOnly := systemMode, systemOnlyMode
+	t.Cleanup(func() { systemMode, systemOnlyMode = prevSystem, prevSystemOnly })
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			systemMode = tc.systemMode
+			systemOnlyMode = tc.systemOnlyMode
+			assert.Equal(t, tc.want, scopeFromFlags())
+		})
+	}
+}
+
+func TestPersistentPreRunE_MutualExclusion(t *testing.T) {
+	// Not parallel: mutates package globals.
+	prevSystem, prevSystemOnly := systemMode, systemOnlyMode
+	t.Cleanup(func() { systemMode, systemOnlyMode = prevSystem, prevSystemOnly })
+
+	systemMode = true
+	systemOnlyMode = true
+	err := rootCmd.PersistentPreRunE(rootCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--system and --system-only are mutually exclusive")
+
+	systemMode = true
+	systemOnlyMode = false
+	require.NoError(t, rootCmd.PersistentPreRunE(rootCmd, nil))
+
+	systemMode = false
+	systemOnlyMode = true
+	require.NoError(t, rootCmd.PersistentPreRunE(rootCmd, nil))
+
+	systemMode = false
+	systemOnlyMode = false
+	require.NoError(t, rootCmd.PersistentPreRunE(rootCmd, nil))
+}

--- a/cmd/tomei/root_test.go
+++ b/cmd/tomei/root_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,9 +56,15 @@ func TestScopeFromFlags(t *testing.T) {
 }
 
 func TestPersistentPreRunE_MutualExclusion(t *testing.T) {
-	// Not parallel: mutates package globals.
+	// Not parallel: mutates package globals AND the process-default slog
+	// logger (PersistentPreRunE calls slog.SetDefault). Restore both so
+	// parallel cmd/tomei tests don't see leaked state.
 	prevSystem, prevSystemOnly := systemMode, systemOnlyMode
-	t.Cleanup(func() { systemMode, systemOnlyMode = prevSystem, prevSystemOnly })
+	prevLogger := slog.Default()
+	t.Cleanup(func() {
+		systemMode, systemOnlyMode = prevSystem, prevSystemOnly
+		slog.SetDefault(prevLogger)
+	})
 
 	systemMode = true
 	systemOnlyMode = true

--- a/cmd/tomei/root_test.go
+++ b/cmd/tomei/root_test.go
@@ -18,8 +18,8 @@ func TestApplyScope_Predicates(t *testing.T) {
 		wantString     string
 	}{
 		{ScopeUser, true, false, false, "user"},
-		{ScopeAll, true, true, true, "system"},
-		{ScopeSystemOnly, false, true, true, "system-only"},
+		{ScopeAll, true, true, true, flagSystem},
+		{ScopeSystemOnly, false, true, true, flagSystemOnly},
 	}
 	for _, tc := range cases {
 		t.Run(tc.wantString, func(t *testing.T) {
@@ -41,8 +41,8 @@ func TestScopeFromFlags(t *testing.T) {
 		want           ApplyScope
 	}{
 		{"default", false, false, ScopeUser},
-		{"system", true, false, ScopeAll},
-		{"system-only", false, true, ScopeSystemOnly},
+		{flagSystem, true, false, ScopeAll},
+		{flagSystemOnly, false, true, ScopeSystemOnly},
 	}
 	prevSystem, prevSystemOnly := systemMode, systemOnlyMode
 	t.Cleanup(func() { systemMode, systemOnlyMode = prevSystem, prevSystemOnly })

--- a/e2e/privileged_test.go
+++ b/e2e/privileged_test.go
@@ -197,4 +197,95 @@ normalTool: {
 			Expect(stateOutput).NotTo(ContainSubstring("privileged-tool"))
 		})
 	})
+
+	Context("Mutual exclusion of --system and --system-only", func() {
+		It("rejects --system --system-only with a clear error", func() {
+			// PersistentPreRunE should reject the combination before any
+			// command body runs, so both apply and plan must surface the
+			// same message on stderr. Use plan to avoid touching state.
+			output, err := testExec.Exec("tomei", "plan", "--system", "--system-only", "~/privileged-test/")
+			Expect(err).To(HaveOccurred(), "combined flags must fail")
+			Expect(output).To(ContainSubstring("--system and --system-only are mutually exclusive"))
+		})
+	})
+
+	Context("Apply with --system-only", func() {
+		BeforeAll(func() {
+			// Reset state and artifacts: the prior "Removal with --system"
+			// context already cleaned the privileged marker, but the normal
+			// tool's user-owned marker still exists. Same cleanup pattern as
+			// the other --system context: unprivileged rm first, escalate
+			// only if a root-owned path remains.
+			_, _ = testExec.ExecBash(`echo '{"runtimes":{},"tools":{},"installers":{},"installerRepositories":{}}' > ~/.local/share/tomei/state.json`)
+			_, _ = testExec.ExecBash("rm -rf /tmp/tomei-normal-test /tmp/tomei-privileged-test 2>/dev/null")
+			out, err := testExec.ExecBash("if [ -e /tmp/tomei-privileged-test ]; then sudo -n rm -rf /tmp/tomei-privileged-test; fi")
+			Expect(err).NotTo(HaveOccurred(), "--system-only apply cleanup failed: %s", out)
+		})
+
+		It("plan marks normal tool skip and privileged install", func() {
+			output, err := testExec.Exec("tomei", "plan", "--system-only", "~/privileged-test/")
+			Expect(err).NotTo(HaveOccurred())
+			// privileged-tool should appear with [+ install]; the
+			// non-privileged normal-tool should appear with [⊘ skip].
+			// Substring asserts are robust to color codes / formatting.
+			Expect(output).To(ContainSubstring("privileged-tool"))
+			Expect(output).To(ContainSubstring("normal-tool"))
+			Expect(output).To(ContainSubstring("install"))
+			Expect(output).To(ContainSubstring("skip"))
+		})
+
+		It("apply installs privileged tool, skips normal tool", func() {
+			output, err := ExecApply(testExec, "--system-only", "~/privileged-test/")
+			Expect(err).NotTo(HaveOccurred())
+			// Skip summary from filterNonPrivilegedWithLog must appear.
+			Expect(output).To(ContainSubstring("non-privileged resource(s) skipped"))
+			Expect(output).To(ContainSubstring("--system-only"))
+		})
+
+		It("creates privileged tool marker via sudo", func() {
+			output, err := testExec.ExecBash("cat /tmp/tomei-privileged-test/marker")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(ContainSubstring("installed"))
+		})
+
+		It("does NOT install normal tool", func() {
+			_, err := testExec.ExecBash("test -f /tmp/tomei-normal-test/marker")
+			Expect(err).To(HaveOccurred(), "non-privileged tool marker must not exist under --system-only")
+		})
+
+		It("records only privileged tool in state", func() {
+			output, err := testExec.Exec("tomei", "get", "tools", "-o", "json")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(ContainSubstring(`"privileged-tool"`))
+			Expect(output).NotTo(ContainSubstring(`"normal-tool"`))
+		})
+	})
+
+	Context("--system-only preserves earlier non-priv installs", func() {
+		// Verify that running --system-only after a default `tomei apply` (which
+		// installed normal-tool) does NOT remove normal-tool from state — the
+		// filter strips it before the engine sees it, so no removal action is
+		// computed against state.
+		BeforeAll(func() {
+			// Clean slate, then do a default apply to install normal-tool.
+			_, _ = testExec.ExecBash(`echo '{"runtimes":{},"tools":{},"installers":{},"installerRepositories":{}}' > ~/.local/share/tomei/state.json`)
+			_, _ = testExec.ExecBash("rm -rf /tmp/tomei-normal-test /tmp/tomei-privileged-test 2>/dev/null")
+			out, err := testExec.ExecBash("if [ -e /tmp/tomei-privileged-test ]; then sudo -n rm -rf /tmp/tomei-privileged-test; fi")
+			Expect(err).NotTo(HaveOccurred(), "preserve-test cleanup failed: %s", out)
+
+			// Default apply: installs normal-tool, skips privileged-tool.
+			_, err = ExecApply(testExec, "~/privileged-test/")
+			Expect(err).NotTo(HaveOccurred(), "preserve-test default apply failed")
+		})
+
+		It("normal-tool stays in state after --system-only apply", func() {
+			_, err := ExecApply(testExec, "--system-only", "~/privileged-test/")
+			Expect(err).NotTo(HaveOccurred())
+
+			output, err := testExec.Exec("tomei", "get", "tools", "-o", "json")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output).To(ContainSubstring(`"normal-tool"`), "normal-tool must NOT be removed by --system-only")
+			Expect(output).To(ContainSubstring(`"privileged-tool"`), "privileged-tool should now be in state")
+		})
+	})
 }

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -2150,7 +2150,7 @@ EOF`, dir, repoBlock)
 				// User-visible warning from cmd/tomei/apply.go.
 				// NOTE: this exact string is UX-coupling — if the wording
 				// in apply.go changes, update both in lockstep.
-				Expect(out).To(ContainSubstring("system resource(s) skipped. Use 'tomei apply --system' to manage"),
+				Expect(out).To(ContainSubstring("system resource(s) skipped. Use 'tomei apply --system' or 'tomei apply --system-only' to manage"),
 					"expected the skip warning to be printed; got:\n%s", out)
 
 				// Files and state must be byte-identical to the

--- a/internal/installer/engine/engine.go
+++ b/internal/installer/engine/engine.go
@@ -1325,18 +1325,20 @@ func (e *Engine) handleRemovals(ctx context.Context, resources []resource.Resour
 				// Partial/corrupted state: we can't determine privilege.
 				// Skip removal conservatively (the installer's Remove would
 				// likely deref the nil state and panic) and log distinctly
-				// so this case is not conflated with non-priv tools.
+				// so this case is not conflated with non-priv tools. Do NOT
+				// increment skippedUserKindRemoves — this is unknown-
+				// privilege, not necessarily a user-kind, and would mislead
+				// the counter.
 				slog.Warn("skipping tool removal with nil state (--system-only)",
 					"name", action.Name)
 			case !action.State.Privileged:
 				slog.Info("skipping removal of non-privileged tool (--system-only)",
 					"name", action.Name)
+				e.skippedUserKindRemoves++
 			default:
 				// Privileged removal: in scope under --system-only, keep it.
 				filteredTools = append(filteredTools, action)
-				continue
 			}
-			e.skippedUserKindRemoves++
 		}
 		toolActions = filteredTools
 

--- a/internal/installer/engine/engine.go
+++ b/internal/installer/engine/engine.go
@@ -157,6 +157,13 @@ type Engine struct {
 	parallelism             int
 	updateCfg               UpdateConfig
 	skippedPrivileged       int // count of privileged removals skipped (no --system)
+	// skipUserKindRemovals: when true, handleRemovals skips ActionRemove for
+	// non-privileged Tools, Runtimes, and InstallerRepositories. Set by the
+	// cmd layer under --system-only so the engine does not tear down
+	// user-level state that was installed by a prior plain `tomei apply`.
+	// Counterpart of the privilegeHandler==nil skip for priv tools.
+	skipUserKindRemovals   bool
+	skippedUserKindRemoves int // count of user-kind removals skipped (--system-only)
 }
 
 // UpdateConfig holds update-related flags for apply and plan commands.
@@ -242,6 +249,23 @@ func (e *Engine) SkippedPrivileged() int {
 	return e.skippedPrivileged
 }
 
+// SetSkipUserKindRemovals enables the symmetric counterpart of the priv-
+// removal skip for --system-only mode. When true, handleRemovals filters
+// out ActionRemove for non-privileged Tools, Runtimes, and
+// InstallerRepositories so that state installed by a prior `tomei apply`
+// is preserved across `tomei apply --system-only`. Privileged Tool
+// removals are unaffected (they're in scope under --system-only).
+func (e *Engine) SetSkipUserKindRemovals(skip bool) {
+	e.skipUserKindRemovals = skip
+}
+
+// SkippedUserKindRemoves returns the number of user-kind removals
+// (non-priv Tool, Runtime, InstallerRepository) skipped by
+// SetSkipUserKindRemovals. Call after Apply() completes.
+func (e *Engine) SkippedUserKindRemoves() int {
+	return e.skippedUserKindRemoves
+}
+
 // eventEmitter is an unexported interface for emitting engine events.
 // Both Engine and SystemEngine satisfy this interface.
 type eventEmitter interface {
@@ -275,6 +299,7 @@ func (e *Engine) Apply(ctx context.Context, resources []resource.Resource) error
 	// SkippedPrivileged() reflect only this Apply invocation, not prior runs
 	// when the Engine instance is reused (e.g., in tests or orchestration).
 	e.skippedPrivileged = 0
+	e.skippedUserKindRemoves = 0
 
 	// Expand set resources (ToolSet, etc.) into individual resources
 	var err error
@@ -1279,6 +1304,51 @@ func (e *Engine) handleRemovals(ctx context.Context, resources []resource.Resour
 			filtered = append(filtered, action)
 		}
 		toolActions = filtered
+	}
+
+	// --system-only: skip removals of non-priv Tools, Runtimes, and
+	// InstallerRepositories. These were filtered out of the manifest at
+	// the cmd layer (filterNonPrivilegedWithLog in cmd/tomei/apply.go), so
+	// the reconciler sees their state entries as orphaned and emits
+	// ActionRemove. Skipping them here preserves the prior `tomei apply`
+	// installation across `tomei apply --system-only`. Priv Tool removals
+	// are NOT skipped — privilege is in scope under --system-only.
+	if e.skipUserKindRemovals {
+		filteredTools := make([]ToolAction, 0, len(toolActions))
+		for _, action := range toolActions {
+			if action.Type == resource.ActionRemove && (action.State == nil || !action.State.Privileged) {
+				slog.Info("skipping removal of non-privileged tool (--system-only)",
+					"name", action.Name)
+				e.skippedUserKindRemoves++
+				continue
+			}
+			filteredTools = append(filteredTools, action)
+		}
+		toolActions = filteredTools
+
+		filteredRuntimes := make([]RuntimeAction, 0, len(runtimeActions))
+		for _, action := range runtimeActions {
+			if action.Type == resource.ActionRemove {
+				slog.Info("skipping removal of runtime (--system-only)",
+					"name", action.Name)
+				e.skippedUserKindRemoves++
+				continue
+			}
+			filteredRuntimes = append(filteredRuntimes, action)
+		}
+		runtimeActions = filteredRuntimes
+
+		filteredRepos := make([]InstallerRepositoryAction, 0, len(repoActions))
+		for _, action := range repoActions {
+			if action.Type == resource.ActionRemove {
+				slog.Info("skipping removal of installer repository (--system-only)",
+					"name", action.Name)
+				e.skippedUserKindRemoves++
+				continue
+			}
+			filteredRepos = append(filteredRepos, action)
+		}
+		repoActions = filteredRepos
 	}
 
 	// Validate no remaining tools depend on runtimes being removed

--- a/internal/installer/engine/engine.go
+++ b/internal/installer/engine/engine.go
@@ -1316,13 +1316,27 @@ func (e *Engine) handleRemovals(ctx context.Context, resources []resource.Resour
 	if e.skipUserKindRemovals {
 		filteredTools := make([]ToolAction, 0, len(toolActions))
 		for _, action := range toolActions {
-			if action.Type == resource.ActionRemove && (action.State == nil || !action.State.Privileged) {
-				slog.Info("skipping removal of non-privileged tool (--system-only)",
-					"name", action.Name)
-				e.skippedUserKindRemoves++
+			if action.Type != resource.ActionRemove {
+				filteredTools = append(filteredTools, action)
 				continue
 			}
-			filteredTools = append(filteredTools, action)
+			switch {
+			case action.State == nil:
+				// Partial/corrupted state: we can't determine privilege.
+				// Skip removal conservatively (the installer's Remove would
+				// likely deref the nil state and panic) and log distinctly
+				// so this case is not conflated with non-priv tools.
+				slog.Warn("skipping tool removal with nil state (--system-only)",
+					"name", action.Name)
+			case !action.State.Privileged:
+				slog.Info("skipping removal of non-privileged tool (--system-only)",
+					"name", action.Name)
+			default:
+				// Privileged removal: in scope under --system-only, keep it.
+				filteredTools = append(filteredTools, action)
+				continue
+			}
+			e.skippedUserKindRemoves++
 		}
 		toolActions = filteredTools
 

--- a/internal/installer/engine/engine.go
+++ b/internal/installer/engine/engine.go
@@ -255,6 +255,13 @@ func (e *Engine) SkippedPrivileged() int {
 // InstallerRepositories so that state installed by a prior `tomei apply`
 // is preserved across `tomei apply --system-only`. Privileged Tool
 // removals are unaffected (they're in scope under --system-only).
+//
+// As a safety side-effect, tool removals whose stored state is nil
+// (corrupted/partial state) are also skipped — privilege cannot be
+// determined and the installer's Remove would likely deref nil. These
+// nil-state skips are logged at Warn and do NOT increment
+// SkippedUserKindRemoves (the counter is reserved for confirmed
+// user-kind skips).
 func (e *Engine) SetSkipUserKindRemovals(skip bool) {
 	e.skipUserKindRemovals = skip
 }

--- a/internal/installer/engine/engine.go
+++ b/internal/installer/engine/engine.go
@@ -1302,7 +1302,7 @@ func (e *Engine) handleRemovals(ctx context.Context, resources []resource.Resour
 		filtered := make([]ToolAction, 0, len(toolActions))
 		for _, action := range toolActions {
 			if action.Type == resource.ActionRemove && action.State != nil && action.State.Privileged {
-				slog.Warn("skipping removal of privileged tool (use --system)",
+				slog.Warn("skipping removal of privileged tool (use --system or --system-only)",
 					"name", action.Name,
 					"reason", action.State.PrivilegedRemovalReason())
 				e.skippedPrivileged++

--- a/internal/installer/engine/engine_test.go
+++ b/internal/installer/engine/engine_test.go
@@ -4974,3 +4974,97 @@ tool: {
 	assert.True(t, runtimeInstalled.Load(), "runtime (layer 0) should have been installed")
 	assert.False(t, toolInstalled.Load(), "tool (layer 1) should not be installed after cancellation")
 }
+
+// TestEngine_SkipUserKindRemovals_SystemOnly verifies the --system-only
+// preservation guarantee: with SetSkipUserKindRemovals(true) and a manifest
+// that omits a previously-installed non-privileged tool, the engine MUST
+// NOT remove that tool from state. Mirrors the apply.go wiring under
+// ScopeSystemOnly where filterNonPrivilegedWithLog strips non-priv
+// resources before the engine sees them.
+func TestEngine_SkipUserKindRemovals_SystemOnly(t *testing.T) {
+	t.Parallel()
+
+	// Manifest has only the privileged tool (priv-tool). State has both
+	// priv-tool and a previously-installed non-priv tool (normal-tool).
+	configDir := t.TempDir()
+	cueContent := `package tomei
+
+privTool: {
+	apiVersion: "tomei.terassyi.net/v1beta1"
+	kind: "Tool"
+	metadata: name: "priv-tool"
+	spec: {
+		privileged: true
+		commands: {
+			install: ["echo install"]
+			check: ["true"]
+			remove: ["echo remove"]
+			resolveVersion: ["echo 1.0.0"]
+		}
+	}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "resources.cue"), []byte(cueContent), 0644))
+
+	loader := config.NewLoader(nil)
+	resources, err := loader.Load(configDir)
+	require.NoError(t, err)
+
+	stateDir := t.TempDir()
+	store, err := state.NewStore[state.UserState](stateDir)
+	require.NoError(t, err)
+	require.NoError(t, store.Lock())
+	initial := state.NewUserState()
+	initial.Tools["priv-tool"] = &resource.ToolState{
+		Version:    "1.0.0",
+		Privileged: true,
+		Commands:   &resource.ToolCommandSet{CommandSet: resource.CommandSet{Remove: []string{"echo remove"}}},
+	}
+	initial.Tools["normal-tool"] = &resource.ToolState{
+		Version: "1.0.0",
+		BinPath: "/bin/normal-tool",
+	}
+	initial.Runtimes["normal-runtime"] = &resource.RuntimeState{
+		Version:     "1.0.0",
+		InstallPath: "/runtimes/normal-runtime",
+	}
+	require.NoError(t, store.Save(initial))
+	require.NoError(t, store.Unlock())
+
+	toolMock := &mockToolInstaller{
+		installFunc: func(_ context.Context, res *resource.Tool, _ string) (*resource.ToolState, error) {
+			return &resource.ToolState{
+				Version:    res.ToolSpec.Version,
+				Privileged: res.ToolSpec.Privileged,
+			}, nil
+		},
+	}
+
+	eng := NewEngine(toolMock, &mockRuntimeInstaller{}, &mockInstallerRepositoryInstaller{}, store)
+	// SetPrivilegeHandler is required so priv-tool removal would proceed
+	// if it were emitted; here it's not emitted because priv-tool is in
+	// the manifest. The handler also disables the priv-skip block so we
+	// isolate the user-kind-skip path.
+	eng.SetPrivilegeHandler(&noopPrivilegeHandler{})
+	eng.SetSkipUserKindRemovals(true)
+
+	require.NoError(t, eng.Apply(context.Background(), resources))
+
+	// Verify: non-priv tool + runtime still present in state.
+	require.NoError(t, store.Lock())
+	got, err := store.Load()
+	require.NoError(t, err)
+	require.NoError(t, store.Unlock())
+
+	assert.Contains(t, got.Tools, "normal-tool", "non-priv tool must NOT be removed under --system-only")
+	assert.Contains(t, got.Runtimes, "normal-runtime", "runtime must NOT be removed under --system-only")
+	assert.Contains(t, got.Tools, "priv-tool", "priv tool still in state (also in manifest)")
+
+	// Counter should reflect the 2 skipped removals (normal-tool, normal-runtime).
+	assert.Equal(t, 2, eng.SkippedUserKindRemoves())
+}
+
+type noopPrivilegeHandler struct{}
+
+func (noopPrivilegeHandler) Acquire(_ context.Context) error { return nil }
+func (noopPrivilegeHandler) Release() error                  { return nil }


### PR DESCRIPTION
Adds a third mode alongside default and --system:
  - default: only non-priv user-level resources
  - --system: all resources (user + privileged + system)
  - --system-only: privileged tools + system resources, with non-priv
    user-level resources forced to skip

Useful for CI provisioning and cron-driven privileged reapply on servers
where you don't want to re-walk the user tool tree.

Implementation:
- cmd/tomei/root.go: ApplyScope tri-state with IncludesUserKinds /
  IncludesPrivileged / IncludesSystemKinds predicates, derived from the
  two persistent bool flags. PersistentPreRunE rejects --system +
  --system-only as mutually exclusive.
- cmd/tomei/plan.go: scope threaded through resolvePlan /
  buildResourceInfo / planForResources. Non-priv resources in
  --system-only get ActionSkip (both fresh and removal-detection
  branches for Tool + Runtime).
- cmd/tomei/apply.go: scope threaded through executeApply. New
  filterNonPrivilegedWithLog strips non-priv user resources when
  --system-only (dual of filterPrivilegedWithLog). SystemEngine
  creation, sudo acquisition, and overlap validation all gate on
  scope.IncludesSystemKinds() / IncludesPrivileged() now.

Crucially: the cmd-layer filter strips non-priv from userResources
before they reach engine.Apply, but the engine's handleRemovals
reconciler would then emit ActionRemove for state-only non-priv
entries — silently tearing down state installed by a prior plain
`tomei apply`. Engine.SetSkipUserKindRemovals(true) is the symmetric
counterpart of the existing priv-removal skip block: when set,
non-priv Tool / Runtime / InstallerRepository removals are filtered
out of handleRemovals with a slog.Info per skipped resource and a
SkippedUserKindRemoves counter.

Tests:
- cmd/tomei/root_test.go: ApplyScope predicates, scopeFromFlags,
  PersistentPreRunE mutual-exclusion error
- cmd/tomei/apply_test.go: filterNonPrivilegedWithLog (3 subtests)
- internal/installer/engine/engine_test.go: priv-only manifest + mixed
  state proves non-priv tool + runtime survive a --system-only apply
- e2e/privileged_test.go: --system-only contexts (plan, apply,
  state-preservation, mutual-exclusion)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
