### PR TITLE
feat(resource): add Tool.spec.ref for SHA-pinned go install

### DIFF
--- a/cmd/tomei/plan.go
+++ b/cmd/tomei/plan.go
@@ -203,6 +203,7 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 		case resource.KindTool:
 			if tool, ok := res.(*resource.Tool); ok && tool.ToolSpec != nil {
 				resInfo.Version = tool.ToolSpec.Version
+				resInfo.Ref = tool.ToolSpec.Ref
 			}
 		}
 
@@ -235,11 +236,18 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 				}
 			case resource.KindTool:
 				if tool, ok := userState.Tools[res.Name()]; ok && tool != nil {
-					if tool.IsTainted() {
+					// Branch ordering MUST match reconciler.ToolComparator
+					// (internal/installer/reconciler/tool.go) — otherwise
+					// `tomei plan` and the engine disagree on the reason
+					// surfaced when multiple signals fire at once.
+					switch {
+					case tool.Ref != resInfo.Ref:
+						resInfo.Action = resource.ActionUpgrade
+					case tool.IsTainted():
 						resInfo.Action = resource.ActionReinstall
-					} else if tool.Version == resInfo.Version {
+					case tool.Version == resInfo.Version:
 						resInfo.Action = resource.ActionNone
-					} else {
+					default:
 						resInfo.Action = resource.ActionUpgrade
 					}
 				}
@@ -330,6 +338,7 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 					Kind:       resource.KindTool,
 					Name:       name,
 					Version:    tool.Version,
+					Ref:        tool.Ref,
 					Action:     action,
 					Privileged: tool.Privileged,
 				}
@@ -558,6 +567,7 @@ func addDisabledResourceInfo(info map[graph.NodeID]graph.ResourceInfo, disabled 
 		}
 		if tool, ok := res.(*resource.Tool); ok && tool.ToolSpec != nil {
 			ri.Version = tool.ToolSpec.Version
+			ri.Ref = tool.ToolSpec.Ref
 		}
 		info[nodeID] = ri
 	}

--- a/cuemodule/schema/schema.cue
+++ b/cuemodule/schema/schema.cue
@@ -164,13 +164,25 @@ package schema
 		runtimeRef?:    string
 		repositoryRef?: string
 		version?:       string
-		enabled?:       bool
-		source?:        #DownloadSource
-		package?:       #Package
-		commands?:      #ToolCommandSet
-		binaryName?:    string & =~"^[a-zA-Z0-9][a-zA-Z0-9._-]*$"
+		// ref pins installation to a 40-char lowercase hex git SHA.
+		// Only supported with runtimeRef: "go" today (the Go module proxy
+		// verifies the SHA against the GOSUMDB transparency log). The
+		// schema enforces the runtimeRef gate below; Validate enforces
+		// the format and the ref/version mutual exclusion.
+		ref?:        string & =~"^[0-9a-f]{40}$"
+		enabled?:    bool
+		source?:     #DownloadSource
+		package?:    #Package
+		commands?:   #ToolCommandSet
+		binaryName?: string & =~"^[a-zA-Z0-9][a-zA-Z0-9._-]*$"
 		args?: [...string]
 		privileged?: bool
+
+		// ref requires runtimeRef: "go". Encoded as a CUE constraint so
+		// the schema rejects misuse before Go-side Validate runs.
+		if ref != _|_ {
+			runtimeRef: "go"
+		}
 	}
 }
 
@@ -184,6 +196,7 @@ package schema
 		repositoryRef?: string
 		tools: {[string]: {
 			version?:    string
+			ref?:        string & =~"^[0-9a-f]{40}$"
 			enabled?:    bool
 			source?:     #DownloadSource
 			package?:    #Package

--- a/cuemodule/schema/schema.cue
+++ b/cuemodule/schema/schema.cue
@@ -178,10 +178,14 @@ package schema
 		args?: [...string]
 		privileged?: bool
 
-		// ref requires runtimeRef: "go". Encoded as a CUE constraint so
-		// the schema rejects misuse before Go-side Validate runs.
+		// ref requires runtimeRef: "go" and forbids installerRef / commands.
+		// Encoded as CUE constraints so the schema rejects misuse with a
+		// precise field-level error before Go-side Validate runs (otherwise
+		// downstream mutual-exclusion errors would be confusing).
 		if ref != _|_ {
-			runtimeRef: "go"
+			runtimeRef:    "go"
+			installerRef?: =~"^$" // forbid: ref + installerRef is invalid
+			commands?:     null   // forbid: ref + commands is invalid
 		}
 	}
 }

--- a/internal/graph/export.go
+++ b/internal/graph/export.go
@@ -20,9 +20,12 @@ type PlanOutput struct {
 
 // PlanResource represents a resource in the plan output.
 type PlanResource struct {
-	Kind         resource.Kind       `json:"kind" yaml:"kind"`
-	Name         string              `json:"name" yaml:"name"`
+	Kind resource.Kind `json:"kind" yaml:"kind"`
+	Name string        `json:"name" yaml:"name"`
+	// Version and Ref are mutually exclusive: Ref carries the git commit
+	// SHA for SHA-pinned tools; Version carries the tag/release otherwise.
 	Version      string              `json:"version,omitempty" yaml:"version,omitempty"`
+	Ref          string              `json:"ref,omitempty" yaml:"ref,omitempty"`
 	Action       resource.ActionType `json:"action" yaml:"action"`
 	Layer        int                 `json:"layer" yaml:"layer"`
 	Dependencies []string            `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
@@ -90,6 +93,7 @@ func (e *Exporter) BuildOutput() PlanOutput {
 				Kind:         node.Kind,
 				Name:         node.Name,
 				Version:      info.Version,
+				Ref:          info.Ref,
 				Action:       info.Action,
 				Layer:        i + 1,
 				Dependencies: deps[nodeID],
@@ -114,6 +118,7 @@ func (e *Exporter) BuildOutput() PlanOutput {
 				Kind:    info.Kind,
 				Name:    info.Name,
 				Version: info.Version,
+				Ref:     info.Ref,
 				Action:  resource.ActionSkip,
 				Layer:   0,
 			})

--- a/internal/graph/tree.go
+++ b/internal/graph/tree.go
@@ -13,9 +13,13 @@ import (
 
 // ResourceInfo holds information about a resource for display.
 type ResourceInfo struct {
-	Kind       resource.Kind
-	Name       string
-	Version    string
+	Kind    resource.Kind
+	Name    string
+	Version string
+	// Ref holds the git commit SHA for SHA-pinned tools. Mutually exclusive
+	// with Version (Validate enforces this on the spec side). Stored in full
+	// here; the tree renderer truncates for display.
+	Ref        string
 	Action     resource.ActionType
 	Privileged bool
 }
@@ -149,6 +153,16 @@ func (p *TreePrinter) printNode(nodeID NodeID, prefix string, isLast bool, child
 	}
 }
 
+// shortRef truncates a 40-char SHA to a 12-char prefix + ellipsis for display.
+// State retains the full SHA — only the rendered tree is shortened.
+func shortRef(ref string) string {
+	const display = 12
+	if len(ref) <= display {
+		return ref
+	}
+	return ref[:display] + "…"
+}
+
 func (p *TreePrinter) formatNode(nodeID NodeID, info ResourceInfo, hasInfo bool) string {
 	var sb strings.Builder
 
@@ -156,9 +170,13 @@ func (p *TreePrinter) formatNode(nodeID NodeID, info ResourceInfo, hasInfo bool)
 	nodeName := string(nodeID)
 
 	if hasInfo {
-		// Version
+		// Version / Ref (mutually exclusive — Ref wins when both are set,
+		// though Validate prevents that on the spec side).
 		versionStr := ""
-		if info.Version != "" {
+		switch {
+		case info.Ref != "":
+			versionStr = fmt.Sprintf(" (ref: %s)", shortRef(info.Ref))
+		case info.Version != "":
 			versionStr = fmt.Sprintf(" (%s)", info.Version)
 		}
 

--- a/internal/graph/tree_test.go
+++ b/internal/graph/tree_test.go
@@ -8,6 +8,44 @@ import (
 	"github.com/terassyi/tomei/internal/resource"
 )
 
+func TestShortRef(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "40-char SHA truncates to 12+ellipsis", in: "0123456789abcdef0123456789abcdef01234567", want: "0123456789ab…"},
+		{name: "12-char passes through", in: "0123456789ab", want: "0123456789ab"},
+		{name: "empty stays empty", in: "", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, shortRef(tt.in))
+		})
+	}
+}
+
+// TestFormatNode_RefRendering pins the tree's ref display: Ref-pinned tools
+// render as " (ref: <12chars>…)" instead of the usual " (version)" slot,
+// preserving the full SHA only in state (not in the rendered tree).
+func TestFormatNode_RefRendering(t *testing.T) {
+	t.Parallel()
+	p := NewTreePrinter(&bytes.Buffer{}, true)
+	const sha = "0123456789abcdef0123456789abcdef01234567"
+
+	info := ResourceInfo{
+		Kind:   resource.KindTool,
+		Name:   "gopls",
+		Ref:    sha,
+		Action: resource.ActionInstall,
+	}
+	out := p.formatNode(NewNodeID(resource.KindTool, "gopls"), info, true)
+	assert.Contains(t, out, "(ref: 0123456789ab…)", "ref must render truncated, not as full SHA")
+	assert.NotContains(t, out, sha, "full SHA must not appear in rendered tree")
+}
+
 func TestPrintSummary(t *testing.T) {
 	t.Parallel()
 

--- a/internal/installer/reconciler/reconciler_test.go
+++ b/internal/installer/reconciler/reconciler_test.go
@@ -1,6 +1,7 @@
 package reconciler
 
 import (
+	"strings"
 	"testing"
 	"testing/quick"
 	"time"
@@ -644,6 +645,139 @@ func TestToolComparator_PrivilegedChanged(t *testing.T) {
 			}
 		})
 	}
+}
+
+// --- ToolComparator ref (SHA pin) tests ---
+
+func TestToolComparator_RefChanged(t *testing.T) {
+	t.Parallel()
+	const oldSHA = "0123456789abcdef0123456789abcdef01234567"
+	const newSHA = "fedcba9876543210fedcba9876543210fedcba98"
+
+	tests := []struct {
+		name       string
+		specRef    string
+		stateRef   string
+		wantUpdate bool
+		wantReason string
+	}{
+		{
+			name:       "ref unchanged - no update",
+			specRef:    oldSHA,
+			stateRef:   oldSHA,
+			wantUpdate: false,
+		},
+		{
+			name:       "ref rotated to new SHA",
+			specRef:    newSHA,
+			stateRef:   oldSHA,
+			wantUpdate: true,
+			wantReason: "ref changed: " + oldSHA + " -> " + newSHA,
+		},
+		{
+			name:       "ref deselected (version takes over)",
+			specRef:    "",
+			stateRef:   oldSHA,
+			wantUpdate: true,
+			wantReason: "ref changed: " + oldSHA + " -> ",
+		},
+		{
+			name:       "ref newly set (was version-pinned)",
+			specRef:    newSHA,
+			stateRef:   "",
+			wantUpdate: true,
+			wantReason: "ref changed:  -> " + newSHA,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			comparator := ToolComparator()
+
+			res := &resource.Tool{
+				BaseResource: resource.BaseResource{
+					Metadata: resource.Metadata{Name: "gopls"},
+				},
+				ToolSpec: &resource.ToolSpec{
+					RuntimeRef: "go",
+					Ref:        tt.specRef,
+					Package:    &resource.Package{Name: "golang.org/x/tools/gopls"},
+				},
+			}
+
+			state := &resource.ToolState{
+				RuntimeRef:  "go",
+				Ref:         tt.stateRef,
+				Version:     "",
+				VersionKind: resource.VersionExact,
+				SpecVersion: "",
+			}
+
+			needsUpdate, reason := comparator(res, state)
+			assert.Equal(t, tt.wantUpdate, needsUpdate)
+			if tt.wantReason != "" {
+				assert.Equal(t, tt.wantReason, reason)
+			}
+		})
+	}
+}
+
+// TestToolComparator_RefOrdering pins the precedence of the new Ref branch
+// against the existing Version and taint branches. The Ref check runs first;
+// when ref differs the reason must be "ref changed:" even if version or taint
+// would also fire on their own.
+func TestToolComparator_RefOrdering(t *testing.T) {
+	t.Parallel()
+	const oldSHA = "0123456789abcdef0123456789abcdef01234567"
+	const newSHA = "fedcba9876543210fedcba9876543210fedcba98"
+
+	t.Run("ref change wins over version change", func(t *testing.T) {
+		t.Parallel()
+		comparator := ToolComparator()
+		res := &resource.Tool{
+			BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "gopls"}},
+			ToolSpec: &resource.ToolSpec{
+				RuntimeRef: "go",
+				Ref:        newSHA,
+				Package:    &resource.Package{Name: "golang.org/x/tools/gopls"},
+			},
+		}
+		state := &resource.ToolState{
+			RuntimeRef:  "go",
+			Ref:         oldSHA,
+			Version:     "v0.16.0",
+			VersionKind: resource.VersionExact,
+			SpecVersion: "v0.16.0",
+		}
+		needsUpdate, reason := comparator(res, state)
+		assert.True(t, needsUpdate)
+		assert.True(t, strings.HasPrefix(reason, "ref changed:"),
+			"ref branch must short-circuit version branch (got %q)", reason)
+	})
+
+	t.Run("ref change wins over taint", func(t *testing.T) {
+		t.Parallel()
+		comparator := ToolComparator()
+		res := &resource.Tool{
+			BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "gopls"}},
+			ToolSpec: &resource.ToolSpec{
+				RuntimeRef: "go",
+				Ref:        newSHA,
+				Package:    &resource.Package{Name: "golang.org/x/tools/gopls"},
+			},
+		}
+		state := &resource.ToolState{
+			RuntimeRef:  "go",
+			Ref:         oldSHA,
+			VersionKind: resource.VersionExact,
+			TaintReason: resource.TaintReasonRuntimeUpgraded,
+		}
+		needsUpdate, reason := comparator(res, state)
+		assert.True(t, needsUpdate)
+		assert.True(t, strings.HasPrefix(reason, "ref changed:"),
+			"ref branch must short-circuit taint branch (got %q)", reason)
+	})
 }
 
 // --- RuntimeComparator tests with VersionKind ---

--- a/internal/installer/reconciler/tool.go
+++ b/internal/installer/reconciler/tool.go
@@ -24,8 +24,20 @@ func specVersionChanged(specVersion string, stateVersionKind resource.VersionKin
 }
 
 // ToolComparator returns a comparator for Tool resources.
+//
+// Branch ordering MUST match cmd/tomei/plan.go's buildResourceInfo Tool
+// switch — otherwise plan output and the engine disagree on the reason
+// surfaced when multiple signals fire at once.
 func ToolComparator() Comparator[*resource.Tool, *resource.ToolState] {
 	return func(res *resource.Tool, state *resource.ToolState) (bool, string) {
+		// Ref pinning (SHA) is checked first. ref→ref rotation, ref→version,
+		// and version→ref switches are all surfaced by simple string equality
+		// against state.Ref. Ordering note: a ref change short-circuits the
+		// Version/taint branches below — taint will be cleared by the reinstall
+		// regardless.
+		if res.ToolSpec.Ref != state.Ref {
+			return true, "ref changed: " + state.Ref + " -> " + res.ToolSpec.Ref
+		}
 		if specVersionChanged(res.ToolSpec.Version, state.VersionKind, state.Version, state.SpecVersion) {
 			return true, "version changed: " + state.Version + " -> " + res.ToolSpec.Version
 		}

--- a/internal/installer/tool/installer.go
+++ b/internal/installer/tool/installer.go
@@ -785,9 +785,18 @@ func (i *Installer) installByRuntime(ctx context.Context, res *resource.Tool, na
 	if spec.BinaryName != "" {
 		binName = spec.BinaryName
 	}
+	// Ref pins this install to a git SHA. The preset template
+	// (e.g. "go install {{.Package}}@{{.Version}}") receives the SHA via
+	// .Version, expanding to `@<sha>` without modifying the preset.
+	// buildDelegationState reads spec.Ref directly to persist it separately,
+	// so spec is left untouched.
+	versionSlot := spec.Version
+	if spec.Ref != "" {
+		versionSlot = spec.Ref
+	}
 	vars := command.Vars{
 		Package: spec.Package.String(),
-		Version: spec.Version,
+		Version: versionSlot,
 		Name:    name,
 		BinPath: filepath.Join(info.ToolBinPath, binName),
 		Args:    strings.Join(spec.Args, " "),
@@ -818,7 +827,13 @@ func (i *Installer) installByRuntime(ctx context.Context, res *resource.Tool, na
 		return nil, fmt.Errorf("failed to execute install command: %w", err)
 	}
 
-	slog.Debug("tool installed via runtime", "name", name, "version", spec.Version, "runtime", spec.RuntimeRef)
+	if spec.Ref != "" {
+		// SHA-pinned installs are security-relevant: surface the SHA at Info so
+		// audit logs record exactly which commit was resolved.
+		slog.Info("tool installed via runtime (ref-pinned)", "name", name, "ref", spec.Ref, "runtime", spec.RuntimeRef)
+	} else {
+		slog.Debug("tool installed via runtime", "name", name, "version", spec.Version, "runtime", spec.RuntimeRef)
+	}
 
 	// Clean up old binary when binaryName changes on upgrade/reinstall.
 	// Safety: only remove if the old path is within the expected ToolBinPath directory.
@@ -876,6 +891,7 @@ func (i *Installer) buildDelegationState(spec *resource.ToolSpec, binPath string
 	return &resource.ToolState{
 		InstallerRef: spec.InstallerRef,
 		Version:      spec.Version,
+		Ref:          spec.Ref,
 		VersionKind:  resource.ClassifyVersion(spec.Version),
 		SpecVersion:  spec.Version,
 		BinPath:      binPath,

--- a/internal/installer/tool/installer.go
+++ b/internal/installer/tool/installer.go
@@ -888,11 +888,20 @@ func (i *Installer) installByInstaller(ctx context.Context, res *resource.Tool, 
 
 // buildDelegationState creates a ToolState for delegation pattern installations.
 func (i *Installer) buildDelegationState(spec *resource.ToolSpec, binPath string) *resource.ToolState {
+	// Ref-pinned tools must classify as VersionExact, not VersionLatest.
+	// spec.Version is empty for ref pins, so ClassifyVersion would otherwise
+	// return VersionLatest and tomei's --sync / --update-tools modes would
+	// taint the tool (engine.applyUpdateTaints predicates on VersionLatest).
+	// A SHA pin is the strictest form of "exact" — don't surprise-reinstall.
+	versionKind := resource.ClassifyVersion(spec.Version)
+	if spec.Ref != "" {
+		versionKind = resource.VersionExact
+	}
 	return &resource.ToolState{
 		InstallerRef: spec.InstallerRef,
 		Version:      spec.Version,
 		Ref:          spec.Ref,
-		VersionKind:  resource.ClassifyVersion(spec.Version),
+		VersionKind:  versionKind,
 		SpecVersion:  spec.Version,
 		BinPath:      binPath,
 		RuntimeRef:   spec.RuntimeRef,

--- a/internal/installer/tool/installer_test.go
+++ b/internal/installer/tool/installer_test.go
@@ -847,6 +847,59 @@ func TestToolInstaller_Install_Args(t *testing.T) {
 	}
 }
 
+// TestToolInstaller_RuntimeRef_SubstitutesIntoVersion locks D2's invariant:
+// when ToolSpec.Ref is set, the SHA is substituted into the {{.Version}}
+// template slot so the preset's "go install pkg@{{.Version}}" expands to
+// "@<sha>". The persisted ToolState stores spec.Ref in state.Ref while
+// state.Version remains empty (the exclusivity invariant from Validate).
+func TestToolInstaller_RuntimeRef_SubstitutesIntoVersion(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	captureFile := filepath.Join(tmpDir, "captured_cmd.txt")
+
+	inst := NewInstaller(
+		download.NewDownloader(),
+		place.NewPlacer(filepath.Join(tmpDir, "tools")),
+		filepath.Join(tmpDir, "bin"),
+		filepath.Join(tmpDir, "system-bin"),
+	)
+	inst.RegisterRuntime("go", &RuntimeInfo{
+		BinDir:      "/usr/local/bin",
+		ToolBinPath: filepath.Dir(captureFile),
+		Commands: &resource.CommandsSpec{
+			Install: []string{"echo {{.Package}}@{{.Version}} > " + captureFile},
+		},
+	})
+
+	const sha = "0123456789abcdef0123456789abcdef01234567"
+	tool := &resource.Tool{
+		BaseResource: resource.BaseResource{
+			Metadata: resource.Metadata{Name: "gopls"},
+		},
+		ToolSpec: &resource.ToolSpec{
+			RuntimeRef: "go",
+			Ref:        sha,
+			Package:    &resource.Package{Name: "golang.org/x/tools/gopls"},
+		},
+	}
+
+	state, err := inst.Install(context.Background(), tool, tool.Name())
+	require.NoError(t, err)
+	require.NotNil(t, state)
+
+	content, err := os.ReadFile(captureFile)
+	require.NoError(t, err)
+	assert.Equal(t, "golang.org/x/tools/gopls@"+sha, strings.TrimSpace(string(content)),
+		"Ref must flow into {{.Version}} so go-install templates expand to @<sha>")
+
+	assert.Equal(t, sha, state.Ref, "state.Ref records the pinned SHA")
+	assert.Empty(t, state.Version, "state.Version stays empty when ref is set (exclusivity invariant)")
+
+	// spec must not be mutated — buildDelegationState reads it after install.
+	assert.Empty(t, tool.ToolSpec.Version, "spec.Version untouched after install")
+	assert.Equal(t, sha, tool.ToolSpec.Ref, "spec.Ref untouched after install")
+}
+
 func TestToolInstaller_ProgressCallback_Priority(t *testing.T) {
 	t.Parallel()
 	archiveData := createTarGzContent(t, "mytool", []byte("#!/bin/sh\necho hello"))

--- a/internal/installer/tool/installer_test.go
+++ b/internal/installer/tool/installer_test.go
@@ -894,6 +894,12 @@ func TestToolInstaller_RuntimeRef_SubstitutesIntoVersion(t *testing.T) {
 
 	assert.Equal(t, sha, state.Ref, "state.Ref records the pinned SHA")
 	assert.Empty(t, state.Version, "state.Version stays empty when ref is set (exclusivity invariant)")
+	// Regression (Copilot R1): ref-pinned tools must classify as VersionExact,
+	// NOT VersionLatest. ClassifyVersion("") would return VersionLatest by
+	// default and tomei's --sync / --update-tools modes (engine.applyUpdateTaints)
+	// would then taint the tool, causing surprise reinstalls of a SHA pin.
+	assert.Equal(t, resource.VersionExact, state.VersionKind,
+		"ref-pinned tools must classify as VersionExact so --sync/--update-tools don't taint them")
 
 	// spec must not be mutated — buildDelegationState reads it after install.
 	assert.Empty(t, tool.ToolSpec.Version, "spec.Version untouched after install")

--- a/internal/resource/tool.go
+++ b/internal/resource/tool.go
@@ -372,9 +372,12 @@ func (s *ToolSpec) Validate() error {
 		return fmt.Errorf("commands.install is required")
 	}
 
-	// For non-commands patterns, version/source/package is required
+	// For non-commands patterns, version/ref/source/package is required.
+	// Ref satisfies this gate so a ref-only spec falls through to the more
+	// specific runtimeRef/package check below instead of stopping here with
+	// a generic "version, source, or package is required" message.
 	if !hasCommands {
-		if s.Version == "" && s.Source == nil && s.Package.IsEmpty() {
+		if s.Version == "" && s.Ref == "" && s.Source == nil && s.Package.IsEmpty() {
 			return fmt.Errorf("version, source, or package is required")
 		}
 	}

--- a/internal/resource/tool.go
+++ b/internal/resource/tool.go
@@ -3,11 +3,17 @@ package resource
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/terassyi/tomei/internal/checksum"
 	"github.com/terassyi/tomei/internal/installer/extract"
 )
+
+// refSHAPattern matches a 40-character lowercase hex SHA-1, the form
+// `go install` resolves through GOPROXY+GOSUMDB. Short SHAs are rejected to
+// avoid proxy-side prefix-resolution ambiguity and downstream collision risk.
+var refSHAPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
 
 // DownloadSource holds download configuration for tools and runtimes
 // that are installed via the download pattern (e.g., aqua installer).
@@ -200,9 +206,15 @@ type Checksum struct {
 	Algorithm checksum.Algorithm `json:"algorithm,omitempty"`
 }
 
-// InstallerNameAqua is the canonical name of the builtin aqua installer.
-// Tools using a Registry package (owner/repo form) must reference this installer.
-const InstallerNameAqua = "aqua"
+// Canonical names of builtin runtimes and installers.
+const (
+	// RuntimeNameGo is the canonical name of the builtin Go runtime.
+	RuntimeNameGo = "go"
+
+	// InstallerNameAqua is the canonical name of the builtin aqua installer.
+	// Tools using a Registry package (owner/repo form) must reference this installer.
+	InstallerNameAqua = "aqua"
+)
 
 // ToolSpec defines the desired state of an individual tool.
 // A tool can be installed via four patterns:
@@ -228,6 +240,14 @@ type ToolSpec struct {
 	// Required for download pattern with Source; optional for registry pattern (defaults to latest).
 	// Optional for commands pattern (can be resolved via commands.resolveVersion).
 	Version string `json:"version,omitempty"`
+
+	// Ref pins installation to a specific git commit SHA instead of a tag/version.
+	// Must be a 40-character lowercase hex SHA-1. Mutually exclusive with Version.
+	// Currently supported only with RuntimeRef: "go" (go install pkg@<sha> resolves
+	// the SHA through GOPROXY+GOSUMDB transparency log). For other installers, Ref
+	// is rejected at Validate time — extending support requires re-deriving the
+	// integrity model for that installer.
+	Ref string `json:"ref,omitempty"`
 
 	// Enabled controls whether this tool should be installed.
 	// Default is true. Set to false to skip installation without removing the config.
@@ -343,6 +363,10 @@ func (s *ToolSpec) Validate() error {
 		return fmt.Errorf("privileged: true is not supported with runtimeRef")
 	}
 
+	if err := s.validateRef(); err != nil {
+		return err
+	}
+
 	// Commands must have at least Install
 	if hasCommands && len(s.Commands.Install) == 0 {
 		return fmt.Errorf("commands.install is required")
@@ -375,6 +399,27 @@ func (s *ToolSpec) Validate() error {
 		return err
 	}
 
+	return nil
+}
+
+// validateRef enforces the ref-pin policy: ref pins to a 40-char lowercase
+// hex SHA and is currently supported only with `runtimeRef: go`. Other
+// installers (aqua, cargo, npm, ...) have no equivalent integrity guarantee,
+// so extending support requires re-deriving the supply-chain model — do not
+// relax this check casually.
+func (s *ToolSpec) validateRef() error {
+	if s.Ref == "" {
+		return nil
+	}
+	if s.Version != "" {
+		return fmt.Errorf("ref and version are mutually exclusive")
+	}
+	if s.RuntimeRef != RuntimeNameGo {
+		return fmt.Errorf("ref is only supported with runtimeRef: go (got runtimeRef: %q)", s.RuntimeRef)
+	}
+	if !refSHAPattern.MatchString(s.Ref) {
+		return fmt.Errorf("ref must be a 40-character lowercase hex SHA (got %q)", s.Ref)
+	}
 	return nil
 }
 
@@ -573,6 +618,7 @@ func buildToolFromSetItem(ts *ToolSet, name string, item ToolItem) *Tool {
 			RepositoryRef: ts.ToolSetSpec.RepositoryRef,
 			RuntimeRef:    ts.ToolSetSpec.RuntimeRef,
 			Version:       item.Version,
+			Ref:           item.Ref,
 			Source:        item.Source,
 			Package:       item.Package,
 			BinaryName:    item.BinaryName,
@@ -588,6 +634,11 @@ type ToolItem struct {
 	// Version specifies the tool version to install.
 	// Overrides any default version from the ToolSet.
 	Version string `json:"version,omitempty"`
+
+	// Ref pins this tool to a git commit SHA. Mutually exclusive with Version.
+	// See ToolSpec.Ref for full semantics. Currently supported only with
+	// runtimeRef: "go".
+	Ref string `json:"ref,omitempty"`
 
 	// Enabled controls whether this specific tool should be installed.
 	// Default is true. Set to false to exclude this tool from the set.
@@ -653,6 +704,11 @@ type ToolState struct {
 
 	// Version is the installed version of the tool.
 	Version string `json:"version"`
+
+	// Ref is the git commit SHA that pinned the install (when spec.ref was set).
+	// Mutually exclusive with Version in the spec; only one of the two is populated
+	// at a time. Empty for tools installed by tag/version (the common case).
+	Ref string `json:"ref,omitempty"`
 
 	// Digest is the SHA256 hash of the installed binary (for download pattern).
 	// Used to verify integrity and detect if the binary was modified.

--- a/internal/resource/tool_test.go
+++ b/internal/resource/tool_test.go
@@ -271,6 +271,84 @@ func TestToolSpec_Validate(t *testing.T) {
 			},
 			wantErr: "privileged: true is not supported with runtimeRef",
 		},
+		{
+			name: "valid ref with go runtime",
+			spec: &ToolSpec{
+				RuntimeRef: "go",
+				Ref:        "0123456789abcdef0123456789abcdef01234567",
+				Package:    &Package{Name: "golang.org/x/tools/gopls"},
+			},
+			wantErr: "",
+		},
+		{
+			// Ordering pin: privileged + runtimeRef + ref must hit the
+			// privileged-vs-runtimeRef error first (existing rule wins over
+			// the newer ref-only rule). Locks ref validation BELOW the
+			// privileged check in Validate().
+			name: "privileged + ref + runtimeRef hits privileged error first",
+			spec: &ToolSpec{
+				RuntimeRef: "go",
+				Ref:        "0123456789abcdef0123456789abcdef01234567",
+				Package:    &Package{Name: "golang.org/x/tools/gopls"},
+				Privileged: true,
+			},
+			wantErr: "privileged: true is not supported with runtimeRef",
+		},
+		{
+			name: "ref + version mutually exclusive",
+			spec: &ToolSpec{
+				RuntimeRef: "go",
+				Ref:        "0123456789abcdef0123456789abcdef01234567",
+				Version:    "v0.16.0",
+				Package:    &Package{Name: "golang.org/x/tools/gopls"},
+			},
+			wantErr: "ref and version are mutually exclusive",
+		},
+		{
+			name: "ref with non-go runtime rejected",
+			spec: &ToolSpec{
+				RuntimeRef: "cargo",
+				Ref:        "0123456789abcdef0123456789abcdef01234567",
+				Package:    &Package{Name: "ripgrep"},
+			},
+			wantErr: `ref is only supported with runtimeRef: go (got runtimeRef: "cargo")`,
+		},
+		{
+			name: "ref with installerRef rejected",
+			spec: &ToolSpec{
+				InstallerRef: "aqua",
+				Ref:          "0123456789abcdef0123456789abcdef01234567",
+				Package:      &Package{Owner: "cli", Repo: "cli"},
+			},
+			wantErr: `ref is only supported with runtimeRef: go (got runtimeRef: "")`,
+		},
+		{
+			name: "ref short SHA rejected",
+			spec: &ToolSpec{
+				RuntimeRef: "go",
+				Ref:        "0123456",
+				Package:    &Package{Name: "golang.org/x/tools/gopls"},
+			},
+			wantErr: `ref must be a 40-character lowercase hex SHA (got "0123456")`,
+		},
+		{
+			name: "ref tag-like string rejected",
+			spec: &ToolSpec{
+				RuntimeRef: "go",
+				Ref:        "v1.2.3",
+				Package:    &Package{Name: "golang.org/x/tools/gopls"},
+			},
+			wantErr: `ref must be a 40-character lowercase hex SHA (got "v1.2.3")`,
+		},
+		{
+			name: "ref uppercase hex rejected",
+			spec: &ToolSpec{
+				RuntimeRef: "go",
+				Ref:        "0123456789ABCDEF0123456789abcdef01234567",
+				Package:    &Package{Name: "golang.org/x/tools/gopls"},
+			},
+			wantErr: `ref must be a 40-character lowercase hex SHA (got "0123456789ABCDEF0123456789abcdef01234567")`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -985,6 +1063,37 @@ func TestToolSet_Expand_CopiesArgs(t *testing.T) {
 	}
 }
 
+// Regression: ToolItem.Ref must propagate into the expanded Tool spec.
+// Without this, a ref-pinned tool declared inside a ToolSet would silently
+// lose the SHA at expansion time and resolve to @latest.
+func TestToolSet_Expand_CopiesRef(t *testing.T) {
+	t.Parallel()
+	const sha = "0123456789abcdef0123456789abcdef01234567"
+	ts := &ToolSet{
+		BaseResource: BaseResource{
+			APIVersion:   GroupVersion,
+			ResourceKind: KindToolSet,
+			Metadata:     Metadata{Name: "go-tools"},
+		},
+		ToolSetSpec: &ToolSetSpec{
+			RuntimeRef: "go",
+			Tools: map[string]ToolItem{
+				"gopls": {
+					Package: &Package{Name: "golang.org/x/tools/gopls"},
+					Ref:     sha,
+				},
+			},
+		},
+	}
+
+	resources, err := ts.Expand()
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	tool := resources[0].(*Tool)
+	assert.Equal(t, sha, tool.ToolSpec.Ref, "ToolItem.Ref must flow into expanded ToolSpec.Ref")
+	assert.Empty(t, tool.ToolSpec.Version, "version stays empty when ref is set")
+}
+
 func TestToolSet_Expand_WithRepositoryRef(t *testing.T) {
 	t.Parallel()
 	ts := &ToolSet{
@@ -1175,6 +1284,48 @@ func TestToolState_MarshalRoundtrip_WithoutCommands(t *testing.T) {
 	assert.Equal(t, original.InstallerRef, got.InstallerRef)
 	assert.Equal(t, original.Version, got.Version)
 	assert.Nil(t, got.Commands)
+}
+
+// Legacy state.json files (pre-ref) have no `ref` key. Verify they unmarshal
+// cleanly with ToolState.Ref defaulting to "".
+func TestToolState_Unmarshal_LegacyWithoutRef(t *testing.T) {
+	t.Parallel()
+	legacy := []byte(`{
+		"installerRef": "go",
+		"version": "v0.16.0",
+		"versionKind": "exact",
+		"installPath": "/home/u/go/bin/gopls",
+		"binPath": "",
+		"runtimeRef": "go",
+		"updatedAt": "2025-01-01T00:00:00Z"
+	}`)
+
+	var got ToolState
+	require.NoError(t, json.Unmarshal(legacy, &got))
+	assert.Empty(t, got.Ref, "Ref must default to empty for legacy state without the field")
+	assert.Equal(t, "v0.16.0", got.Version)
+}
+
+// Round-trip a ToolState that has Ref set; confirm the SHA survives marshal+unmarshal
+// and that Version stays empty (the exclusivity invariant from Validate).
+func TestToolState_MarshalRoundtrip_WithRef(t *testing.T) {
+	t.Parallel()
+	original := &ToolState{
+		InstallerRef: "go",
+		Version:      "",
+		Ref:          "0123456789abcdef0123456789abcdef01234567",
+		VersionKind:  VersionExact,
+		RuntimeRef:   "go",
+		UpdatedAt:    time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var got ToolState
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, original.Ref, got.Ref)
+	assert.Empty(t, got.Version)
 }
 
 func TestToolSpec_UnmarshalJSON_Commands(t *testing.T) {


### PR DESCRIPTION
Adds a new top-level ToolSpec field `ref` that pins installation to a
40-character lowercase hex git commit SHA. Initial scope is
`runtimeRef: go` only — `go install pkg@<sha>` resolves the SHA
through GOPROXY and verifies the resulting module zip against the
GOSUMDB transparency log, giving the integrity story this feature
depends on.

Other installers (aqua, cargo, npm, ...) have no equivalent guarantee
and are rejected at Validate time. The supply-chain rationale is
recorded in code (resource/tool.go validateRef) so future contributors
don't relax the gate without re-deriving the model.

Resource model:
- ToolSpec.Ref + ToolState.Ref carry the SHA. State.Ref is independent
  of State.Version (the alternative — overloading State.Version with
  the SHA — was rejected because it would corrupt ClassifyVersion and
  conflate diagnostic messages).
- ToolItem.Ref propagates into expanded ToolSpec via
  buildToolFromSetItem so ref-pinning works inside ToolSet entries too.
- ToolSpec.Validate() enforces three rules (mutual exclusion with
  version, runtimeRef-go requirement, 40-hex regex) via a dedicated
  validateRef() helper.

Install / reconcile / plan:
- installer.installByRuntime: when spec.Ref is set, the SHA flows
  through command.Vars.Version locally so the existing preset
  template `go install {{.Package}}@{{.Version}}` expands to @<sha>
  without preset changes. spec is not mutated; buildDelegationState
  reads spec.Ref directly to persist state.Ref. SHA-pinned installs
  emit slog.Info with the ref attribute for audit.
- reconciler.ToolComparator: Ref check runs before the version /
  taint / binaryName / privileged checks. Ref → Ref rotation,
  Ref → version, and version → Ref transitions all surface as a
  single "ref changed: ..." reason.
- cmd/tomei/plan.go: buildResourceInfo Tool switch mirrors the
  reconciler's branch order with a cross-reference comment in both
  files. Plan tree truncates SHAs to "ref: <12chars>…" for display;
  state retains the full SHA.

Schema (CUE):
- #Tool.spec.ref?: string & =~"^[0-9a-f]{40}$" with a CUE constraint
  `if ref != _|_ { spec.runtimeRef: "go" }` so the wrong installer
  is rejected before Go-side Validate runs.
- #ToolSet.spec.tools[*].ref? mirrors the same regex.

Tests (unit only):
- internal/resource: 7 Validate cases (positive + 6 rejection
  patterns), 2 ToolState JSON round-trip cases (legacy without ref,
  ref set with empty version), 1 ToolSet expand regression
  (TestToolSet_Expand_CopiesRef), and 1 ordering-pin case
  (privileged + ref + runtimeRef hits the privileged error first).
- internal/installer/tool: TestToolInstaller_RuntimeRef_SubstitutesIntoVersion
  pins D2's install-time invariant — captured shell command must
  contain @<sha>, state.Ref carries the SHA, state.Version stays
  empty, spec is not mutated.
- internal/installer/reconciler: 4 Ref cases (noop, rotation,
  deselected, newly set) + 2 ordering subtests (Ref wins over
  Version, Ref wins over taint).
- internal/graph: shortRef truncation + formatNode ref-rendering
  assertion (full SHA must not appear in output).

E2E deferred to a follow-up: picking a stable SHA available on the
Go module proxy needs network verification that's brittle to
hardcode. Unit + install-layer coverage already exercises the full
shell-template path; e2e adds end-to-end signal without changing
the implementation surface.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
