### PR TITLE
docs: document Tool.spec.ref for SHA-pinned go install

### DIFF
--- a/docs/cue-schema.md
+++ b/docs/cue-schema.md
@@ -152,6 +152,33 @@ spec: {
 }
 ```
 
+##### Pinning to a git commit SHA (`ref`)
+
+For `runtimeRef: "go"` tools, you can pin to a specific commit instead of
+a tag/version. `go install pkg@<sha>` resolves the SHA through GOPROXY and
+verifies the resulting module zip against the GOSUMDB transparency log,
+so the install is reproducible and integrity-checked.
+
+```cue
+apiVersion: "tomei.terassyi.net/v1beta1"
+kind:       "Tool"
+metadata: name: "gopls"
+spec: {
+    runtimeRef: "go"
+    package:    "golang.org/x/tools/gopls"
+    ref:        "0123456789abcdef0123456789abcdef01234567"
+}
+```
+
+- `ref` must be a 40-character lowercase hex SHA-1. Short SHAs and
+  tag-like strings are rejected at validate time.
+- `ref` and `version` are mutually exclusive.
+- `ref` is currently supported only with `runtimeRef: "go"`. Other
+  installers (aqua, cargo, npm, ...) have no equivalent SHA-pin path
+  with comparable integrity guarantees and reject `ref` at validate time.
+- The plan tree renders `ref` as a 12-character prefix + ellipsis (e.g.
+  `(ref: 0123456789ab…)`); state retains the full SHA.
+
 #### Via self-managed commands
 
 ```cue
@@ -177,7 +204,8 @@ spec: {
 | `spec.runtimeRef` | string | no* | Reference to a Runtime (e.g., `"go"`, `"rust"`) |
 | `spec.commands` | [ToolCommandSet](#toolcommandset) | no* | Shell commands for self-managed tool installation |
 | `spec.repositoryRef` | string | no | Reference to an InstallerRepository |
-| `spec.version` | string | no | Tool version |
+| `spec.version` | string | no | Tool version (mutually exclusive with `ref`) |
+| `spec.ref` | string | no | 40-char lowercase hex git commit SHA for SHA-pinned install. Only allowed with `runtimeRef: "go"`. Mutually exclusive with `version`. |
 | `spec.enabled` | bool | no | Default `true`. Set `false` to skip |
 | `spec.source` | [DownloadSource](#downloadsource) | no | Explicit download source |
 | `spec.package` | [Package](#package) | no | Package identifier for registry or delegation |
@@ -209,7 +237,7 @@ spec: {
 | `spec.installerRef` | string | no | Shared installer for all tools |
 | `spec.runtimeRef` | string | no | Shared runtime for all tools |
 | `spec.repositoryRef` | string | no | Shared repository reference |
-| `spec.tools` | map | yes | Tool definitions (same fields as Tool.spec minus installerRef/runtimeRef). Each tool supports `version`, `enabled`, `source`, `package`, `binaryName`, `args` |
+| `spec.tools` | map | yes | Tool definitions (same fields as Tool.spec minus installerRef/runtimeRef). Each tool supports `version`, `ref`, `enabled`, `source`, `package`, `binaryName`, `args` |
 
 ### Installer
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -21,10 +21,18 @@ Delegates the actual work to an external command.
 
 ```
 go install <package>@<version>
+go install <package>@<sha>        # via spec.ref (Go only)
 cargo install <package>
 ```
 
 `tomei` instructs *what* to install; the external tool handles *how*.
+
+For `runtimeRef: "go"` tools, `spec.ref` pins the install to a specific
+git commit SHA instead of a tag. The SHA flows through `GOPROXY` and is
+verified against the `GOSUMDB` transparency log — this is why ref pinning
+is currently limited to Go; other ecosystems lack equivalent end-to-end
+integrity for arbitrary commits. See [usage.md](usage.md) for the user-
+facing guide and [cue-schema.md](cue-schema.md) for the field definition.
 
 ### Download pattern
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -241,6 +241,39 @@ tomei apply --update-all .
 tomei apply --parallel 4 .
 ```
 
+### Pinning a Tool to a git commit SHA
+
+For tools installed via `runtimeRef: "go"`, set `spec.ref` to a 40-character
+lowercase hex commit SHA to pin the install to an exact commit instead of
+a tag. `go install pkg@<sha>` resolves the SHA through `GOPROXY` and
+verifies the module zip against `GOSUMDB`, so the install is reproducible
+and integrity-checked.
+
+```cue
+gopls: {
+    apiVersion: "tomei.terassyi.net/v1beta1"
+    kind:       "Tool"
+    metadata: name: "gopls"
+    spec: {
+        runtimeRef: "go"
+        package:    "golang.org/x/tools/gopls"
+        ref:        "0123456789abcdef0123456789abcdef01234567"
+    }
+}
+```
+
+Constraints:
+
+- `ref` and `version` are mutually exclusive.
+- `ref` requires `runtimeRef: "go"`; other installers reject `ref` at
+  validate time.
+- Short SHAs and tag-like strings (e.g. `v1.2.3`) are rejected — only
+  40-char lowercase hex matches.
+- Ref-pinned tools are NOT tainted by `--sync` / `--update-tools` (a SHA
+  is the strictest form of exact pin).
+- `tomei plan` displays the SHA truncated to 12 characters; state retains
+  the full SHA.
+
 ### Self-Managed Tools (Commands Pattern)
 
 Tools with `spec.commands` manage their own installation via shell commands, without needing a runtime or installer dependency.


### PR DESCRIPTION
## Summary
- Document the new `Tool.spec.ref` field (added in #248) across the three relevant docs.
- `cue-schema.md`: new subsection under Tool/Via runtime delegation with example, constraints, and display behavior; `ref` row added to the Tool fields table; ToolSet field description updated.
- `usage.md`: new "Pinning a Tool to a git commit SHA" section between Update Modes and Self-Managed Tools, summarizing constraints (mutual exclusion, runtimeRef:go only, regex, sync-immunity, tree truncation).
- `design.md`: Delegation-pattern intro covers the SHA case + one-paragraph note on why ref is currently Go-only (GOPROXY + GOSUMDB).
- README left untouched intentionally — it's an intro and would bloat with feature parity.

## Test plan
- [ ] Visually inspect the rendered markdown on GitHub
- [ ] Confirm field table matches `cuemodule/schema/schema.cue` (`ref?: string & =~"^[0-9a-f]{40}$"`)
- [ ] Confirm constraints match `internal/resource/tool.go` `validateRef()` and the engine sync-immunity behavior from `buildDelegationState` (VersionExact for ref-pinned tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)