### PR TITLE
refactor(resource): rename Tool.spec.ref to Tool.spec.sha

### DIFF
--- a/cmd/tomei/plan.go
+++ b/cmd/tomei/plan.go
@@ -203,7 +203,7 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 		case resource.KindTool:
 			if tool, ok := res.(*resource.Tool); ok && tool.ToolSpec != nil {
 				resInfo.Version = tool.ToolSpec.Version
-				resInfo.Ref = tool.ToolSpec.Ref
+				resInfo.SHA = tool.ToolSpec.SHA
 			}
 		}
 
@@ -241,7 +241,7 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 					// `tomei plan` and the engine disagree on the reason
 					// surfaced when multiple signals fire at once.
 					switch {
-					case tool.Ref != resInfo.Ref:
+					case tool.SHA != resInfo.SHA:
 						resInfo.Action = resource.ActionUpgrade
 					case tool.IsTainted():
 						resInfo.Action = resource.ActionReinstall
@@ -338,7 +338,7 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 					Kind:       resource.KindTool,
 					Name:       name,
 					Version:    tool.Version,
-					Ref:        tool.Ref,
+					SHA:        tool.SHA,
 					Action:     action,
 					Privileged: tool.Privileged,
 				}
@@ -567,7 +567,7 @@ func addDisabledResourceInfo(info map[graph.NodeID]graph.ResourceInfo, disabled 
 		}
 		if tool, ok := res.(*resource.Tool); ok && tool.ToolSpec != nil {
 			ri.Version = tool.ToolSpec.Version
-			ri.Ref = tool.ToolSpec.Ref
+			ri.SHA = tool.ToolSpec.SHA
 		}
 		info[nodeID] = ri
 	}

--- a/cuemodule/schema/schema.cue
+++ b/cuemodule/schema/schema.cue
@@ -209,13 +209,16 @@ package schema
 			privileged?: bool
 		}}
 
-		// If any tool item sets sha, the ToolSet's runtimeRef must be "go" —
-		// matches the #Tool.spec constraint so misuse inside a ToolSet is
-		// rejected at the CUE layer instead of falling through to Go-side
-		// Validate with a less specific message.
+		// If any tool item sets sha, the ToolSet's runtimeRef must be "go"
+		// and installerRef must be empty — matches the #Tool.spec constraint
+		// so misuse inside a ToolSet is rejected at the CUE layer instead
+		// of falling through to Go-side Validate with a less specific
+		// message. (#ToolSet has no spec-level commands field, so the
+		// `commands?: null` arm of the #Tool.spec gate has no analog here.)
 		for _, tool in tools {
 			if tool.sha != _|_ {
-				runtimeRef: "go"
+				runtimeRef:    "go"
+				installerRef?: =~"^$"
 			}
 		}
 	}

--- a/cuemodule/schema/schema.cue
+++ b/cuemodule/schema/schema.cue
@@ -166,9 +166,10 @@ package schema
 		version?:       string
 		// sha pins installation to a 40-char lowercase hex git commit SHA-1.
 		// Only supported with runtimeRef: "go" today (the Go module proxy
-		// verifies the SHA against the GOSUMDB transparency log). The
-		// schema enforces the runtimeRef gate below; Validate enforces
-		// the format and the sha/version mutual exclusion.
+		// verifies the SHA against the GOSUMDB transparency log). Format
+		// is enforced by the regex on this field; the schema also enforces
+		// the runtimeRef gate below; Go-side Validate enforces the
+		// sha/version mutual exclusion.
 		sha?:        string & =~"^[0-9a-f]{40}$"
 		enabled?:    bool
 		source?:     #DownloadSource

--- a/cuemodule/schema/schema.cue
+++ b/cuemodule/schema/schema.cue
@@ -164,12 +164,12 @@ package schema
 		runtimeRef?:    string
 		repositoryRef?: string
 		version?:       string
-		// ref pins installation to a 40-char lowercase hex git SHA.
+		// sha pins installation to a 40-char lowercase hex git commit SHA-1.
 		// Only supported with runtimeRef: "go" today (the Go module proxy
 		// verifies the SHA against the GOSUMDB transparency log). The
 		// schema enforces the runtimeRef gate below; Validate enforces
-		// the format and the ref/version mutual exclusion.
-		ref?:        string & =~"^[0-9a-f]{40}$"
+		// the format and the sha/version mutual exclusion.
+		sha?:        string & =~"^[0-9a-f]{40}$"
 		enabled?:    bool
 		source?:     #DownloadSource
 		package?:    #Package
@@ -178,14 +178,14 @@ package schema
 		args?: [...string]
 		privileged?: bool
 
-		// ref requires runtimeRef: "go" and forbids installerRef / commands.
+		// sha requires runtimeRef: "go" and forbids installerRef / commands.
 		// Encoded as CUE constraints so the schema rejects misuse with a
 		// precise field-level error before Go-side Validate runs (otherwise
 		// downstream mutual-exclusion errors would be confusing).
-		if ref != _|_ {
+		if sha != _|_ {
 			runtimeRef:    "go"
-			installerRef?: =~"^$" // forbid: ref + installerRef is invalid
-			commands?:     null   // forbid: ref + commands is invalid
+			installerRef?: =~"^$" // forbid: sha + installerRef is invalid
+			commands?:     null   // forbid: sha + commands is invalid
 		}
 	}
 }
@@ -200,7 +200,7 @@ package schema
 		repositoryRef?: string
 		tools: {[string]: {
 			version?:    string
-			ref?:        string & =~"^[0-9a-f]{40}$"
+			sha?:        string & =~"^[0-9a-f]{40}$"
 			enabled?:    bool
 			source?:     #DownloadSource
 			package?:    #Package
@@ -208,6 +208,16 @@ package schema
 			args?: [...string]
 			privileged?: bool
 		}}
+
+		// If any tool item sets sha, the ToolSet's runtimeRef must be "go" —
+		// matches the #Tool.spec constraint so misuse inside a ToolSet is
+		// rejected at the CUE layer instead of falling through to Go-side
+		// Validate with a less specific message.
+		for _, tool in tools {
+			if tool.sha != _|_ {
+				runtimeRef: "go"
+			}
+		}
 	}
 }
 

--- a/cuemodule/schema_test.go
+++ b/cuemodule/schema_test.go
@@ -1064,6 +1064,28 @@ func TestSchema_InvalidResources(t *testing.T) {
 				}
 			}`,
 		},
+		{
+			// ToolSet sha-in-tool-item + installerRef set must fail at the
+			// CUE layer — mirrors #Tool.spec's installerRef forbiddance so
+			// a ToolSet with sha-pinned tools cannot also delegate to an
+			// installer.
+			name: "ToolSet with sha in tool item and installerRef rejected",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "ToolSet"
+				metadata: name: "mixed-tools"
+				spec: {
+					runtimeRef:  "go"
+					installerRef: "aqua"
+					tools: {
+						gopls: {
+							package: "golang.org/x/tools/gopls"
+							sha:     "0123456789abcdef0123456789abcdef01234567"
+						}
+					}
+				}
+			}`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/cuemodule/schema_test.go
+++ b/cuemodule/schema_test.go
@@ -300,6 +300,28 @@ func TestSchema_ValidResources(t *testing.T) {
 			}`,
 		},
 		{
+			// Locks the #ToolSet.spec for-comprehension that forces
+			// runtimeRef: "go" when any tool item carries sha. The valid
+			// case here passes runtimeRef: "go" explicitly so unification
+			// is a no-op; the InvalidResources counterpart sets a
+			// different runtimeRef and expects rejection.
+			name: "ToolSet with sha in tool item",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "ToolSet"
+				metadata: name: "go-tools"
+				spec: {
+					runtimeRef: "go"
+					tools: {
+						gopls: {
+							package: "golang.org/x/tools/gopls"
+							sha:     "0123456789abcdef0123456789abcdef01234567"
+						}
+					}
+				}
+			}`,
+		},
+		{
 			name: "SystemPackageSet",
 			cue: `{
 				apiVersion: "tomei.terassyi.net/v1beta1"
@@ -988,9 +1010,57 @@ func TestSchema_InvalidResources(t *testing.T) {
 				kind:       "SystemPackage"
 				metadata: name: "git"
 				spec: {
-					installerRef:  "apt"
+					installerRef: "apt"
 					repositoryRef: ""
 					package:       "git"
+				}
+			}`,
+		},
+		{
+			// Tool with sha set + installerRef ≠ "" must fail at the CUE
+			// layer (installerRef?: =~"^$" forbids any non-empty installer).
+			name: "Tool with sha and installerRef rejected",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "Tool"
+				metadata: name: "gopls"
+				spec: {
+					installerRef: "aqua"
+					sha:          "0123456789abcdef0123456789abcdef01234567"
+					package: {owner: "x", repo: "y"}
+				}
+			}`,
+		},
+		{
+			// Tool with sha set + commands defined must fail at the CUE
+			// layer (commands?: null forbids any non-null commands).
+			name: "Tool with sha and commands rejected",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "Tool"
+				metadata: name: "gopls"
+				spec: {
+					sha: "0123456789abcdef0123456789abcdef01234567"
+					commands: install: ["true"]
+				}
+			}`,
+		},
+		{
+			// ToolSet sha-in-tool-item + runtimeRef ≠ "go" must fail at
+			// the CUE layer via the for-comprehension constraint.
+			name: "ToolSet with sha in tool item but runtimeRef cargo rejected",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "ToolSet"
+				metadata: name: "mixed-tools"
+				spec: {
+					runtimeRef: "cargo"
+					tools: {
+						gopls: {
+							package: "golang.org/x/tools/gopls"
+							sha:     "0123456789abcdef0123456789abcdef01234567"
+						}
+					}
 				}
 			}`,
 		},

--- a/docs/cue-schema.md
+++ b/docs/cue-schema.md
@@ -152,7 +152,7 @@ spec: {
 }
 ```
 
-##### Pinning to a git commit SHA (`ref`)
+##### Pinning to a git commit SHA (`sha`)
 
 For `runtimeRef: "go"` tools, you can pin to a specific commit instead of
 a tag/version. `go install pkg@<sha>` resolves the SHA through GOPROXY and
@@ -166,18 +166,18 @@ metadata: name: "gopls"
 spec: {
     runtimeRef: "go"
     package:    "golang.org/x/tools/gopls"
-    ref:        "0123456789abcdef0123456789abcdef01234567"
+    sha:        "0123456789abcdef0123456789abcdef01234567"
 }
 ```
 
-- `ref` must be a 40-character lowercase hex SHA-1. Short SHAs and
+- `sha` must be a 40-character lowercase hex SHA-1. Short SHAs and
   tag-like strings are rejected at validate time.
-- `ref` and `version` are mutually exclusive.
-- `ref` is currently supported only with `runtimeRef: "go"`. Other
+- `sha` and `version` are mutually exclusive.
+- `sha` is currently supported only with `runtimeRef: "go"`. Other
   installers (aqua, cargo, npm, ...) have no equivalent SHA-pin path
-  with comparable integrity guarantees and reject `ref` at validate time.
-- The plan tree renders `ref` as a 12-character prefix + ellipsis (e.g.
-  `(ref: 0123456789ab…)`); state retains the full SHA.
+  with comparable integrity guarantees and reject `sha` at validate time.
+- The plan tree renders `sha` as a 12-character prefix + ellipsis (e.g.
+  `(sha: 0123456789ab…)`); state retains the full SHA.
 
 #### Via self-managed commands
 
@@ -204,8 +204,8 @@ spec: {
 | `spec.runtimeRef` | string | no* | Reference to a Runtime (e.g., `"go"`, `"rust"`) |
 | `spec.commands` | [ToolCommandSet](#toolcommandset) | no* | Shell commands for self-managed tool installation |
 | `spec.repositoryRef` | string | no | Reference to an InstallerRepository |
-| `spec.version` | string | no | Tool version (mutually exclusive with `ref`) |
-| `spec.ref` | string | no | 40-char lowercase hex git commit SHA for SHA-pinned install. Only allowed with `runtimeRef: "go"`. Mutually exclusive with `version`. |
+| `spec.version` | string | no | Tool version (mutually exclusive with `sha`) |
+| `spec.sha` | string | no | 40-char lowercase hex git commit SHA for SHA-pinned install. Only allowed with `runtimeRef: "go"`. Mutually exclusive with `version`. |
 | `spec.enabled` | bool | no | Default `true`. Set `false` to skip |
 | `spec.source` | [DownloadSource](#downloadsource) | no | Explicit download source |
 | `spec.package` | [Package](#package) | no | Package identifier for registry or delegation |
@@ -237,7 +237,7 @@ spec: {
 | `spec.installerRef` | string | no | Shared installer for all tools |
 | `spec.runtimeRef` | string | no | Shared runtime for all tools |
 | `spec.repositoryRef` | string | no | Shared repository reference |
-| `spec.tools` | map | yes | Tool definitions (same fields as Tool.spec minus installerRef/runtimeRef). Each tool supports `version`, `ref`, `enabled`, `source`, `package`, `binaryName`, `args` |
+| `spec.tools` | map | yes | Tool definitions (same fields as Tool.spec minus installerRef/runtimeRef). Each tool supports `version`, `sha`, `enabled`, `source`, `package`, `binaryName`, `args` |
 
 ### Installer
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -21,15 +21,15 @@ Delegates the actual work to an external command.
 
 ```
 go install <package>@<version>
-go install <package>@<sha>        # via spec.ref (Go only)
+go install <package>@<sha>        # via spec.sha (Go only)
 cargo install <package>
 ```
 
 `tomei` instructs *what* to install; the external tool handles *how*.
 
-For `runtimeRef: "go"` tools, `spec.ref` pins the install to a specific
+For `runtimeRef: "go"` tools, `spec.sha` pins the install to a specific
 git commit SHA instead of a tag. The SHA flows through `GOPROXY` and is
-verified against the `GOSUMDB` transparency log — this is why ref pinning
+verified against the `GOSUMDB` transparency log — this is why SHA pinning
 is currently limited to Go; other ecosystems lack equivalent end-to-end
 integrity for arbitrary commits. See [usage.md](usage.md) for the user-
 facing guide and [cue-schema.md](cue-schema.md) for the field definition.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -243,7 +243,7 @@ tomei apply --parallel 4 .
 
 ### Pinning a Tool to a git commit SHA
 
-For tools installed via `runtimeRef: "go"`, set `spec.ref` to a 40-character
+For tools installed via `runtimeRef: "go"`, set `spec.sha` to a 40-character
 lowercase hex commit SHA to pin the install to an exact commit instead of
 a tag. `go install pkg@<sha>` resolves the SHA through `GOPROXY` and
 verifies the module zip against `GOSUMDB`, so the install is reproducible
@@ -257,19 +257,19 @@ gopls: {
     spec: {
         runtimeRef: "go"
         package:    "golang.org/x/tools/gopls"
-        ref:        "0123456789abcdef0123456789abcdef01234567"
+        sha:        "0123456789abcdef0123456789abcdef01234567"
     }
 }
 ```
 
 Constraints:
 
-- `ref` and `version` are mutually exclusive.
-- `ref` requires `runtimeRef: "go"`; other installers reject `ref` at
+- `sha` and `version` are mutually exclusive.
+- `sha` requires `runtimeRef: "go"`; other installers reject `sha` at
   validate time.
 - Short SHAs and tag-like strings (e.g. `v1.2.3`) are rejected — only
   40-char lowercase hex matches.
-- Ref-pinned tools are NOT tainted by `--sync` / `--update-tools` (a SHA
+- SHA-pinned tools are NOT tainted by `--sync` / `--update-tools` (a SHA
   is the strictest form of exact pin).
 - `tomei plan` displays the SHA truncated to 12 characters; state retains
   the full SHA.

--- a/internal/graph/export.go
+++ b/internal/graph/export.go
@@ -22,10 +22,10 @@ type PlanOutput struct {
 type PlanResource struct {
 	Kind resource.Kind `json:"kind" yaml:"kind"`
 	Name string        `json:"name" yaml:"name"`
-	// Version and Ref are mutually exclusive: Ref carries the git commit
-	// SHA for SHA-pinned tools; Version carries the tag/release otherwise.
+	// Version and SHA are mutually exclusive: SHA carries the git commit
+	// for SHA-pinned tools; Version carries the tag/release otherwise.
 	Version      string              `json:"version,omitempty" yaml:"version,omitempty"`
-	Ref          string              `json:"ref,omitempty" yaml:"ref,omitempty"`
+	SHA          string              `json:"sha,omitempty" yaml:"sha,omitempty"`
 	Action       resource.ActionType `json:"action" yaml:"action"`
 	Layer        int                 `json:"layer" yaml:"layer"`
 	Dependencies []string            `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
@@ -93,7 +93,7 @@ func (e *Exporter) BuildOutput() PlanOutput {
 				Kind:         node.Kind,
 				Name:         node.Name,
 				Version:      info.Version,
-				Ref:          info.Ref,
+				SHA:          info.SHA,
 				Action:       info.Action,
 				Layer:        i + 1,
 				Dependencies: deps[nodeID],
@@ -118,7 +118,7 @@ func (e *Exporter) BuildOutput() PlanOutput {
 				Kind:    info.Kind,
 				Name:    info.Name,
 				Version: info.Version,
-				Ref:     info.Ref,
+				SHA:     info.SHA,
 				Action:  resource.ActionSkip,
 				Layer:   0,
 			})

--- a/internal/graph/tree.go
+++ b/internal/graph/tree.go
@@ -16,10 +16,10 @@ type ResourceInfo struct {
 	Kind    resource.Kind
 	Name    string
 	Version string
-	// Ref holds the git commit SHA for SHA-pinned tools. Mutually exclusive
+	// SHA holds the git commit SHA for SHA-pinned tools. Mutually exclusive
 	// with Version (Validate enforces this on the spec side). Stored in full
 	// here; the tree renderer truncates for display.
-	Ref        string
+	SHA        string
 	Action     resource.ActionType
 	Privileged bool
 }
@@ -153,14 +153,14 @@ func (p *TreePrinter) printNode(nodeID NodeID, prefix string, isLast bool, child
 	}
 }
 
-// shortRef truncates a 40-char SHA to a 12-char prefix + ellipsis for display.
+// shortSHA truncates a 40-char SHA to a 12-char prefix + ellipsis for display.
 // State retains the full SHA — only the rendered tree is shortened.
-func shortRef(ref string) string {
+func shortSHA(sha string) string {
 	const display = 12
-	if len(ref) <= display {
-		return ref
+	if len(sha) <= display {
+		return sha
 	}
-	return ref[:display] + "…"
+	return sha[:display] + "…"
 }
 
 func (p *TreePrinter) formatNode(nodeID NodeID, info ResourceInfo, hasInfo bool) string {
@@ -170,12 +170,12 @@ func (p *TreePrinter) formatNode(nodeID NodeID, info ResourceInfo, hasInfo bool)
 	nodeName := string(nodeID)
 
 	if hasInfo {
-		// Version / Ref (mutually exclusive — Ref wins when both are set,
+		// Version / SHA (mutually exclusive — SHA wins when both are set,
 		// though Validate prevents that on the spec side).
 		versionStr := ""
 		switch {
-		case info.Ref != "":
-			versionStr = fmt.Sprintf(" (ref: %s)", shortRef(info.Ref))
+		case info.SHA != "":
+			versionStr = fmt.Sprintf(" (sha: %s)", shortSHA(info.SHA))
 		case info.Version != "":
 			versionStr = fmt.Sprintf(" (%s)", info.Version)
 		}

--- a/internal/graph/tree_test.go
+++ b/internal/graph/tree_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/terassyi/tomei/internal/resource"
 )
 
-func TestShortRef(t *testing.T) {
+func TestShortSHA(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name string
@@ -22,15 +22,15 @@ func TestShortRef(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.want, shortRef(tt.in))
+			assert.Equal(t, tt.want, shortSHA(tt.in))
 		})
 	}
 }
 
-// TestFormatNode_RefRendering pins the tree's ref display: Ref-pinned tools
-// render as " (ref: <12chars>…)" instead of the usual " (version)" slot,
+// TestFormatNode_SHARendering pins the tree's sha display: SHA-pinned tools
+// render as " (sha: <12chars>…)" instead of the usual " (version)" slot,
 // preserving the full SHA only in state (not in the rendered tree).
-func TestFormatNode_RefRendering(t *testing.T) {
+func TestFormatNode_SHARendering(t *testing.T) {
 	t.Parallel()
 	p := NewTreePrinter(&bytes.Buffer{}, true)
 	const sha = "0123456789abcdef0123456789abcdef01234567"
@@ -38,11 +38,11 @@ func TestFormatNode_RefRendering(t *testing.T) {
 	info := ResourceInfo{
 		Kind:   resource.KindTool,
 		Name:   "gopls",
-		Ref:    sha,
+		SHA:    sha,
 		Action: resource.ActionInstall,
 	}
 	out := p.formatNode(NewNodeID(resource.KindTool, "gopls"), info, true)
-	assert.Contains(t, out, "(ref: 0123456789ab…)", "ref must render truncated, not as full SHA")
+	assert.Contains(t, out, "(sha: 0123456789ab…)", "sha must render truncated, not as full SHA")
 	assert.NotContains(t, out, sha, "full SHA must not appear in rendered tree")
 }
 

--- a/internal/installer/reconciler/reconciler_test.go
+++ b/internal/installer/reconciler/reconciler_test.go
@@ -647,46 +647,55 @@ func TestToolComparator_PrivilegedChanged(t *testing.T) {
 	}
 }
 
-// --- ToolComparator ref (SHA pin) tests ---
+// --- ToolComparator sha (SHA pin) tests ---
 
-func TestToolComparator_RefChanged(t *testing.T) {
+// Fixed SHA pair shared by all SHA-comparator tests. Defined once so future
+// cases reuse the same "old vs new" identities.
+const (
+	oldSHA = "0123456789abcdef0123456789abcdef01234567"
+	newSHA = "fedcba9876543210fedcba9876543210fedcba98"
+)
+
+func TestToolComparator_SHAChanged(t *testing.T) {
 	t.Parallel()
-	const oldSHA = "0123456789abcdef0123456789abcdef01234567"
-	const newSHA = "fedcba9876543210fedcba9876543210fedcba98"
 
 	tests := []struct {
 		name       string
-		specRef    string
-		stateRef   string
+		specSHA    string
+		stateSHA   string
 		wantUpdate bool
 		wantReason string
 	}{
 		{
-			name:       "ref unchanged - no update",
-			specRef:    oldSHA,
-			stateRef:   oldSHA,
+			name:       "sha unchanged - no update",
+			specSHA:    oldSHA,
+			stateSHA:   oldSHA,
 			wantUpdate: false,
 		},
 		{
-			name:       "ref rotated to new SHA",
-			specRef:    newSHA,
-			stateRef:   oldSHA,
+			name:       "sha rotated to new value",
+			specSHA:    newSHA,
+			stateSHA:   oldSHA,
 			wantUpdate: true,
-			wantReason: "ref changed: " + oldSHA + " -> " + newSHA,
+			wantReason: "sha changed: " + oldSHA + " -> " + newSHA,
 		},
 		{
-			name:       "ref deselected (version takes over)",
-			specRef:    "",
-			stateRef:   oldSHA,
+			// state was sha-pinned, spec clears it — comparator must still
+			// surface "sha changed:" so the caller knows the pin is gone
+			// (whether or not a version replaces it). The trailing space
+			// after "-> " is intentional: spec.SHA is empty.
+			name:       "sha cleared (was sha-pinned, spec empty)",
+			specSHA:    "",
+			stateSHA:   oldSHA,
 			wantUpdate: true,
-			wantReason: "ref changed: " + oldSHA + " -> ",
+			wantReason: "sha changed: " + oldSHA + " -> ",
 		},
 		{
-			name:       "ref newly set (was version-pinned)",
-			specRef:    newSHA,
-			stateRef:   "",
+			name:       "sha newly set (was version-pinned)",
+			specSHA:    newSHA,
+			stateSHA:   "",
 			wantUpdate: true,
-			wantReason: "ref changed:  -> " + newSHA,
+			wantReason: "sha changed:  -> " + newSHA,
 		},
 	}
 
@@ -701,14 +710,14 @@ func TestToolComparator_RefChanged(t *testing.T) {
 				},
 				ToolSpec: &resource.ToolSpec{
 					RuntimeRef: "go",
-					Ref:        tt.specRef,
+					SHA:        tt.specSHA,
 					Package:    &resource.Package{Name: "golang.org/x/tools/gopls"},
 				},
 			}
 
 			state := &resource.ToolState{
 				RuntimeRef:  "go",
-				Ref:         tt.stateRef,
+				SHA:         tt.stateSHA,
 				Version:     "",
 				VersionKind: resource.VersionExact,
 				SpecVersion: "",
@@ -723,60 +732,58 @@ func TestToolComparator_RefChanged(t *testing.T) {
 	}
 }
 
-// TestToolComparator_RefOrdering pins the precedence of the new Ref branch
-// against the existing Version and taint branches. The Ref check runs first;
-// when ref differs the reason must be "ref changed:" even if version or taint
+// TestToolComparator_SHAOrdering pins the precedence of the new SHA branch
+// against the existing Version and taint branches. The SHA check runs first;
+// when sha differs the reason must be "sha changed:" even if version or taint
 // would also fire on their own.
-func TestToolComparator_RefOrdering(t *testing.T) {
+func TestToolComparator_SHAOrdering(t *testing.T) {
 	t.Parallel()
-	const oldSHA = "0123456789abcdef0123456789abcdef01234567"
-	const newSHA = "fedcba9876543210fedcba9876543210fedcba98"
 
-	t.Run("ref change wins over version change", func(t *testing.T) {
+	t.Run("sha change wins over version change", func(t *testing.T) {
 		t.Parallel()
 		comparator := ToolComparator()
 		res := &resource.Tool{
 			BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "gopls"}},
 			ToolSpec: &resource.ToolSpec{
 				RuntimeRef: "go",
-				Ref:        newSHA,
+				SHA:        newSHA,
 				Package:    &resource.Package{Name: "golang.org/x/tools/gopls"},
 			},
 		}
 		state := &resource.ToolState{
 			RuntimeRef:  "go",
-			Ref:         oldSHA,
+			SHA:         oldSHA,
 			Version:     "v0.16.0",
 			VersionKind: resource.VersionExact,
 			SpecVersion: "v0.16.0",
 		}
 		needsUpdate, reason := comparator(res, state)
 		assert.True(t, needsUpdate)
-		assert.True(t, strings.HasPrefix(reason, "ref changed:"),
-			"ref branch must short-circuit version branch (got %q)", reason)
+		assert.True(t, strings.HasPrefix(reason, "sha changed:"),
+			"sha branch must short-circuit version branch (got %q)", reason)
 	})
 
-	t.Run("ref change wins over taint", func(t *testing.T) {
+	t.Run("sha change wins over taint", func(t *testing.T) {
 		t.Parallel()
 		comparator := ToolComparator()
 		res := &resource.Tool{
 			BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "gopls"}},
 			ToolSpec: &resource.ToolSpec{
 				RuntimeRef: "go",
-				Ref:        newSHA,
+				SHA:        newSHA,
 				Package:    &resource.Package{Name: "golang.org/x/tools/gopls"},
 			},
 		}
 		state := &resource.ToolState{
 			RuntimeRef:  "go",
-			Ref:         oldSHA,
+			SHA:         oldSHA,
 			VersionKind: resource.VersionExact,
 			TaintReason: resource.TaintReasonRuntimeUpgraded,
 		}
 		needsUpdate, reason := comparator(res, state)
 		assert.True(t, needsUpdate)
-		assert.True(t, strings.HasPrefix(reason, "ref changed:"),
-			"ref branch must short-circuit taint branch (got %q)", reason)
+		assert.True(t, strings.HasPrefix(reason, "sha changed:"),
+			"sha branch must short-circuit taint branch (got %q)", reason)
 	})
 }
 

--- a/internal/installer/reconciler/tool.go
+++ b/internal/installer/reconciler/tool.go
@@ -30,13 +30,13 @@ func specVersionChanged(specVersion string, stateVersionKind resource.VersionKin
 // surfaced when multiple signals fire at once.
 func ToolComparator() Comparator[*resource.Tool, *resource.ToolState] {
 	return func(res *resource.Tool, state *resource.ToolState) (bool, string) {
-		// Ref pinning (SHA) is checked first. ref→ref rotation, ref→version,
-		// and version→ref switches are all surfaced by simple string equality
-		// against state.Ref. Ordering note: a ref change short-circuits the
+		// SHA pinning is checked first. sha→sha rotation, sha→version,
+		// and version→sha switches are all surfaced by simple string equality
+		// against state.SHA. Ordering note: a sha change short-circuits the
 		// Version/taint branches below — taint will be cleared by the reinstall
 		// regardless.
-		if res.ToolSpec.Ref != state.Ref {
-			return true, "ref changed: " + state.Ref + " -> " + res.ToolSpec.Ref
+		if res.ToolSpec.SHA != state.SHA {
+			return true, "sha changed: " + state.SHA + " -> " + res.ToolSpec.SHA
 		}
 		if specVersionChanged(res.ToolSpec.Version, state.VersionKind, state.Version, state.SpecVersion) {
 			return true, "version changed: " + state.Version + " -> " + res.ToolSpec.Version

--- a/internal/installer/tool/installer.go
+++ b/internal/installer/tool/installer.go
@@ -785,14 +785,14 @@ func (i *Installer) installByRuntime(ctx context.Context, res *resource.Tool, na
 	if spec.BinaryName != "" {
 		binName = spec.BinaryName
 	}
-	// Ref pins this install to a git SHA. The preset template
+	// SHA pins this install to a git commit. The preset template
 	// (e.g. "go install {{.Package}}@{{.Version}}") receives the SHA via
 	// .Version, expanding to `@<sha>` without modifying the preset.
-	// buildDelegationState reads spec.Ref directly to persist it separately,
+	// buildDelegationState reads spec.SHA directly to persist it separately,
 	// so spec is left untouched.
 	versionSlot := spec.Version
-	if spec.Ref != "" {
-		versionSlot = spec.Ref
+	if spec.SHA != "" {
+		versionSlot = spec.SHA
 	}
 	vars := command.Vars{
 		Package: spec.Package.String(),
@@ -827,10 +827,10 @@ func (i *Installer) installByRuntime(ctx context.Context, res *resource.Tool, na
 		return nil, fmt.Errorf("failed to execute install command: %w", err)
 	}
 
-	if spec.Ref != "" {
+	if spec.SHA != "" {
 		// SHA-pinned installs are security-relevant: surface the SHA at Info so
 		// audit logs record exactly which commit was resolved.
-		slog.Info("tool installed via runtime (ref-pinned)", "name", name, "ref", spec.Ref, "runtime", spec.RuntimeRef)
+		slog.Info("tool installed via runtime (sha-pinned)", "name", name, "sha", spec.SHA, "runtime", spec.RuntimeRef)
 	} else {
 		slog.Debug("tool installed via runtime", "name", name, "version", spec.Version, "runtime", spec.RuntimeRef)
 	}
@@ -888,19 +888,19 @@ func (i *Installer) installByInstaller(ctx context.Context, res *resource.Tool, 
 
 // buildDelegationState creates a ToolState for delegation pattern installations.
 func (i *Installer) buildDelegationState(spec *resource.ToolSpec, binPath string) *resource.ToolState {
-	// Ref-pinned tools must classify as VersionExact, not VersionLatest.
-	// spec.Version is empty for ref pins, so ClassifyVersion would otherwise
+	// SHA-pinned tools must classify as VersionExact, not VersionLatest.
+	// spec.Version is empty for sha pins, so ClassifyVersion would otherwise
 	// return VersionLatest and tomei's --sync / --update-tools modes would
 	// taint the tool (engine.applyUpdateTaints predicates on VersionLatest).
 	// A SHA pin is the strictest form of "exact" — don't surprise-reinstall.
 	versionKind := resource.ClassifyVersion(spec.Version)
-	if spec.Ref != "" {
+	if spec.SHA != "" {
 		versionKind = resource.VersionExact
 	}
 	return &resource.ToolState{
 		InstallerRef: spec.InstallerRef,
 		Version:      spec.Version,
-		Ref:          spec.Ref,
+		SHA:          spec.SHA,
 		VersionKind:  versionKind,
 		SpecVersion:  spec.Version,
 		BinPath:      binPath,

--- a/internal/installer/tool/installer_test.go
+++ b/internal/installer/tool/installer_test.go
@@ -847,11 +847,11 @@ func TestToolInstaller_Install_Args(t *testing.T) {
 	}
 }
 
-// TestToolInstaller_RuntimeRef_SubstitutesIntoVersion locks D2's invariant:
-// when ToolSpec.Ref is set, the SHA is substituted into the {{.Version}}
-// template slot so the preset's "go install pkg@{{.Version}}" expands to
-// "@<sha>". The persisted ToolState stores spec.Ref in state.Ref while
-// state.Version remains empty (the exclusivity invariant from Validate).
+// TestToolInstaller_RuntimeRef_SubstitutesIntoVersion locks the install-time
+// invariant: when ToolSpec.SHA is set, the SHA is substituted into the
+// {{.Version}} template slot so the preset's "go install pkg@{{.Version}}"
+// expands to "@<sha>". The persisted ToolState stores spec.SHA in state.SHA
+// while state.Version remains empty (the exclusivity invariant from Validate).
 func TestToolInstaller_RuntimeRef_SubstitutesIntoVersion(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
@@ -878,7 +878,7 @@ func TestToolInstaller_RuntimeRef_SubstitutesIntoVersion(t *testing.T) {
 		},
 		ToolSpec: &resource.ToolSpec{
 			RuntimeRef: "go",
-			Ref:        sha,
+			SHA:        sha,
 			Package:    &resource.Package{Name: "golang.org/x/tools/gopls"},
 		},
 	}
@@ -890,20 +890,20 @@ func TestToolInstaller_RuntimeRef_SubstitutesIntoVersion(t *testing.T) {
 	content, err := os.ReadFile(captureFile)
 	require.NoError(t, err)
 	assert.Equal(t, "golang.org/x/tools/gopls@"+sha, strings.TrimSpace(string(content)),
-		"Ref must flow into {{.Version}} so go-install templates expand to @<sha>")
+		"SHA must flow into {{.Version}} so go-install templates expand to @<sha>")
 
-	assert.Equal(t, sha, state.Ref, "state.Ref records the pinned SHA")
-	assert.Empty(t, state.Version, "state.Version stays empty when ref is set (exclusivity invariant)")
-	// Regression (Copilot R1): ref-pinned tools must classify as VersionExact,
+	assert.Equal(t, sha, state.SHA, "state.SHA records the pinned SHA")
+	assert.Empty(t, state.Version, "state.Version stays empty when sha is set (exclusivity invariant)")
+	// Regression (Copilot R1): sha-pinned tools must classify as VersionExact,
 	// NOT VersionLatest. ClassifyVersion("") would return VersionLatest by
 	// default and tomei's --sync / --update-tools modes (engine.applyUpdateTaints)
 	// would then taint the tool, causing surprise reinstalls of a SHA pin.
 	assert.Equal(t, resource.VersionExact, state.VersionKind,
-		"ref-pinned tools must classify as VersionExact so --sync/--update-tools don't taint them")
+		"sha-pinned tools must classify as VersionExact so --sync/--update-tools don't taint them")
 
 	// spec must not be mutated — buildDelegationState reads it after install.
 	assert.Empty(t, tool.ToolSpec.Version, "spec.Version untouched after install")
-	assert.Equal(t, sha, tool.ToolSpec.Ref, "spec.Ref untouched after install")
+	assert.Equal(t, sha, tool.ToolSpec.SHA, "spec.SHA untouched after install")
 }
 
 func TestToolInstaller_ProgressCallback_Priority(t *testing.T) {

--- a/internal/resource/tool.go
+++ b/internal/resource/tool.go
@@ -10,10 +10,10 @@ import (
 	"github.com/terassyi/tomei/internal/installer/extract"
 )
 
-// refSHAPattern matches a 40-character lowercase hex SHA-1, the form
+// shaPattern matches a 40-character lowercase hex SHA-1, the form
 // `go install` resolves through GOPROXY+GOSUMDB. Short SHAs are rejected to
 // avoid proxy-side prefix-resolution ambiguity and downstream collision risk.
-var refSHAPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
+var shaPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
 
 // DownloadSource holds download configuration for tools and runtimes
 // that are installed via the download pattern (e.g., aqua installer).
@@ -241,13 +241,13 @@ type ToolSpec struct {
 	// Optional for commands pattern (can be resolved via commands.resolveVersion).
 	Version string `json:"version,omitempty"`
 
-	// Ref pins installation to a specific git commit SHA instead of a tag/version.
+	// SHA pins installation to a specific git commit SHA instead of a tag/version.
 	// Must be a 40-character lowercase hex SHA-1. Mutually exclusive with Version.
 	// Currently supported only with RuntimeRef: "go" (go install pkg@<sha> resolves
-	// the SHA through GOPROXY+GOSUMDB transparency log). For other installers, Ref
+	// the SHA through GOPROXY+GOSUMDB transparency log). For other installers, SHA
 	// is rejected at Validate time — extending support requires re-deriving the
 	// integrity model for that installer.
-	Ref string `json:"ref,omitempty"`
+	SHA string `json:"sha,omitempty"`
 
 	// Enabled controls whether this tool should be installed.
 	// Default is true. Set to false to skip installation without removing the config.
@@ -363,7 +363,7 @@ func (s *ToolSpec) Validate() error {
 		return fmt.Errorf("privileged: true is not supported with runtimeRef")
 	}
 
-	if err := s.validateRef(); err != nil {
+	if err := s.validateSHA(); err != nil {
 		return err
 	}
 
@@ -372,12 +372,12 @@ func (s *ToolSpec) Validate() error {
 		return fmt.Errorf("commands.install is required")
 	}
 
-	// For non-commands patterns, version/ref/source/package is required.
-	// Ref satisfies this gate so a ref-only spec falls through to the more
+	// For non-commands patterns, version/sha/source/package is required.
+	// SHA satisfies this gate so a sha-only spec falls through to the more
 	// specific runtimeRef/package check below instead of stopping here with
 	// a generic "version, source, or package is required" message.
 	if !hasCommands {
-		if s.Version == "" && s.Ref == "" && s.Source == nil && s.Package.IsEmpty() {
+		if s.Version == "" && s.SHA == "" && s.Source == nil && s.Package.IsEmpty() {
 			return fmt.Errorf("version, source, or package is required")
 		}
 	}
@@ -405,23 +405,23 @@ func (s *ToolSpec) Validate() error {
 	return nil
 }
 
-// validateRef enforces the ref-pin policy: ref pins to a 40-char lowercase
-// hex SHA and is currently supported only with `runtimeRef: go`. Other
+// validateSHA enforces the sha-pin policy: sha pins to a 40-char lowercase
+// hex SHA-1 and is currently supported only with `runtimeRef: go`. Other
 // installers (aqua, cargo, npm, ...) have no equivalent integrity guarantee,
 // so extending support requires re-deriving the supply-chain model — do not
 // relax this check casually.
-func (s *ToolSpec) validateRef() error {
-	if s.Ref == "" {
+func (s *ToolSpec) validateSHA() error {
+	if s.SHA == "" {
 		return nil
 	}
 	if s.Version != "" {
-		return fmt.Errorf("ref and version are mutually exclusive")
+		return fmt.Errorf("sha and version are mutually exclusive")
 	}
 	if s.RuntimeRef != RuntimeNameGo {
-		return fmt.Errorf("ref is only supported with runtimeRef: go (got runtimeRef: %q)", s.RuntimeRef)
+		return fmt.Errorf("sha is only supported with runtimeRef: go (got runtimeRef: %q)", s.RuntimeRef)
 	}
-	if !refSHAPattern.MatchString(s.Ref) {
-		return fmt.Errorf("ref must be a 40-character lowercase hex SHA (got %q)", s.Ref)
+	if !shaPattern.MatchString(s.SHA) {
+		return fmt.Errorf("sha must be a 40-character lowercase hex SHA-1 (got %q)", s.SHA)
 	}
 	return nil
 }
@@ -621,7 +621,7 @@ func buildToolFromSetItem(ts *ToolSet, name string, item ToolItem) *Tool {
 			RepositoryRef: ts.ToolSetSpec.RepositoryRef,
 			RuntimeRef:    ts.ToolSetSpec.RuntimeRef,
 			Version:       item.Version,
-			Ref:           item.Ref,
+			SHA:           item.SHA,
 			Source:        item.Source,
 			Package:       item.Package,
 			BinaryName:    item.BinaryName,
@@ -638,10 +638,10 @@ type ToolItem struct {
 	// Overrides any default version from the ToolSet.
 	Version string `json:"version,omitempty"`
 
-	// Ref pins this tool to a git commit SHA. Mutually exclusive with Version.
-	// See ToolSpec.Ref for full semantics. Currently supported only with
+	// SHA pins this tool to a git commit SHA. Mutually exclusive with Version.
+	// See ToolSpec.SHA for full semantics. Currently supported only with
 	// runtimeRef: "go".
-	Ref string `json:"ref,omitempty"`
+	SHA string `json:"sha,omitempty"`
 
 	// Enabled controls whether this specific tool should be installed.
 	// Default is true. Set to false to exclude this tool from the set.
@@ -708,10 +708,11 @@ type ToolState struct {
 	// Version is the installed version of the tool.
 	Version string `json:"version"`
 
-	// Ref is the git commit SHA that pinned the install (when spec.ref was set).
-	// Mutually exclusive with Version in the spec; only one of the two is populated
-	// at a time. Empty for tools installed by tag/version (the common case).
-	Ref string `json:"ref,omitempty"`
+	// SHA records the 40-char commit SHA-1 that pinned this install (when
+	// spec.sha was set). Mutually exclusive with Version in the spec; only one
+	// of the two is populated at a time. Empty for tools installed by
+	// tag/version (the common case).
+	SHA string `json:"sha,omitempty"`
 
 	// Digest is the SHA256 hash of the installed binary (for download pattern).
 	// Used to verify integrity and detect if the binary was modified.

--- a/internal/resource/tool.go
+++ b/internal/resource/tool.go
@@ -374,11 +374,10 @@ func (s *ToolSpec) Validate() error {
 
 	// For non-commands patterns, version/sha/source/package is required.
 	// SHA satisfies this gate so a sha-only spec falls through to the more
-	// specific runtimeRef/package check below instead of stopping here with
-	// a generic "version, source, or package is required" message.
+	// specific runtimeRef/package check below.
 	if !hasCommands {
 		if s.Version == "" && s.SHA == "" && s.Source == nil && s.Package.IsEmpty() {
-			return fmt.Errorf("version, source, or package is required")
+			return fmt.Errorf("version, sha, source, or package is required")
 		}
 	}
 

--- a/internal/resource/tool_test.go
+++ b/internal/resource/tool_test.go
@@ -1304,7 +1304,13 @@ func TestToolState_Marshal_OmitsEmptySHA(t *testing.T) {
 
 	data, err := json.Marshal(st)
 	require.NoError(t, err)
-	assert.NotContains(t, string(data), `"sha"`,
+	// Unmarshal to a map and check key absence — substring matching is brittle
+	// because another field's value (e.g. "sha256:..." in a checksum) could
+	// contain the literal `"sha`.
+	var fields map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &fields))
+	_, present := fields["sha"]
+	assert.False(t, present,
 		"empty SHA must be omitted from the serialized state to keep non-sha-pinned entries unchanged")
 }
 

--- a/internal/resource/tool_test.go
+++ b/internal/resource/tool_test.go
@@ -148,7 +148,7 @@ func TestToolSpec_Validate(t *testing.T) {
 			spec: &ToolSpec{
 				InstallerRef: "aqua",
 			},
-			wantErr: "version, source, or package is required",
+			wantErr: "version, sha, source, or package is required",
 		},
 		{
 			name: "runtimeRef without package",

--- a/internal/resource/tool_test.go
+++ b/internal/resource/tool_test.go
@@ -272,82 +272,82 @@ func TestToolSpec_Validate(t *testing.T) {
 			wantErr: "privileged: true is not supported with runtimeRef",
 		},
 		{
-			name: "valid ref with go runtime",
+			name: "valid sha with go runtime",
 			spec: &ToolSpec{
 				RuntimeRef: "go",
-				Ref:        "0123456789abcdef0123456789abcdef01234567",
+				SHA:        "0123456789abcdef0123456789abcdef01234567",
 				Package:    &Package{Name: "golang.org/x/tools/gopls"},
 			},
 			wantErr: "",
 		},
 		{
-			// Ordering pin: privileged + runtimeRef + ref must hit the
+			// Ordering pin: privileged + runtimeRef + sha must hit the
 			// privileged-vs-runtimeRef error first (existing rule wins over
-			// the newer ref-only rule). Locks ref validation BELOW the
+			// the newer sha-only rule). Locks sha validation BELOW the
 			// privileged check in Validate().
-			name: "privileged + ref + runtimeRef hits privileged error first",
+			name: "privileged + sha + runtimeRef hits privileged error first",
 			spec: &ToolSpec{
 				RuntimeRef: "go",
-				Ref:        "0123456789abcdef0123456789abcdef01234567",
+				SHA:        "0123456789abcdef0123456789abcdef01234567",
 				Package:    &Package{Name: "golang.org/x/tools/gopls"},
 				Privileged: true,
 			},
 			wantErr: "privileged: true is not supported with runtimeRef",
 		},
 		{
-			name: "ref + version mutually exclusive",
+			name: "sha + version mutually exclusive",
 			spec: &ToolSpec{
 				RuntimeRef: "go",
-				Ref:        "0123456789abcdef0123456789abcdef01234567",
+				SHA:        "0123456789abcdef0123456789abcdef01234567",
 				Version:    "v0.16.0",
 				Package:    &Package{Name: "golang.org/x/tools/gopls"},
 			},
-			wantErr: "ref and version are mutually exclusive",
+			wantErr: "sha and version are mutually exclusive",
 		},
 		{
-			name: "ref with non-go runtime rejected",
+			name: "sha with non-go runtime rejected",
 			spec: &ToolSpec{
 				RuntimeRef: "cargo",
-				Ref:        "0123456789abcdef0123456789abcdef01234567",
+				SHA:        "0123456789abcdef0123456789abcdef01234567",
 				Package:    &Package{Name: "ripgrep"},
 			},
-			wantErr: `ref is only supported with runtimeRef: go (got runtimeRef: "cargo")`,
+			wantErr: `sha is only supported with runtimeRef: go (got runtimeRef: "cargo")`,
 		},
 		{
-			name: "ref with installerRef rejected",
+			name: "sha with installerRef rejected",
 			spec: &ToolSpec{
 				InstallerRef: "aqua",
-				Ref:          "0123456789abcdef0123456789abcdef01234567",
+				SHA:          "0123456789abcdef0123456789abcdef01234567",
 				Package:      &Package{Owner: "cli", Repo: "cli"},
 			},
-			wantErr: `ref is only supported with runtimeRef: go (got runtimeRef: "")`,
+			wantErr: `sha is only supported with runtimeRef: go (got runtimeRef: "")`,
 		},
 		{
-			name: "ref short SHA rejected",
+			name: "sha short SHA rejected",
 			spec: &ToolSpec{
 				RuntimeRef: "go",
-				Ref:        "0123456",
+				SHA:        "0123456",
 				Package:    &Package{Name: "golang.org/x/tools/gopls"},
 			},
-			wantErr: `ref must be a 40-character lowercase hex SHA (got "0123456")`,
+			wantErr: `sha must be a 40-character lowercase hex SHA-1 (got "0123456")`,
 		},
 		{
-			name: "ref tag-like string rejected",
+			name: "sha tag-like string rejected",
 			spec: &ToolSpec{
 				RuntimeRef: "go",
-				Ref:        "v1.2.3",
+				SHA:        "v1.2.3",
 				Package:    &Package{Name: "golang.org/x/tools/gopls"},
 			},
-			wantErr: `ref must be a 40-character lowercase hex SHA (got "v1.2.3")`,
+			wantErr: `sha must be a 40-character lowercase hex SHA-1 (got "v1.2.3")`,
 		},
 		{
-			name: "ref uppercase hex rejected",
+			name: "sha uppercase hex rejected",
 			spec: &ToolSpec{
 				RuntimeRef: "go",
-				Ref:        "0123456789ABCDEF0123456789abcdef01234567",
+				SHA:        "0123456789ABCDEF0123456789abcdef01234567",
 				Package:    &Package{Name: "golang.org/x/tools/gopls"},
 			},
-			wantErr: `ref must be a 40-character lowercase hex SHA (got "0123456789ABCDEF0123456789abcdef01234567")`,
+			wantErr: `sha must be a 40-character lowercase hex SHA-1 (got "0123456789ABCDEF0123456789abcdef01234567")`,
 		},
 	}
 
@@ -1063,10 +1063,10 @@ func TestToolSet_Expand_CopiesArgs(t *testing.T) {
 	}
 }
 
-// Regression: ToolItem.Ref must propagate into the expanded Tool spec.
-// Without this, a ref-pinned tool declared inside a ToolSet would silently
+// Regression: ToolItem.SHA must propagate into the expanded Tool spec.
+// Without this, a sha-pinned tool declared inside a ToolSet would silently
 // lose the SHA at expansion time and resolve to @latest.
-func TestToolSet_Expand_CopiesRef(t *testing.T) {
+func TestToolSet_Expand_CopiesSHA(t *testing.T) {
 	t.Parallel()
 	const sha = "0123456789abcdef0123456789abcdef01234567"
 	ts := &ToolSet{
@@ -1080,7 +1080,7 @@ func TestToolSet_Expand_CopiesRef(t *testing.T) {
 			Tools: map[string]ToolItem{
 				"gopls": {
 					Package: &Package{Name: "golang.org/x/tools/gopls"},
-					Ref:     sha,
+					SHA:     sha,
 				},
 			},
 		},
@@ -1090,8 +1090,8 @@ func TestToolSet_Expand_CopiesRef(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, resources, 1)
 	tool := resources[0].(*Tool)
-	assert.Equal(t, sha, tool.ToolSpec.Ref, "ToolItem.Ref must flow into expanded ToolSpec.Ref")
-	assert.Empty(t, tool.ToolSpec.Version, "version stays empty when ref is set")
+	assert.Equal(t, sha, tool.ToolSpec.SHA, "ToolItem.SHA must flow into expanded ToolSpec.SHA")
+	assert.Empty(t, tool.ToolSpec.Version, "version stays empty when sha is set")
 }
 
 func TestToolSet_Expand_WithRepositoryRef(t *testing.T) {
@@ -1286,34 +1286,36 @@ func TestToolState_MarshalRoundtrip_WithoutCommands(t *testing.T) {
 	assert.Nil(t, got.Commands)
 }
 
-// Legacy state.json files (pre-ref) have no `ref` key. Verify they unmarshal
-// cleanly with ToolState.Ref defaulting to "".
-func TestToolState_Unmarshal_LegacyWithoutRef(t *testing.T) {
+// State entries without a SHA pin (the common case) must NOT serialize a
+// spurious "sha":"" line — `json:"sha,omitempty"` on ToolState.SHA is what
+// guarantees this. Locks the omitempty tag so a future contributor who
+// drops it doesn't silently bloat every state.json entry.
+func TestToolState_Marshal_OmitsEmptySHA(t *testing.T) {
 	t.Parallel()
-	legacy := []byte(`{
-		"installerRef": "go",
-		"version": "v0.16.0",
-		"versionKind": "exact",
-		"installPath": "/home/u/go/bin/gopls",
-		"binPath": "",
-		"runtimeRef": "go",
-		"updatedAt": "2025-01-01T00:00:00Z"
-	}`)
+	st := &ToolState{
+		InstallerRef: "go",
+		Version:      "v0.16.0",
+		VersionKind:  VersionExact,
+		SpecVersion:  "v0.16.0",
+		RuntimeRef:   "go",
+		InstallPath:  "/home/u/go/bin/gopls",
+		UpdatedAt:    time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
 
-	var got ToolState
-	require.NoError(t, json.Unmarshal(legacy, &got))
-	assert.Empty(t, got.Ref, "Ref must default to empty for legacy state without the field")
-	assert.Equal(t, "v0.16.0", got.Version)
+	data, err := json.Marshal(st)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), `"sha"`,
+		"empty SHA must be omitted from the serialized state to keep non-sha-pinned entries unchanged")
 }
 
-// Round-trip a ToolState that has Ref set; confirm the SHA survives marshal+unmarshal
+// Round-trip a ToolState that has SHA set; confirm the SHA survives marshal+unmarshal
 // and that Version stays empty (the exclusivity invariant from Validate).
-func TestToolState_MarshalRoundtrip_WithRef(t *testing.T) {
+func TestToolState_MarshalRoundtrip_WithSHA(t *testing.T) {
 	t.Parallel()
 	original := &ToolState{
 		InstallerRef: "go",
 		Version:      "",
-		Ref:          "0123456789abcdef0123456789abcdef01234567",
+		SHA:          "0123456789abcdef0123456789abcdef01234567",
 		VersionKind:  VersionExact,
 		RuntimeRef:   "go",
 		UpdatedAt:    time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -1324,7 +1326,7 @@ func TestToolState_MarshalRoundtrip_WithRef(t *testing.T) {
 
 	var got ToolState
 	require.NoError(t, json.Unmarshal(data, &got))
-	assert.Equal(t, original.Ref, got.Ref)
+	assert.Equal(t, original.SHA, got.SHA)
 	assert.Empty(t, got.Version)
 }
 


### PR DESCRIPTION
The SHA-pin feature added in #248 used `ref` as the field name, which
overloads "ref" — a token already used in the codebase for resource
references (`runtimeRef`, `installerRef`, `repositoryRef`, dependency
`Ref` struct) and for the aqua-registry git ref. Renaming to `sha`
matches what the value actually is (a 40-char hex SHA-1 commit hash)
and removes the read-time ambiguity.

Scope: spec field, state field, ToolSet item field, ResourceInfo,
PlanResource, JSON tag, CUE schema field + constraint, validator,
reconciler reason string, tree-render label, install-time log key,
tests, docs. No behavior change; backward compatibility for the
short-lived `ref` field name was explicitly waived.

CUE-side, the rename was a chance to also tighten enforcement:
- `#Tool.spec` keeps the existing `if sha != _|_ { runtimeRef: "go";
  installerRef?: =~"^$"; commands?: null }` block (now keyed on sha).
- `#ToolSet.spec` gains a parallel `for _, tool in tools { if tool.sha
  != _|_ { runtimeRef: "go" } }` comprehension so a sha-pinned tool
  inside a ToolSet is rejected at the schema layer when the ToolSet's
  runtimeRef is anything other than "go" — previously the gate only
  fired through Go-side Validate.

Tests:
- 7 ToolSpec.Validate cases (positive + 6 rejection patterns) renamed
  to sha vocabulary; ordering-pin case for privileged+sha+runtimeRef
  retained; error wording aligned to "SHA-1".
- ToolSet expansion regression test (ToolItem.sha → ToolSpec.sha)
  renamed to TestToolSet_Expand_CopiesSHA.
- Old "TestToolState_Unmarshal_LegacyWithoutSHA" was repurposed to
  TestToolState_Marshal_OmitsEmptySHA — locks the `omitempty` tag so
  non-sha-pinned entries don't bloat state.json.
- 4 reconciler comparator cases + 2 ordering subtests renamed; oldSHA
  /newSHA constants hoisted to package level; "sha cleared" case
  documents the trailing-space-after-arrow as intentional.
- 4 schema_test cases added: ToolSet with sha+runtimeRef:go (valid),
  Tool with sha+installerRef (rejected), Tool with sha+commands
  (rejected), ToolSet with sha+runtimeRef:cargo (rejected) — pins the
  new for-comprehension and the existing #Tool.spec gate at the
  CUE-evaluation layer instead of Go-side Validate.
- TestShortSHA / TestFormatNode_SHARendering renamed accordingly.

Docs updated: docs/cue-schema.md, docs/usage.md, docs/design.md all
refer to `sha` throughout the SHA-pin sections; field table updated.

E2E was not re-run for this rename (no behavioral change). Unit +
integration + lint all green; existing CI gates cover this surface.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
