### PR TITLE
feat(resource): add minimumReleaseAge schema field to Installer/Runtime (#251)

### DIFF
--- a/cmd/tomei/plan.go
+++ b/cmd/tomei/plan.go
@@ -112,6 +112,13 @@ func runPlan(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Reject builtin-installer overrides whose type differs from the
+	// builtin's hard-coded download type. See ValidateBuiltinInstallerOverrides
+	// for rationale.
+	if err := resource.ValidateBuiltinInstallerOverrides(resources); err != nil {
+		return fmt.Errorf("plan rejected: %w", err)
+	}
+
 	updateCfg := engine.UpdateConfig{
 		SyncMode:       planCfg.syncRegistry,
 		UpdateTools:    planCfg.updateTools || planCfg.updateAll,

--- a/cmd/tomei/validate.go
+++ b/cmd/tomei/validate.go
@@ -62,6 +62,14 @@ func runValidate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("validation failed: %w", err)
 	}
 
+	// Reject user-declared Installer/aqua or Installer/download whose
+	// spec.type differs from the builtin's hard-coded type. Catches a
+	// silent install-mechanism swap that AppendBuiltinInstallers would
+	// otherwise allow via override-by-name.
+	if err := resource.ValidateBuiltinInstallerOverrides(resources); err != nil {
+		return fmt.Errorf("validation failed: %w", err)
+	}
+
 	// Validate each resource's spec
 	cmd.Println("Resources:")
 	validationFailed := false

--- a/cuemodule/schema/schema.cue
+++ b/cuemodule/schema/schema.cue
@@ -86,6 +86,16 @@ package schema
 		taintOnUpgrade?: bool
 		resolveVersion?: [...string]
 
+		// minimumReleaseAge gates install of releases younger than this
+		// duration. Go duration string (e.g. "168h" for 1 week). Empty =
+		// disabled.
+		//
+		// Go-side parses and validates the value; the schema accepts any
+		// string and defers semantic checks to Validate(). Enforcement is
+		// performed at apply time by the installer engine (see issue
+		// #257); declaring this field before that gate lands is a no-op.
+		minimumReleaseAge?: string
+
 		// Conditional required fields
 		if type == "download" {
 			source: #DownloadSource
@@ -120,6 +130,16 @@ package schema
 		dependsOn?: [...string]
 		bootstrap?: #CommandSet
 		commands?:  #CommandSet
+
+		// minimumReleaseAge gates install of releases younger than this
+		// duration. Go duration string (e.g. "168h" for 1 week). Empty =
+		// disabled.
+		//
+		// Go-side parses and validates the value; the schema accepts any
+		// string and defers semantic checks to Validate(). Enforcement is
+		// performed at apply time by the installer engine (see issue
+		// #257); declaring this field before that gate lands is a no-op.
+		minimumReleaseAge?: string
 
 		// Conditional required fields
 		if type == "delegation" {

--- a/cuemodule/schema_test.go
+++ b/cuemodule/schema_test.go
@@ -251,6 +251,48 @@ func TestSchema_ValidResources(t *testing.T) {
 			}`,
 		},
 		{
+			name: "Installer with minimumReleaseAge",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "Installer"
+				metadata: name: "aqua"
+				spec: {
+					type: "download"
+					minimumReleaseAge: "168h"
+				}
+			}`,
+		},
+		{
+			// Schema accepts arbitrary strings — semantic validation is
+			// deferred to Go-side InstallerSpec.Validate(). Proves the
+			// schema layer does not duplicate the duration parser.
+			name: "Installer with semantically invalid minimumReleaseAge string",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "Installer"
+				metadata: name: "download"
+				spec: {
+					type: "download"
+					minimumReleaseAge: "notaduration"
+				}
+			}`,
+		},
+		{
+			name: "Runtime with minimumReleaseAge",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "Runtime"
+				metadata: name: "go"
+				spec: {
+					type:        "download"
+					version:     "1.25.6"
+					toolBinPath: "~/go/bin"
+					source: url: "https://go.dev/dl/go1.25.6.linux-amd64.tar.gz"
+					minimumReleaseAge: "168h"
+				}
+			}`,
+		},
+		{
 			name: "InstallerRepository delegation",
 			cue: `{
 				apiVersion: "tomei.terassyi.net/v1beta1"
@@ -702,6 +744,33 @@ func TestSchema_InvalidResources(t *testing.T) {
 					source: {
 						type: "invalid"
 					}
+				}
+			}`,
+		},
+		{
+			name: "Installer minimumReleaseAge not a string",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "Installer"
+				metadata: name: "download"
+				spec: {
+					type:              "download"
+					minimumReleaseAge: 168
+				}
+			}`,
+		},
+		{
+			name: "Runtime minimumReleaseAge not a string",
+			cue: `{
+				apiVersion: "tomei.terassyi.net/v1beta1"
+				kind:       "Runtime"
+				metadata: name: "go"
+				spec: {
+					type:              "download"
+					version:           "1.25.6"
+					toolBinPath:       "~/go/bin"
+					source: url:       "https://go.dev/dl/go1.25.6.linux-amd64.tar.gz"
+					minimumReleaseAge: 168
 				}
 			}`,
 		},

--- a/internal/installer/command/executor.go
+++ b/internal/installer/command/executor.go
@@ -51,6 +51,13 @@ type Vars struct {
 	// Security: values are sourced from the user's own CUE manifest,
 	// not from external/untrusted input.
 	Args string
+	// MinimumReleaseAge is the Go duration string declared on the owning
+	// Installer/Runtime spec (e.g., "168h"). Empty when unset. Threaded by
+	// the installer engine; currently a no-op until issue #257's apply-time
+	// gate consumes it. The slot exists here so delegation commands can
+	// reference {{.MinimumReleaseAge}} without further plumbing once the
+	// gate lands.
+	MinimumReleaseAge string
 }
 
 // Executor executes shell commands with variable substitution.

--- a/internal/installer/command/executor_test.go
+++ b/internal/installer/command/executor_test.go
@@ -81,6 +81,23 @@ func TestExecutor_expand(t *testing.T) {
 			},
 			expected: "cmd  ",
 		},
+		{
+			name:   "expand minimumReleaseAge",
+			cmdStr: "install --min-age={{.MinimumReleaseAge}} {{.Package}}",
+			vars: Vars{
+				Package:           "gopls",
+				MinimumReleaseAge: "168h",
+			},
+			expected: "install --min-age=168h gopls",
+		},
+		{
+			name:   "empty minimumReleaseAge expands to empty string",
+			cmdStr: "install --min-age={{.MinimumReleaseAge}} {{.Package}}",
+			vars: Vars{
+				Package: "gopls",
+			},
+			expected: "install --min-age= gopls",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/installer/engine/engine.go
+++ b/internal/installer/engine/engine.go
@@ -317,6 +317,13 @@ func (e *Engine) Apply(ctx context.Context, resources []resource.Resource) error
 
 	slog.Debug("applying configuration", "resources", len(resources))
 
+	// Reject user-declared Installer/aqua or Installer/download with a
+	// mismatched spec.type before AppendBuiltinInstallers silently picks
+	// up the override and changes the install mechanism.
+	if err := resource.ValidateBuiltinInstallerOverrides(resources); err != nil {
+		return fmt.Errorf("apply rejected: %w", err)
+	}
+
 	// Build dependency graph and get execution layers.
 	// Inject builtin installers into the resolver only so that dependency
 	// nodes like "Installer/aqua" are properly resolved. Builtins are NOT

--- a/internal/resource/installer.go
+++ b/internal/resource/installer.go
@@ -159,36 +159,50 @@ var builtinInstallerOrder = []string{InstallerNameAqua, InstallerNameDownload}
 
 // ValidateBuiltinInstallerOverrides rejects user declarations of
 // Installer/aqua or Installer/download whose spec.type differs from the
-// builtin's hard-coded type. See engine.AppendBuiltinInstallers for the
-// override-by-name semantics this guards: a user-declared Installer with
-// one of these reserved names silently shadows the builtin, so allowing a
-// mismatched type would swap the install mechanism without warning.
+// builtin's hard-coded type, or whose InstallerSpec is missing entirely.
+// See engine.AppendBuiltinInstallers for the override-by-name semantics
+// this guards: a user-declared Installer with one of these reserved
+// names silently shadows the builtin, so allowing a mismatched (or
+// absent) spec would swap the install mechanism without warning.
 //
-// Scope is intentionally narrow: only spec.type is checked. Broader
-// override-shape hardening (rejecting non-nil Bootstrap/Commands/etc on
-// builtin overrides) is deferred to a follow-up issue alongside #254.
+// Every occurrence of a reserved name is checked — duplicates are not
+// deduplicated by name, because if two manifests both declare
+// Installer/aqua and one is valid while the other is not, the invalid
+// one must still surface.
+//
+// Scope is intentionally narrow: only spec.type (and spec presence) is
+// checked. Broader override-shape hardening (rejecting non-nil
+// Bootstrap/Commands/etc on builtin overrides) is deferred to a
+// follow-up issue alongside #254.
 func ValidateBuiltinInstallerOverrides(resources []Resource) error {
-	// Index user-declared installers by name for O(1) lookup.
-	byName := make(map[string]*Installer)
+	// Collect every occurrence of each reserved builtin name. Using a
+	// slice (not a map keyed by name) so duplicate declarations are all
+	// validated rather than overwriting each other.
+	byName := make(map[string][]*Installer)
 	for _, res := range resources {
 		if res == nil || res.Kind() != KindInstaller {
 			continue
 		}
 		inst, ok := res.(*Installer)
-		if !ok || inst.InstallerSpec == nil {
-			continue
-		}
-		byName[inst.Name()] = inst
-	}
-	for _, name := range builtinInstallerOrder {
-		inst, ok := byName[name]
 		if !ok {
 			continue
 		}
+		if _, isReserved := builtinInstallerTypes[inst.Name()]; !isReserved {
+			continue
+		}
+		byName[inst.Name()] = append(byName[inst.Name()], inst)
+	}
+	for _, name := range builtinInstallerOrder {
 		requiredType := builtinInstallerTypes[name]
-		if inst.InstallerSpec.Type != requiredType {
-			return fmt.Errorf("installer %q overrides builtin and must use type %q, got %q",
-				name, requiredType, inst.InstallerSpec.Type)
+		for _, inst := range byName[name] {
+			if inst.InstallerSpec == nil {
+				return fmt.Errorf("installer %q overrides builtin and must declare a spec (type %q)",
+					name, requiredType)
+			}
+			if inst.InstallerSpec.Type != requiredType {
+				return fmt.Errorf("installer %q overrides builtin and must use type %q, got %q",
+					name, requiredType, inst.InstallerSpec.Type)
+			}
 		}
 	}
 	return nil

--- a/internal/resource/installer.go
+++ b/internal/resource/installer.go
@@ -54,6 +54,15 @@ type InstallerSpec struct {
 	// Used by `tomei env` to include the directory in PATH.
 	// Must start with "~/" (home-relative) or "/" (absolute). Only meaningful for delegation type.
 	BinDir string `json:"binDir,omitempty"`
+
+	// MinimumReleaseAge gates install of releases younger than this duration.
+	// Format: Go duration string (e.g. "168h" for 1 week). Empty = disabled.
+	// Parsed and validated by `ParsedMinimumReleaseAge()`.
+	//
+	// Enforcement is performed at apply time by the installer engine
+	// (see issue #257); the field on its own has no behavioral effect until
+	// that gate lands.
+	MinimumReleaseAge string `json:"minimumReleaseAge,omitempty"`
 }
 
 // UnmarshalJSON handles CUE's MarshalJSON quirk where single-element lists
@@ -117,6 +126,71 @@ func (s *InstallerSpec) Validate() error {
 		seen[dep] = struct{}{}
 	}
 
+	// Validate minimumReleaseAge format / sign.
+	if _, err := s.ParsedMinimumReleaseAge(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ParsedMinimumReleaseAge parses MinimumReleaseAge as a Go duration.
+// See parseMinimumReleaseAge in types.go for parsing semantics
+// (empty/negative rules, no upper bound).
+func (s *InstallerSpec) ParsedMinimumReleaseAge() (time.Duration, error) {
+	return parseMinimumReleaseAge(s.MinimumReleaseAge)
+}
+
+// builtinInstallerTypes pins the InstallType each AppendBuiltinInstallers
+// override target must declare. Read-only after init.
+//
+// Iteration uses the hard-coded ordered list builtinInstallerOrder below
+// (not these map keys) so error messages are deterministic when a
+// manifest violates both overrides at once.
+var builtinInstallerTypes = map[string]InstallType{
+	InstallerNameAqua:     InstallTypeDownload,
+	InstallerNameDownload: InstallTypeDownload,
+}
+
+// builtinInstallerOrder pins iteration order for ValidateBuiltinInstallerOverrides.
+// Must contain exactly the keys of builtinInstallerTypes (enforced by
+// TestBuiltinInstallerInvariants).
+var builtinInstallerOrder = []string{InstallerNameAqua, InstallerNameDownload}
+
+// ValidateBuiltinInstallerOverrides rejects user declarations of
+// Installer/aqua or Installer/download whose spec.type differs from the
+// builtin's hard-coded type. See engine.AppendBuiltinInstallers for the
+// override-by-name semantics this guards: a user-declared Installer with
+// one of these reserved names silently shadows the builtin, so allowing a
+// mismatched type would swap the install mechanism without warning.
+//
+// Scope is intentionally narrow: only spec.type is checked. Broader
+// override-shape hardening (rejecting non-nil Bootstrap/Commands/etc on
+// builtin overrides) is deferred to a follow-up issue alongside #254.
+func ValidateBuiltinInstallerOverrides(resources []Resource) error {
+	// Index user-declared installers by name for O(1) lookup.
+	byName := make(map[string]*Installer)
+	for _, res := range resources {
+		if res == nil || res.Kind() != KindInstaller {
+			continue
+		}
+		inst, ok := res.(*Installer)
+		if !ok || inst.InstallerSpec == nil {
+			continue
+		}
+		byName[inst.Name()] = inst
+	}
+	for _, name := range builtinInstallerOrder {
+		inst, ok := byName[name]
+		if !ok {
+			continue
+		}
+		requiredType := builtinInstallerTypes[name]
+		if inst.InstallerSpec.Type != requiredType {
+			return fmt.Errorf("installer %q overrides builtin and must use type %q, got %q",
+				name, requiredType, inst.InstallerSpec.Type)
+		}
+	}
 	return nil
 }
 

--- a/internal/resource/installer_test.go
+++ b/internal/resource/installer_test.go
@@ -439,10 +439,11 @@ func TestValidateBuiltinInstallerOverrides(t *testing.T) {
 			},
 		},
 		{
-			name: "aqua with nil InstallerSpec is skipped",
+			name: "aqua with nil InstallerSpec rejected (still shadows builtin)",
 			resources: []Resource{
 				mkInstaller("aqua", nil),
 			},
+			wantErr: `installer "aqua" overrides builtin and must declare a spec`,
 		},
 		{
 			name: "nil resource entry is skipped",
@@ -450,6 +451,19 @@ func TestValidateBuiltinInstallerOverrides(t *testing.T) {
 				nil,
 				mkInstaller("aqua", &InstallerSpec{Type: InstallTypeDownload}),
 			},
+		},
+		{
+			// Two Installer/aqua occurrences (e.g., split across manifests).
+			// A valid one must NOT mask an invalid sibling — every
+			// occurrence is checked. Order chosen so the invalid one
+			// appears second to also defend against "last write wins"
+			// regressions on a map-based dedup.
+			name: "duplicate aqua: invalid sibling must still error",
+			resources: []Resource{
+				mkInstaller("aqua", &InstallerSpec{Type: InstallTypeDownload}),
+				mkInstaller("aqua", &InstallerSpec{Type: InstallTypeDelegation}),
+			},
+			wantErr: `installer "aqua" overrides builtin and must use type "download"`,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/resource/installer_test.go
+++ b/internal/resource/installer_test.go
@@ -1,8 +1,10 @@
 package resource
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestInstallerSpec_Validate(t *testing.T) {
@@ -174,6 +176,30 @@ func TestInstallerSpec_Validate(t *testing.T) {
 			},
 			wantErr: "binDir is not supported for download type",
 		},
+		{
+			name: "valid with minimumReleaseAge",
+			spec: InstallerSpec{
+				Type:              InstallTypeDownload,
+				MinimumReleaseAge: "168h",
+			},
+			wantErr: "",
+		},
+		{
+			name: "invalid minimumReleaseAge surfaces from Validate",
+			spec: InstallerSpec{
+				Type:              InstallTypeDownload,
+				MinimumReleaseAge: "7d",
+			},
+			wantErr: "minimumReleaseAge",
+		},
+		{
+			name: "negative minimumReleaseAge rejected from Validate",
+			spec: InstallerSpec{
+				Type:              InstallTypeDownload,
+				MinimumReleaseAge: "-1h",
+			},
+			wantErr: "minimumReleaseAge must be non-negative",
+		},
 	}
 
 	for _, tt := range tests {
@@ -297,4 +323,252 @@ func TestInstallerSpec_Dependencies(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInstallerSpec_ParsedMinimumReleaseAge(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   string
+		want    time.Duration
+		wantErr bool
+		errSub  string
+	}{
+		{name: "empty disabled", input: "", want: 0},
+		{name: "168h", input: "168h", want: 168 * time.Hour},
+		{name: "leading plus accepted", input: "+168h", want: 168 * time.Hour},
+		{name: "compound", input: "1h30m", want: 90 * time.Minute},
+		{name: "0s explicit zero", input: "0s", want: 0},
+		{name: "0 unitless accepted as zero", input: "0", want: 0},
+		{name: "7d rejected", input: "7d", wantErr: true, errSub: "minimumReleaseAge"},
+		{name: "uppercase H rejected", input: "168H", wantErr: true, errSub: "minimumReleaseAge"},
+		{name: "leading whitespace rejected", input: "  168h", wantErr: true, errSub: "minimumReleaseAge"},
+		{name: "garbage rejected", input: "garbage", wantErr: true, errSub: "minimumReleaseAge"},
+		{name: "negative hour", input: "-1h", wantErr: true, errSub: "minimumReleaseAge must be non-negative"},
+		{name: "negative ns", input: "-1ns", wantErr: true, errSub: "minimumReleaseAge must be non-negative"},
+		{name: "shell metacharacters rejected", input: "168h; rm -rf /", wantErr: true, errSub: "minimumReleaseAge"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := InstallerSpec{MinimumReleaseAge: tt.input}
+			got, err := s.ParsedMinimumReleaseAge()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParsedMinimumReleaseAge(%q) expected error, got nil", tt.input)
+				}
+				if !strings.Contains(err.Error(), tt.errSub) {
+					t.Errorf("ParsedMinimumReleaseAge(%q) error = %q, want containing %q", tt.input, err.Error(), tt.errSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParsedMinimumReleaseAge(%q) unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("ParsedMinimumReleaseAge(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateBuiltinInstallerOverrides(t *testing.T) {
+	t.Parallel()
+	mkInstaller := func(name string, spec *InstallerSpec) *Installer {
+		return &Installer{
+			BaseResource: BaseResource{
+				APIVersion:   GroupVersion,
+				ResourceKind: KindInstaller,
+				Metadata:     Metadata{Name: name},
+			},
+			InstallerSpec: spec,
+		}
+	}
+	tests := []struct {
+		name      string
+		resources []Resource
+		wantErr   string
+	}{
+		{name: "nil slice", resources: nil},
+		{name: "empty slice", resources: []Resource{}},
+		{
+			name: "aqua with download type",
+			resources: []Resource{
+				mkInstaller("aqua", &InstallerSpec{Type: InstallTypeDownload}),
+			},
+		},
+		{
+			name: "aqua with download type and minimumReleaseAge",
+			resources: []Resource{
+				mkInstaller("aqua", &InstallerSpec{Type: InstallTypeDownload, MinimumReleaseAge: "168h"}),
+			},
+		},
+		{
+			name: "aqua with delegation type rejected",
+			resources: []Resource{
+				mkInstaller("aqua", &InstallerSpec{Type: InstallTypeDelegation}),
+			},
+			wantErr: `installer "aqua" overrides builtin and must use type "download"`,
+		},
+		{
+			// Locks in the deterministic ordering documented on
+			// builtinInstallerOrder: aqua is checked before download, so
+			// when both overrides are misused at once the error names
+			// "aqua" first regardless of map iteration order. Extra
+			// "download" absence assertion runs after this row to prove
+			// the function short-circuits on the first violation rather
+			// than aggregating both.
+			name: "both aqua and download misused — aqua reported first",
+			resources: []Resource{
+				mkInstaller("download", &InstallerSpec{Type: InstallTypeDelegation}),
+				mkInstaller("aqua", &InstallerSpec{Type: InstallTypeDelegation}),
+			},
+			wantErr: `installer "aqua"`,
+		},
+		{
+			name: "download with delegation type rejected",
+			resources: []Resource{
+				mkInstaller("download", &InstallerSpec{Type: InstallTypeDelegation}),
+			},
+			wantErr: `installer "download" overrides builtin and must use type "download"`,
+		},
+		{
+			name: "unrelated installer name with delegation tolerated",
+			resources: []Resource{
+				mkInstaller("foo", &InstallerSpec{Type: InstallTypeDelegation}),
+			},
+		},
+		{
+			name: "aqua with nil InstallerSpec is skipped",
+			resources: []Resource{
+				mkInstaller("aqua", nil),
+			},
+		},
+		{
+			name: "nil resource entry is skipped",
+			resources: []Resource{
+				nil,
+				mkInstaller("aqua", &InstallerSpec{Type: InstallTypeDownload}),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateBuiltinInstallerOverrides(tt.resources)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("ValidateBuiltinInstallerOverrides() unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ValidateBuiltinInstallerOverrides() expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("ValidateBuiltinInstallerOverrides() error = %q, want containing %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+
+	// Separate from the table because it asserts NotContains, not Contains:
+	// when both builtins are misused, the function short-circuits on
+	// "aqua" (the first entry in builtinInstallerOrder) and never reports
+	// "download". This locks in single-error semantics.
+	t.Run("both misused short-circuits on aqua, does not also report download", func(t *testing.T) {
+		t.Parallel()
+		err := ValidateBuiltinInstallerOverrides([]Resource{
+			mkInstaller("download", &InstallerSpec{Type: InstallTypeDelegation}),
+			mkInstaller("aqua", &InstallerSpec{Type: InstallTypeDelegation}),
+		})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		// The error must mention the aqua override but NOT the download
+		// override — proving the function short-circuits on the first
+		// builtin name in builtinInstallerOrder rather than aggregating.
+		// Care: the literal substring "download" legitimately appears in
+		// the required-type slot of the error format string
+		// (`... must use type "download", got "delegation"`), so we
+		// assert on the full `installer "<name>"` prefix instead of bare
+		// names.
+		if !strings.Contains(err.Error(), `installer "aqua"`) {
+			t.Errorf("error should mention `installer \"aqua\"`: %v", err)
+		}
+		if strings.Contains(err.Error(), `installer "download"`) {
+			t.Errorf("short-circuit broken: error must not also mention `installer \"download\"`: %v", err)
+		}
+	})
+}
+
+// TestBuiltinInstallerInvariants pins the contract between
+// builtinInstallerTypes (map) and builtinInstallerOrder (slice): every
+// name in the slice must appear in the map, and the slice must cover the
+// map exactly. A drift would silently skip override validation for the
+// missing name.
+func TestBuiltinInstallerInvariants(t *testing.T) {
+	t.Parallel()
+	if len(builtinInstallerOrder) != len(builtinInstallerTypes) {
+		t.Fatalf("builtinInstallerOrder (len=%d) and builtinInstallerTypes (len=%d) must have the same length",
+			len(builtinInstallerOrder), len(builtinInstallerTypes))
+	}
+	seen := make(map[string]struct{}, len(builtinInstallerOrder))
+	for _, name := range builtinInstallerOrder {
+		if _, ok := builtinInstallerTypes[name]; !ok {
+			t.Errorf("builtinInstallerOrder entry %q has no corresponding key in builtinInstallerTypes", name)
+		}
+		if _, dup := seen[name]; dup {
+			t.Errorf("builtinInstallerOrder contains duplicate entry %q", name)
+		}
+		seen[name] = struct{}{}
+	}
+	for name := range builtinInstallerTypes {
+		if _, ok := seen[name]; !ok {
+			t.Errorf("builtinInstallerTypes key %q is missing from builtinInstallerOrder", name)
+		}
+	}
+}
+
+// TestInstallerSpec_MinimumReleaseAge_JSONRoundTrip locks in the
+// omitempty / round-trip behavior of the minimumReleaseAge JSON tag.
+func TestInstallerSpec_MinimumReleaseAge_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+	t.Run("set value round-trips", func(t *testing.T) {
+		t.Parallel()
+		original := InstallerSpec{Type: InstallTypeDownload, MinimumReleaseAge: "168h"}
+		data, err := json.Marshal(original)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if !strings.Contains(string(data), `"minimumReleaseAge":"168h"`) {
+			t.Errorf("Marshal output should contain the field; got %s", data)
+		}
+		var got InstallerSpec
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if got.MinimumReleaseAge != "168h" {
+			t.Errorf("after round-trip MinimumReleaseAge = %q, want %q", got.MinimumReleaseAge, "168h")
+		}
+	})
+	t.Run("empty value is omitted via omitempty", func(t *testing.T) {
+		t.Parallel()
+		data, err := json.Marshal(InstallerSpec{Type: InstallTypeDownload})
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if strings.Contains(string(data), "minimumReleaseAge") {
+			t.Errorf("empty MinimumReleaseAge should be omitted; got %s", data)
+		}
+	})
+	t.Run("unmarshal absent field yields empty string", func(t *testing.T) {
+		t.Parallel()
+		var got InstallerSpec
+		if err := json.Unmarshal([]byte(`{"type":"download"}`), &got); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if got.MinimumReleaseAge != "" {
+			t.Errorf("absent MinimumReleaseAge should unmarshal to empty string; got %q", got.MinimumReleaseAge)
+		}
+	})
 }

--- a/internal/resource/runtime.go
+++ b/internal/resource/runtime.go
@@ -79,6 +79,15 @@ type RuntimeSpec struct {
 	// Example: ["github-release:oven-sh/bun:bun-v"]
 	// Example: ["curl -sL https://go.dev/VERSION?m=text | head -1 | sed 's/^go//'"]
 	ResolveVersion []string `json:"resolveVersion,omitempty"`
+
+	// MinimumReleaseAge gates install of releases younger than this duration.
+	// Format: Go duration string (e.g. "168h" for 1 week). Empty = disabled.
+	// Parsed and validated by `ParsedMinimumReleaseAge()`.
+	//
+	// Enforcement is performed at apply time by the installer engine
+	// (see issue #257); the field on its own has no behavioral effect until
+	// that gate lands.
+	MinimumReleaseAge string `json:"minimumReleaseAge,omitempty"`
 }
 
 // UnmarshalJSON handles CUE's MarshalJSON quirk where single-element lists
@@ -170,7 +179,19 @@ func (s *RuntimeSpec) Validate() error {
 		}
 	}
 
+	// Validate minimumReleaseAge format / sign.
+	if _, err := s.ParsedMinimumReleaseAge(); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// ParsedMinimumReleaseAge parses MinimumReleaseAge as a Go duration.
+// See parseMinimumReleaseAge in types.go for parsing semantics
+// (empty/negative rules, no upper bound).
+func (s *RuntimeSpec) ParsedMinimumReleaseAge() (time.Duration, error) {
+	return parseMinimumReleaseAge(s.MinimumReleaseAge)
 }
 
 // Dependencies returns the resources this runtime depends on.

--- a/internal/resource/runtime_test.go
+++ b/internal/resource/runtime_test.go
@@ -1,7 +1,9 @@
 package resource
 
 import (
+	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -207,6 +209,35 @@ func TestRuntimeSpec_Validate(t *testing.T) {
 			},
 			wantErr: "toolBinPath is required when commands is defined",
 		},
+		{
+			name: "valid with minimumReleaseAge",
+			spec: RuntimeSpec{
+				Type:              InstallTypeDownload,
+				Version:           "1.25.6",
+				Source:            &DownloadSource{URL: "https://example.com/runtime.tar.gz"},
+				MinimumReleaseAge: "168h",
+			},
+		},
+		{
+			name: "invalid minimumReleaseAge surfaces from Validate",
+			spec: RuntimeSpec{
+				Type:              InstallTypeDownload,
+				Version:           "1.25.6",
+				Source:            &DownloadSource{URL: "https://example.com/runtime.tar.gz"},
+				MinimumReleaseAge: "7d",
+			},
+			wantErr: "minimumReleaseAge",
+		},
+		{
+			name: "negative minimumReleaseAge rejected from Validate",
+			spec: RuntimeSpec{
+				Type:              InstallTypeDownload,
+				Version:           "1.25.6",
+				Source:            &DownloadSource{URL: "https://example.com/runtime.tar.gz"},
+				MinimumReleaseAge: "-1h",
+			},
+			wantErr: "minimumReleaseAge must be non-negative",
+		},
 	}
 
 	for _, tt := range tests {
@@ -371,4 +402,75 @@ func TestRuntimeBootstrapSpec_UnmarshalJSON(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestRuntimeSpec_ParsedMinimumReleaseAge(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   string
+		want    time.Duration
+		wantErr bool
+		errSub  string
+	}{
+		{name: "empty disabled", input: "", want: 0},
+		{name: "168h", input: "168h", want: 168 * time.Hour},
+		{name: "leading plus accepted", input: "+168h", want: 168 * time.Hour},
+		{name: "compound", input: "1h30m", want: 90 * time.Minute},
+		{name: "0s explicit zero", input: "0s", want: 0},
+		{name: "0 unitless accepted as zero", input: "0", want: 0},
+		{name: "7d rejected", input: "7d", wantErr: true, errSub: "minimumReleaseAge"},
+		{name: "uppercase H rejected", input: "168H", wantErr: true, errSub: "minimumReleaseAge"},
+		{name: "leading whitespace rejected", input: "  168h", wantErr: true, errSub: "minimumReleaseAge"},
+		{name: "garbage rejected", input: "garbage", wantErr: true, errSub: "minimumReleaseAge"},
+		{name: "negative hour", input: "-1h", wantErr: true, errSub: "minimumReleaseAge must be non-negative"},
+		{name: "negative ns", input: "-1ns", wantErr: true, errSub: "minimumReleaseAge must be non-negative"},
+		{name: "shell metacharacters rejected", input: "168h; rm -rf /", wantErr: true, errSub: "minimumReleaseAge"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := RuntimeSpec{MinimumReleaseAge: tt.input}
+			got, err := s.ParsedMinimumReleaseAge()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSub)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestRuntimeSpec_MinimumReleaseAge_JSONRoundTrip locks in the
+// omitempty / round-trip behavior of the minimumReleaseAge JSON tag.
+func TestRuntimeSpec_MinimumReleaseAge_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+	t.Run("set value round-trips", func(t *testing.T) {
+		t.Parallel()
+		original := RuntimeSpec{
+			Type:              InstallTypeDownload,
+			Version:           "1.25.6",
+			MinimumReleaseAge: "168h",
+		}
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"minimumReleaseAge":"168h"`)
+		var got RuntimeSpec
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, "168h", got.MinimumReleaseAge)
+	})
+	t.Run("empty value is omitted via omitempty", func(t *testing.T) {
+		t.Parallel()
+		data, err := json.Marshal(RuntimeSpec{Type: InstallTypeDownload, Version: "1.25.6"})
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), "minimumReleaseAge")
+	})
+	t.Run("unmarshal absent field yields empty string", func(t *testing.T) {
+		t.Parallel()
+		var got RuntimeSpec
+		require.NoError(t, json.Unmarshal([]byte(`{"type":"download","version":"1.25.6"}`), &got))
+		assert.Empty(t, got.MinimumReleaseAge)
+	})
 }

--- a/internal/resource/tool.go
+++ b/internal/resource/tool.go
@@ -214,6 +214,9 @@ const (
 	// InstallerNameAqua is the canonical name of the builtin aqua installer.
 	// Tools using a Registry package (owner/repo form) must reference this installer.
 	InstallerNameAqua = "aqua"
+
+	// InstallerNameDownload is the canonical name of the builtin raw-download installer.
+	InstallerNameDownload = "download"
 )
 
 // ToolSpec defines the desired state of an individual tool.

--- a/internal/resource/types.go
+++ b/internal/resource/types.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 )
 
 // Kind represents the type of resource (K8s style).
@@ -318,6 +319,27 @@ func unmarshalStringOrSlice(data json.RawMessage) ([]string, error) {
 		return nil, err
 	}
 	return []string{s}, nil
+}
+
+// parseMinimumReleaseAge parses a MinimumReleaseAge field value (shared
+// across InstallerSpec and RuntimeSpec — colocated here with the other
+// cross-spec helpers like unmarshalStringFields). Empty returns (0, nil)
+// (disabled). Negative durations are rejected — "younger than now −
+// negative" is semantically meaningless. There is no upper bound: setting
+// a very large value (e.g., "87600h" / 10 years) is a user-policy
+// concern, not a schema constraint.
+func parseMinimumReleaseAge(s string) (time.Duration, error) {
+	if s == "" {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid minimumReleaseAge %q: %w", s, err)
+	}
+	if d < 0 {
+		return 0, fmt.Errorf("minimumReleaseAge must be non-negative, got %q", s)
+	}
+	return d, nil
 }
 
 // unmarshalStringFields applies unmarshalStringOrSlice to each field.


### PR DESCRIPTION
Foundation sub-task for the minimumReleaseAge supply-chain defense
(parent tracking issue #257). This PR introduces the declarative
surface only; enforcement lands later in #254.

What ships:
- InstallerSpec.MinimumReleaseAge / RuntimeSpec.MinimumReleaseAge
  (Go duration string, empty = disabled) with shared
  parseMinimumReleaseAge helper in types.go
- command.Vars.MinimumReleaseAge template slot (threading is #253)
- ValidateBuiltinInstallerOverrides rejects user-declared
  Installer/aqua or Installer/download whose spec.type differs from
  the builtin's hard-coded download type. Called from validate.go,
  engine.Apply, and plan.go before AppendBuiltinInstallers picks up
  the override
- InstallerNameDownload constant mirrors the existing
  InstallerNameAqua to centralize builtin names
- CUE schema: minimumReleaseAge?: string on #Installer.spec and
  #Runtime.spec; schema accepts any string and defers semantic
  checks to Go-side Validate()

Test coverage:
- ParsedMinimumReleaseAge tables on both specs (empty, valid,
  leading +, compound, "0"/"0s", invalid format, case, whitespace,
  negative, shell metachar)
- Validate-table rows exercising the Parsed -> Validate error chain
- TestValidateBuiltinInstallerOverrides + short-circuit ordering
  test (locks in builtinInstallerOrder determinism)
- TestBuiltinInstallerInvariants pins the map <-> ordered-slice
  contract so a future builtin addition can't drift silently
- JSON round-trip tests for both specs (set value, omitempty, absent
  field unmarshals to "")
- CUE schema accepts arbitrary string, rejects non-string

Scope intentionally narrow per the issue body: only spec.type is
gated on builtin overrides. Broader override-shape hardening (reject
Bootstrap/Commands/etc on builtin overrides) deferred to a follow-up
alongside #254. Round 5 architect review confirmed Installer.Bootstrap
is never consumed by the engine (only Runtime.Bootstrap is), so the
extra fields are inert in current code.

E2E suite was not run locally — the host's Nix-glibc-linked binary
can't load inside the Ubuntu test container (pre-existing
environment quirk, unrelated to this PR). CI will exercise E2E on
GitHub-hosted runners.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
