### PR TITLE
feat(age): add release publication time fetcher package (#252)

### DIFF
--- a/internal/age/age.go
+++ b/internal/age/age.go
@@ -1,0 +1,254 @@
+// Package age resolves release publication times for tomei tools.
+//
+// The minimumReleaseAge supply-chain defense (issue #257) needs to know
+// when each tool's selected version was published upstream. This package
+// abstracts that lookup behind a Fetcher interface with two backends:
+//
+//   - SourceAquaGitHubReleases — GitHub Releases API's published_at,
+//     consulted for tools installed via the builtin aqua installer.
+//   - SourceLastModified — HTTP Last-Modified header (with HEAD→GET Range
+//     fallback for servers that return 405/501 on HEAD), consulted for
+//     tools installed via the builtin download installer.
+//
+// Tools installed via delegation (custom Installer or Runtime commands)
+// are out of scope here — issue #253 threads the duration string through
+// to the user's install commands and the user's command is responsible
+// for whatever check it wants.
+package age
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/terassyi/tomei/internal/github"
+	"golang.org/x/sync/semaphore"
+)
+
+// Source identifies which backend resolves a Key to a publication time.
+type Source string
+
+const (
+	// SourceAquaGitHubReleases looks up published_at via the GitHub
+	// Releases API. Key fields: Owner, Repo, Tag.
+	SourceAquaGitHubReleases Source = "aqua-github-release"
+	// SourceLastModified looks up the upstream HTTP Last-Modified header
+	// for a raw download URL. Key field: URL.
+	SourceLastModified Source = "last-modified"
+)
+
+// Key identifies a single artifact whose publication time the caller
+// wants to look up. Fields are interpreted per Source — fields not
+// consumed by a given Source are ignored. Key is a comparable value
+// (suitable as a map key) so the cache can index by it directly.
+type Key struct {
+	Source           Source
+	Owner, Repo, Tag string // SourceAquaGitHubReleases
+	URL              string // SourceLastModified
+}
+
+// Fetcher resolves a Key to its upstream publication time.
+//
+// Return semantics:
+//
+//	ok=true, err=nil   → publishedAt is a real upstream timestamp
+//	ok=false, err=nil  → this source cannot supply a timestamp for this
+//	                     key (missing required field, server has no
+//	                     Last-Modified header, aquaClient is nil, etc).
+//	                     Callers MUST treat this as "gate disabled for
+//	                     this key", not an error — a single missing
+//	                     header must not block apply.
+//	ok=false, err!=nil → network / parse / HTTP-non-2xx failure. Callers
+//	                     decide whether to fail-closed (block install)
+//	                     or fail-open. The package does not retry.
+type Fetcher interface {
+	Fetch(ctx context.Context, key Key) (publishedAt time.Time, ok bool, err error)
+}
+
+// AquaReleaseClient is the subset of internal/registry/aqua.VersionClient
+// that the aqua backend needs. Declared as an interface so tests can
+// inject fakes without constructing a full VersionClient + HTTP client.
+type AquaReleaseClient interface {
+	GetReleaseByTag(ctx context.Context, owner, repo, tag string) (github.Release, error)
+}
+
+// Result is one element of a FetchAll batch result.
+type Result struct {
+	Key         Key
+	PublishedAt time.Time
+	OK          bool
+	Err         error
+}
+
+// Option configures the package's defaults via functional options.
+type Option func(*config)
+
+type config struct {
+	perRequestTimeout time.Duration
+	concurrency       int
+	batchTimeout      time.Duration
+	allowLoopback     bool // test-only escape; not exposed publicly
+}
+
+func defaultConfig() *config {
+	return &config{
+		perRequestTimeout: 10 * time.Second,
+		concurrency:       5,
+		batchTimeout:      60 * time.Second,
+	}
+}
+
+// WithPerRequestTimeout caps each individual HTTP fetch. The package
+// applies it via context.WithTimeout — the http.Client itself has no
+// Client.Timeout so the body read for Range-GET fallback is not cut
+// short separately. Non-positive values are ignored (default 10s).
+func WithPerRequestTimeout(d time.Duration) Option {
+	return func(c *config) {
+		if d > 0 {
+			c.perRequestTimeout = d
+		}
+	}
+}
+
+// WithConcurrency caps parallel fetches in FetchAll (default 5).
+// Non-positive values are ignored.
+func WithConcurrency(n int) Option {
+	return func(c *config) {
+		if n > 0 {
+			c.concurrency = n
+		}
+	}
+}
+
+// WithBatchTimeout sets the outer context.WithTimeout that FetchAll
+// applies to the whole batch (default 60s). Non-positive values are
+// ignored.
+func WithBatchTimeout(d time.Duration) Option {
+	return func(c *config) {
+		if d > 0 {
+			c.batchTimeout = d
+		}
+	}
+}
+
+// New returns a cached Fetcher that dispatches by Source.
+//
+// httpClient is used for SourceLastModified; pass nil to get a default
+// client with the package's SSRF-hardened CheckRedirect installed (HTTPS
+// only, no private/loopback/link-local/multicast/unspecified IPs, at
+// most 5 redirect hops). When a non-nil httpClient is supplied the
+// caller is responsible for installing equivalent guards.
+//
+// aquaClient is used for SourceAquaGitHubReleases; nil means the aqua
+// backend is disabled (its keys return ok=false, nil err).
+//
+// GitHub API rate limit: unauthenticated requests are capped at 60/h;
+// authenticated at 5000/h. For manifests with many aqua-installed tools,
+// set GITHUB_TOKEN (or GH_TOKEN) and build the aquaClient with
+// github.NewHTTPClient(github.TokenFromEnv()).
+//
+// Cache lifetime is the Fetcher instance. Callers should construct one
+// Fetcher per tomei plan/apply invocation and discard afterwards.
+// Errors are cached for invocation consistency (transient failures are
+// NOT retried within a single invocation).
+func New(aquaClient AquaReleaseClient, httpClient *http.Client, opts ...Option) Fetcher {
+	cfg := defaultConfig()
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	if httpClient == nil {
+		// No client-level Timeout (context controls deadline);
+		// CheckRedirect re-validates every hop and caps at 5.
+		httpClient = &http.Client{
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				if len(via) >= 5 {
+					return errors.New("stopped after 5 redirects")
+				}
+				return validateRedirectURL(req.URL, cfg.allowLoopback)
+			},
+		}
+	}
+	inner := &dispatchFetcher{
+		aqua:         &aquaFetcher{client: aquaClient},
+		lastModified: &lastModifiedFetcher{client: httpClient, timeout: cfg.perRequestTimeout, allowLoopback: cfg.allowLoopback},
+	}
+	return &cachedFetcher{inner: inner, cache: make(map[Key]cacheEntry), cfg: cfg}
+}
+
+// configurableFetcher is implemented by the Fetcher returned from New.
+// FetchAll uses it to honor options the caller set on the Fetcher
+// without requiring them to be re-passed. Custom Fetcher implementations
+// supplied to FetchAll fall back to defaults.
+type configurableFetcher interface {
+	Fetcher
+	config() *config
+}
+
+// batchConfigFrom returns a fresh config seeded from the Fetcher's own
+// configuration (if it carries one), so FetchAll honors options set at
+// New() time. The returned config is a copy — caller-supplied opts
+// override it without mutating the Fetcher.
+func batchConfigFrom(f Fetcher) *config {
+	if cf, ok := f.(configurableFetcher); ok {
+		c := *cf.config()
+		return &c
+	}
+	return defaultConfig()
+}
+
+// dispatchFetcher routes Fetch calls to the right backend by Source.
+type dispatchFetcher struct {
+	aqua         Fetcher
+	lastModified Fetcher
+}
+
+func (d *dispatchFetcher) Fetch(ctx context.Context, key Key) (time.Time, bool, error) {
+	switch key.Source {
+	case SourceAquaGitHubReleases:
+		return d.aqua.Fetch(ctx, key)
+	case SourceLastModified:
+		return d.lastModified.Fetch(ctx, key)
+	default:
+		return time.Time{}, false, nil
+	}
+}
+
+// FetchAll resolves every key in parallel, bounded by WithConcurrency
+// (default 5). The whole batch is wrapped in
+// context.WithTimeout(ctx, WithBatchTimeout) (default 60s). Results are
+// returned in the same order as keys; keys that couldn't acquire a
+// semaphore slot before ctx expired carry Err set to the ctx error.
+//
+// Options precedence: starts from the config the Fetcher was built with
+// (so options passed to New are honored without re-passing), then any
+// opts supplied here override per-call. Custom Fetcher implementations
+// that don't satisfy configurableFetcher start from package defaults.
+func FetchAll(ctx context.Context, f Fetcher, keys []Key, opts ...Option) []Result {
+	cfg := batchConfigFrom(f)
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	ctx, cancel := context.WithTimeout(ctx, cfg.batchTimeout)
+	defer cancel()
+
+	results := make([]Result, len(keys))
+	sem := semaphore.NewWeighted(int64(cfg.concurrency))
+	var wg sync.WaitGroup
+	for i, k := range keys {
+		if err := sem.Acquire(ctx, 1); err != nil {
+			results[i] = Result{Key: k, Err: err}
+			continue
+		}
+		wg.Add(1)
+		go func(i int, k Key) {
+			defer wg.Done()
+			defer sem.Release(1)
+			t, ok, err := f.Fetch(ctx, k)
+			results[i] = Result{Key: k, PublishedAt: t, OK: ok, Err: err}
+		}(i, k)
+	}
+	wg.Wait()
+	return results
+}

--- a/internal/age/age.go
+++ b/internal/age/age.go
@@ -6,9 +6,10 @@
 //
 //   - SourceAquaGitHubReleases — GitHub Releases API's published_at,
 //     consulted for tools installed via the builtin aqua installer.
-//   - SourceLastModified — HTTP Last-Modified header (with HEAD→GET Range
-//     fallback for servers that return 405/501 on HEAD), consulted for
-//     tools installed via the builtin download installer.
+//   - SourceLastModified — HTTP Last-Modified header (with a HEAD→GET
+//     Range fallback when HEAD returns 405/501, or succeeds but omits
+//     Last-Modified), consulted for tools installed via the builtin
+//     download installer.
 //
 // Tools installed via delegation (custom Installer or Runtime commands)
 // are out of scope here — issue #253 threads the duration string through

--- a/internal/age/age_test.go
+++ b/internal/age/age_test.go
@@ -1,0 +1,208 @@
+package age
+
+import (
+	"context"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// recordingFetcher remembers which Source it last saw, for dispatch tests.
+type recordingFetcher struct {
+	id      string // backend identifier, e.g. "aqua" or "lastmodified"
+	called  atomic.Pointer[string]
+	wantTS  time.Time
+	wantOK  bool
+	wantErr error
+}
+
+func (r *recordingFetcher) Fetch(_ context.Context, _ Key) (time.Time, bool, error) {
+	v := r.id
+	r.called.Store(&v)
+	return r.wantTS, r.wantOK, r.wantErr
+}
+
+func TestDispatchFetcher_RoutesBySource(t *testing.T) {
+	t.Parallel()
+	ts := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	aq := &recordingFetcher{id: "aqua", wantTS: ts, wantOK: true}
+	lm := &recordingFetcher{id: "lastmodified", wantTS: ts, wantOK: true}
+	d := &dispatchFetcher{aqua: aq, lastModified: lm}
+
+	if _, _, err := d.Fetch(context.Background(), Key{Source: SourceAquaGitHubReleases, Owner: "o", Repo: "r", Tag: "v1"}); err != nil {
+		t.Fatalf("aqua dispatch: %v", err)
+	}
+	if got := aq.called.Load(); got == nil || *got != "aqua" {
+		t.Errorf("aqua backend not invoked")
+	}
+	if got := lm.called.Load(); got != nil {
+		t.Errorf("lastmodified backend invoked for aqua key")
+	}
+
+	lm.called.Store(nil)
+	aq.called.Store(nil)
+	if _, _, err := d.Fetch(context.Background(), Key{Source: SourceLastModified, URL: "https://example.com"}); err != nil {
+		t.Fatalf("lastmodified dispatch: %v", err)
+	}
+	if got := lm.called.Load(); got == nil || *got != "lastmodified" {
+		t.Errorf("lastmodified backend not invoked")
+	}
+	if got := aq.called.Load(); got != nil {
+		t.Errorf("aqua backend invoked for lastmodified key")
+	}
+}
+
+func TestDispatchFetcher_UnknownSourceReturnsOKFalse(t *testing.T) {
+	t.Parallel()
+	d := &dispatchFetcher{
+		aqua:         &recordingFetcher{id: "aqua"},
+		lastModified: &recordingFetcher{id: "lastmodified"},
+	}
+	_, ok, err := d.Fetch(context.Background(), Key{Source: "weird"})
+	if ok || err != nil {
+		t.Errorf("unknown source should be (ok=false, nil); got ok=%v err=%v", ok, err)
+	}
+}
+
+func TestNew_AllNilStillBuildsFetcher(t *testing.T) {
+	t.Parallel()
+	f := New(nil, nil)
+	if f == nil {
+		t.Fatal("New(nil, nil) returned nil Fetcher")
+	}
+	// Aqua key → ok=false (aquaFetcher is built with nil client).
+	if _, ok, err := f.Fetch(context.Background(), Key{Source: SourceAquaGitHubReleases, Owner: "o", Repo: "r", Tag: "v1"}); ok || err != nil {
+		t.Errorf("aqua with nil client: got (ok=%v, err=%v), want (false, nil)", ok, err)
+	}
+	// LastModified key with empty URL → ok=false (early return before any
+	// network or SSRF gate runs). Confirms the default httpClient
+	// constructed inside New is wired into the lastModified backend.
+	if _, ok, err := f.Fetch(context.Background(), Key{Source: SourceLastModified, URL: ""}); ok || err != nil {
+		t.Errorf("lastModified with empty URL: got (ok=%v, err=%v), want (false, nil)", ok, err)
+	}
+}
+
+func TestFetchAll_EmptyKeys(t *testing.T) {
+	t.Parallel()
+	results := FetchAll(context.Background(), &fixedFetcher{ts: time.Now()}, nil)
+	if len(results) != 0 {
+		t.Errorf("len(results)=%d, want 0 for nil keys", len(results))
+	}
+	results = FetchAll(context.Background(), &fixedFetcher{ts: time.Now()}, []Key{})
+	if len(results) != 0 {
+		t.Errorf("len(results)=%d, want 0 for empty keys slice", len(results))
+	}
+}
+
+func TestFetchAll_HonorsOptionsFromNew(t *testing.T) {
+	t.Parallel()
+	// Options passed to New propagate to FetchAll via the cachedFetcher's
+	// stored config, so callers don't have to re-pass them at every
+	// FetchAll. A very small WithBatchTimeout makes the assertion
+	// trivially observable: a blocking fetcher exits via ctx.Err in
+	// well under the 60s default.
+	f := New(nil, nil, WithBatchTimeout(100*time.Millisecond))
+	// Replace the inner with a blocking fetcher so the timeout actually
+	// fires; this requires direct field access (same package).
+	cf := f.(*cachedFetcher)
+	cf.inner = &blockingFetcher{dur: 10 * time.Second}
+
+	start := time.Now()
+	results := FetchAll(context.Background(), f, []Key{
+		{Source: SourceLastModified, URL: numberedURL(0)},
+	})
+	elapsed := time.Since(start)
+	if elapsed > 2*time.Second {
+		t.Errorf("FetchAll took %v — WithBatchTimeout from New was not honored", elapsed)
+	}
+	if len(results) != 1 || results[0].Err == nil {
+		t.Errorf("expected one result with ctx error, got %+v", results)
+	}
+}
+
+func TestFetchAll_PreCanceledContext(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	keys := []Key{{Source: SourceLastModified, URL: numberedURL(0)}}
+	results := FetchAll(ctx, &fixedFetcher{ts: time.Now()}, keys)
+	if len(results) != 1 {
+		t.Fatalf("len(results)=%d, want 1", len(results))
+	}
+	if results[0].Err == nil {
+		t.Errorf("expected ctx error, got nil")
+	}
+}
+
+// fixedFetcher returns the same triple for every key. Used as the inner
+// Fetcher in FetchAll tests where we just want the batch mechanics
+// exercised, not per-Source dispatch.
+type fixedFetcher struct {
+	ts time.Time
+}
+
+func (f *fixedFetcher) Fetch(_ context.Context, _ Key) (time.Time, bool, error) {
+	return f.ts, true, nil
+}
+
+func TestFetchAll_PreservesOrder(t *testing.T) {
+	t.Parallel()
+	ts := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	keys := make([]Key, 20)
+	for i := range keys {
+		keys[i] = Key{Source: SourceLastModified, URL: numberedURL(i)}
+	}
+	results := FetchAll(context.Background(), &fixedFetcher{ts: ts}, keys, WithConcurrency(5))
+	if len(results) != len(keys) {
+		t.Fatalf("len(results)=%d, want %d", len(results), len(keys))
+	}
+	for i := range keys {
+		if results[i].Key != keys[i] {
+			t.Errorf("results[%d].Key=%v, want %v", i, results[i].Key, keys[i])
+		}
+		if !results[i].PublishedAt.Equal(ts) || !results[i].OK || results[i].Err != nil {
+			t.Errorf("results[%d] = %+v", i, results[i])
+		}
+	}
+}
+
+func numberedURL(i int) string {
+	return "https://example.com/k" + strconv.Itoa(i)
+}
+
+// blockingFetcher sleeps for `dur` to simulate slow upstream; lets us
+// prove FetchAll's batch timeout actually cancels in-flight goroutines.
+type blockingFetcher struct {
+	dur time.Duration
+}
+
+func (b *blockingFetcher) Fetch(ctx context.Context, _ Key) (time.Time, bool, error) {
+	select {
+	case <-time.After(b.dur):
+		return time.Time{}, false, nil
+	case <-ctx.Done():
+		return time.Time{}, false, ctx.Err()
+	}
+}
+
+func TestFetchAll_BatchTimeoutCancelsInFlight(t *testing.T) {
+	t.Parallel()
+	keys := make([]Key, 5)
+	for i := range keys {
+		keys[i] = Key{Source: SourceLastModified, URL: numberedURL(i)}
+	}
+	start := time.Now()
+	results := FetchAll(context.Background(), &blockingFetcher{dur: 10 * time.Second}, keys,
+		WithConcurrency(2),
+		WithBatchTimeout(100*time.Millisecond))
+	elapsed := time.Since(start)
+	if elapsed > 2*time.Second {
+		t.Errorf("batch took %v, expected ~100ms — timeout did not cancel in-flight", elapsed)
+	}
+	for i, r := range results {
+		if r.Err == nil {
+			t.Errorf("results[%d].Err == nil, expected ctx error after timeout", i)
+		}
+	}
+}

--- a/internal/age/aqua.go
+++ b/internal/age/aqua.go
@@ -1,0 +1,30 @@
+package age
+
+import (
+	"context"
+	"time"
+)
+
+// aquaFetcher resolves SourceAquaGitHubReleases keys via the GitHub
+// Releases API published_at field. A nil client disables the backend
+// (all aqua keys return ok=false, nil).
+type aquaFetcher struct {
+	client AquaReleaseClient
+}
+
+func (a *aquaFetcher) Fetch(ctx context.Context, key Key) (time.Time, bool, error) {
+	if a.client == nil || key.Source != SourceAquaGitHubReleases {
+		return time.Time{}, false, nil
+	}
+	if key.Owner == "" || key.Repo == "" || key.Tag == "" {
+		return time.Time{}, false, nil
+	}
+	rel, err := a.client.GetReleaseByTag(ctx, key.Owner, key.Repo, key.Tag)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	if rel.PublishedAt.IsZero() {
+		return time.Time{}, false, nil
+	}
+	return rel.PublishedAt, true, nil
+}

--- a/internal/age/aqua_test.go
+++ b/internal/age/aqua_test.go
@@ -1,0 +1,109 @@
+package age
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/terassyi/tomei/internal/github"
+)
+
+// fakeAquaClient is a tests-only AquaReleaseClient that returns a
+// preset response without touching the network.
+type fakeAquaClient struct {
+	release github.Release
+	err     error
+	calls   int
+}
+
+func (f *fakeAquaClient) GetReleaseByTag(_ context.Context, _, _, _ string) (github.Release, error) {
+	f.calls++
+	if f.err != nil {
+		return github.Release{}, f.err
+	}
+	return f.release, nil
+}
+
+func TestAquaFetcher_Fetch(t *testing.T) {
+	t.Parallel()
+	ts := time.Date(2024, 9, 13, 15, 42, 8, 0, time.UTC)
+
+	tests := []struct {
+		name    string
+		client  AquaReleaseClient
+		key     Key
+		wantOK  bool
+		wantAt  time.Time
+		wantErr bool
+	}{
+		{
+			name:   "valid response propagates published_at",
+			client: &fakeAquaClient{release: github.Release{TagName: "v1.2.3", PublishedAt: ts}},
+			key:    Key{Source: SourceAquaGitHubReleases, Owner: "o", Repo: "r", Tag: "v1.2.3"},
+			wantOK: true,
+			wantAt: ts,
+		},
+		{
+			name:   "nil client disables the backend (ok=false, nil)",
+			client: nil,
+			key:    Key{Source: SourceAquaGitHubReleases, Owner: "o", Repo: "r", Tag: "v1.2.3"},
+		},
+		{
+			name:   "wrong source returns ok=false nil",
+			client: &fakeAquaClient{},
+			key:    Key{Source: SourceLastModified, URL: "https://example.com"},
+		},
+		{
+			name:   "empty Tag returns ok=false nil",
+			client: &fakeAquaClient{release: github.Release{TagName: "v1", PublishedAt: ts}},
+			key:    Key{Source: SourceAquaGitHubReleases, Owner: "o", Repo: "r"},
+		},
+		{
+			name:   "empty Owner returns ok=false nil",
+			client: &fakeAquaClient{release: github.Release{TagName: "v1", PublishedAt: ts}},
+			key:    Key{Source: SourceAquaGitHubReleases, Repo: "r", Tag: "v1"},
+		},
+		{
+			name:   "empty Repo returns ok=false nil",
+			client: &fakeAquaClient{release: github.Release{TagName: "v1", PublishedAt: ts}},
+			key:    Key{Source: SourceAquaGitHubReleases, Owner: "o", Tag: "v1"},
+		},
+		{
+			name:    "GetReleaseByTag error surfaces",
+			client:  &fakeAquaClient{err: errors.New("404 not found")},
+			key:     Key{Source: SourceAquaGitHubReleases, Owner: "o", Repo: "r", Tag: "v1"},
+			wantErr: true,
+		},
+		{
+			name:   "zero PublishedAt is treated as ok=false nil",
+			client: &fakeAquaClient{release: github.Release{TagName: "v1"}}, // PublishedAt zero
+			key:    Key{Source: SourceAquaGitHubReleases, Owner: "o", Repo: "r", Tag: "v1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			f := &aquaFetcher{client: tt.client}
+			got, ok, err := f.Fetch(context.Background(), tt.key)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if ok {
+					t.Errorf("expected ok=false on error, got true")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ok != tt.wantOK {
+				t.Errorf("ok=%v, want %v", ok, tt.wantOK)
+			}
+			if !got.Equal(tt.wantAt) {
+				t.Errorf("publishedAt=%v, want %v", got, tt.wantAt)
+			}
+		})
+	}
+}

--- a/internal/age/cache.go
+++ b/internal/age/cache.go
@@ -1,0 +1,70 @@
+package age
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+// cachedFetcher wraps another Fetcher with an in-memory result cache
+// (keyed by Key) plus a singleflight.Group so concurrent calls for the
+// same key dedupe to one inner Fetch. Cache lifetime is the wrapper's
+// lifetime — one tomei plan/apply invocation creates one cachedFetcher
+// and discards it afterwards.
+//
+// Errors are cached: a transient network failure on first lookup is
+// returned for every subsequent call to that key in the same
+// invocation. This is intentional — callers expect invocation-local
+// consistency, and the package does not retry.
+type cachedFetcher struct {
+	inner Fetcher
+	mu    sync.Mutex
+	cache map[Key]cacheEntry
+	sf    singleflight.Group
+	cfg   *config // captured from New; surfaced via config() for FetchAll
+}
+
+// config returns the configuration captured at New() time. FetchAll
+// uses this to honor options the caller set on the Fetcher (notably
+// WithConcurrency and WithBatchTimeout) without requiring them to be
+// re-passed.
+func (c *cachedFetcher) config() *config { return c.cfg }
+
+type cacheEntry struct {
+	publishedAt time.Time
+	ok          bool
+	err         error
+}
+
+func (c *cachedFetcher) Fetch(ctx context.Context, key Key) (time.Time, bool, error) {
+	c.mu.Lock()
+	if e, found := c.cache[key]; found {
+		c.mu.Unlock()
+		return e.publishedAt, e.ok, e.err
+	}
+	c.mu.Unlock()
+
+	// Concurrent calls for the same key dedupe to one inner Fetch.
+	type sfResult struct {
+		publishedAt time.Time
+		ok          bool
+	}
+	v, fetchErr, _ := c.sf.Do(keyString(key), func() (any, error) {
+		t, ok, e := c.inner.Fetch(ctx, key)
+		c.mu.Lock()
+		c.cache[key] = cacheEntry{publishedAt: t, ok: ok, err: e}
+		c.mu.Unlock()
+		return sfResult{publishedAt: t, ok: ok}, e
+	})
+	r := v.(sfResult)
+	return r.publishedAt, r.ok, fetchErr
+}
+
+// keyString builds the singleflight dedup key. Doesn't have to be
+// human-readable, only unique per Key value.
+func keyString(k Key) string {
+	return fmt.Sprintf("%s|%s|%s|%s|%s", k.Source, k.Owner, k.Repo, k.Tag, k.URL)
+}

--- a/internal/age/cache.go
+++ b/internal/age/cache.go
@@ -2,6 +2,7 @@ package age
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -18,7 +19,11 @@ import (
 // Errors are cached: a transient network failure on first lookup is
 // returned for every subsequent call to that key in the same
 // invocation. This is intentional — callers expect invocation-local
-// consistency, and the package does not retry.
+// consistency, and the package does not retry. The one exception is
+// context cancellation/timeout: those are caller-driven and per-call,
+// not upstream-derived, so they are not memoized (otherwise one batch
+// timeout would poison the key for every later lookup, even under a
+// fresh context).
 type cachedFetcher struct {
 	inner Fetcher
 	mu    sync.Mutex
@@ -57,9 +62,15 @@ func (c *cachedFetcher) Fetch(ctx context.Context, key Key) (time.Time, bool, er
 	// select below, instead of blocking until that shared fetch returns.
 	ch := c.sf.DoChan(keyString(key), func() (any, error) {
 		t, ok, e := c.inner.Fetch(ctx, key)
-		c.mu.Lock()
-		c.cache[key] = cacheEntry{publishedAt: t, ok: ok, err: e}
-		c.mu.Unlock()
+		// Don't memoize context cancellation/timeout — those are
+		// caller-driven and per-call, so caching them would poison the
+		// key for the rest of the invocation. Only upstream-derived
+		// results/errors are cached.
+		if !errors.Is(e, context.Canceled) && !errors.Is(e, context.DeadlineExceeded) {
+			c.mu.Lock()
+			c.cache[key] = cacheEntry{publishedAt: t, ok: ok, err: e}
+			c.mu.Unlock()
+		}
 		return sfResult{publishedAt: t, ok: ok}, e
 	})
 	select {

--- a/internal/age/cache.go
+++ b/internal/age/cache.go
@@ -52,15 +52,23 @@ func (c *cachedFetcher) Fetch(ctx context.Context, key Key) (time.Time, bool, er
 		publishedAt time.Time
 		ok          bool
 	}
-	v, fetchErr, _ := c.sf.Do(keyString(key), func() (any, error) {
+	// DoChan (not Do) so a caller whose ctx is canceled while waiting on
+	// another goroutine's in-flight fetch can abort promptly via the
+	// select below, instead of blocking until that shared fetch returns.
+	ch := c.sf.DoChan(keyString(key), func() (any, error) {
 		t, ok, e := c.inner.Fetch(ctx, key)
 		c.mu.Lock()
 		c.cache[key] = cacheEntry{publishedAt: t, ok: ok, err: e}
 		c.mu.Unlock()
 		return sfResult{publishedAt: t, ok: ok}, e
 	})
-	r := v.(sfResult)
-	return r.publishedAt, r.ok, fetchErr
+	select {
+	case <-ctx.Done():
+		return time.Time{}, false, ctx.Err()
+	case res := <-ch:
+		r := res.Val.(sfResult)
+		return r.publishedAt, r.ok, res.Err
+	}
 }
 
 // keyString builds the singleflight dedup key. Doesn't have to be

--- a/internal/age/cache.go
+++ b/internal/age/cache.go
@@ -83,7 +83,10 @@ func (c *cachedFetcher) Fetch(ctx context.Context, key Key) (time.Time, bool, er
 }
 
 // keyString builds the singleflight dedup key. Doesn't have to be
-// human-readable, only unique per Key value.
+// human-readable, only unique per Key value. Fields are %q-quoted (not
+// plain "|"-joined) so a "|" embedded in any field — git tags and URLs
+// can contain one — can't make two distinct Keys collide onto the same
+// dedup string.
 func keyString(k Key) string {
-	return fmt.Sprintf("%s|%s|%s|%s|%s", k.Source, k.Owner, k.Repo, k.Tag, k.URL)
+	return fmt.Sprintf("%q|%q|%q|%q|%q", k.Source, k.Owner, k.Repo, k.Tag, k.URL)
 }

--- a/internal/age/cache_test.go
+++ b/internal/age/cache_test.go
@@ -1,0 +1,134 @@
+package age
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// countingFetcher records how many times Fetch was invoked; useful to
+// prove the cache + singleflight dedup work.
+//
+// entered, when non-nil, receives a value the first time Fetch runs.
+// Combined with `block`, this lets concurrency tests wait until the
+// inner Fetch is provably in-flight (avoiding a flaky time.Sleep).
+type countingFetcher struct {
+	calls   atomic.Int64
+	ts      time.Time
+	ok      bool
+	err     error
+	block   chan struct{} // optional gate to hold goroutines in singleflight
+	entered chan struct{} // optional: closed (via sync.Once) when first Fetch enters
+	once    sync.Once
+}
+
+func (f *countingFetcher) Fetch(_ context.Context, _ Key) (time.Time, bool, error) {
+	f.calls.Add(1)
+	if f.entered != nil {
+		f.once.Do(func() { close(f.entered) })
+	}
+	if f.block != nil {
+		<-f.block
+	}
+	return f.ts, f.ok, f.err
+}
+
+func TestCachedFetcher_SameKeyHitsCache(t *testing.T) {
+	t.Parallel()
+	want := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	cf := &countingFetcher{ts: want, ok: true}
+	c := &cachedFetcher{inner: cf, cache: make(map[Key]cacheEntry)}
+	k := Key{Source: SourceLastModified, URL: "https://example.com/a"}
+
+	for i := range 3 {
+		got, ok, err := c.Fetch(context.Background(), k)
+		if err != nil || !ok || !got.Equal(want) {
+			t.Fatalf("iter %d: got (%v,%v,%v)", i, got, ok, err)
+		}
+	}
+	if got := cf.calls.Load(); got != 1 {
+		t.Errorf("inner Fetch called %d times, want 1", got)
+	}
+}
+
+func TestCachedFetcher_DifferentKeysAreSeparate(t *testing.T) {
+	t.Parallel()
+	cf := &countingFetcher{ts: time.Now(), ok: true}
+	c := &cachedFetcher{inner: cf, cache: make(map[Key]cacheEntry)}
+	keys := []Key{
+		{Source: SourceLastModified, URL: "https://example.com/a"},
+		{Source: SourceLastModified, URL: "https://example.com/b"},
+		{Source: SourceAquaGitHubReleases, Owner: "o", Repo: "r", Tag: "v1"},
+	}
+	for _, k := range keys {
+		if _, _, err := c.Fetch(context.Background(), k); err != nil {
+			t.Fatalf("Fetch %v: %v", k, err)
+		}
+	}
+	if got := cf.calls.Load(); got != int64(len(keys)) {
+		t.Errorf("inner Fetch called %d times, want %d", got, len(keys))
+	}
+}
+
+func TestCachedFetcher_SingleflightDedupsConcurrent(t *testing.T) {
+	t.Parallel()
+	cf := &countingFetcher{
+		ts:      time.Now(),
+		ok:      true,
+		block:   make(chan struct{}),
+		entered: make(chan struct{}),
+	}
+	c := &cachedFetcher{inner: cf, cache: make(map[Key]cacheEntry)}
+	k := Key{Source: SourceLastModified, URL: "https://example.com/x"}
+
+	// Start gate: line up all N goroutines so they race together
+	// instead of trickling in over time. Combined with the `entered`
+	// channel + a brief grace period after, this gives N-1 stragglers
+	// time to queue inside singleflight.Do before the first goroutine
+	// completes its inner Fetch and populates the cache.
+	const N = 100
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for range N {
+		go func() {
+			defer wg.Done()
+			<-start
+			_, _, _ = c.Fetch(context.Background(), k)
+		}()
+	}
+	close(start)
+
+	<-cf.entered
+	// Without this short grace period, stragglers could arrive at sf.Do
+	// after the first goroutine returns, missing the in-flight dedup
+	// and the populated cache (a narrow race observed under -race on
+	// fast hardware). 20ms is comfortably above scheduler latency.
+	time.Sleep(20 * time.Millisecond)
+	close(cf.block)
+	wg.Wait()
+
+	if got := cf.calls.Load(); got != 1 {
+		t.Errorf("inner Fetch called %d times under singleflight, want 1", got)
+	}
+}
+
+func TestCachedFetcher_ErrorsAreCached(t *testing.T) {
+	t.Parallel()
+	cf := &countingFetcher{err: errors.New("transient")}
+	c := &cachedFetcher{inner: cf, cache: make(map[Key]cacheEntry)}
+	k := Key{Source: SourceLastModified, URL: "https://example.com/e"}
+
+	for i := range 3 {
+		_, _, err := c.Fetch(context.Background(), k)
+		if err == nil {
+			t.Fatalf("iter %d: expected error, got nil", i)
+		}
+	}
+	if got := cf.calls.Load(); got != 1 {
+		t.Errorf("inner Fetch called %d times, want 1 (error must cache)", got)
+	}
+}

--- a/internal/age/cache_test.go
+++ b/internal/age/cache_test.go
@@ -116,6 +116,53 @@ func TestCachedFetcher_SingleflightDedupsConcurrent(t *testing.T) {
 	}
 }
 
+func TestCachedFetcher_WaiterAbortsOnContextCancel(t *testing.T) {
+	t.Parallel()
+	cf := &countingFetcher{
+		ts:      time.Now(),
+		ok:      true,
+		block:   make(chan struct{}),
+		entered: make(chan struct{}),
+	}
+	c := &cachedFetcher{inner: cf, cache: make(map[Key]cacheEntry)}
+	k := Key{Source: SourceLastModified, URL: "https://example.com/y"}
+
+	// Leader: occupies singleflight, blocked inside inner Fetch.
+	leaderDone := make(chan struct{})
+	go func() {
+		defer close(leaderDone)
+		_, _, _ = c.Fetch(context.Background(), k)
+	}()
+	<-cf.entered // leader is now provably in-flight
+
+	// Waiter: same key, so it dedupes onto the leader's in-flight fetch.
+	// Its ctx is canceled while waiting; it must return promptly with
+	// ctx.Err() instead of blocking until the leader's fetch completes.
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, _, err := c.Fetch(ctx, k)
+		errCh <- err
+	}()
+	// Give the waiter a moment to queue on DoChan, then cancel. The leader
+	// is still blocked, so a Do-based impl would hang here until timeout.
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("waiter err = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiter did not abort promptly on ctx cancel")
+	}
+
+	// Release the leader and let it finish cleanly.
+	close(cf.block)
+	<-leaderDone
+}
+
 func TestCachedFetcher_ErrorsAreCached(t *testing.T) {
 	t.Parallel()
 	cf := &countingFetcher{err: errors.New("transient")}

--- a/internal/age/cache_test.go
+++ b/internal/age/cache_test.go
@@ -200,6 +200,27 @@ func TestCachedFetcher_WaiterAbortsOnContextCancel(t *testing.T) {
 	<-leaderDone
 }
 
+func TestCachedFetcher_PipeInFieldDoesNotCollide(t *testing.T) {
+	t.Parallel()
+	// Two distinct keys whose fields would produce the same plain
+	// "|"-joined string ("a|b" vs "a"+"|b"). They must NOT dedupe onto
+	// one inner Fetch, i.e. keyString must keep them distinct.
+	cf := &countingFetcher{ts: time.Now(), ok: true}
+	c := &cachedFetcher{inner: cf, cache: make(map[Key]cacheEntry)}
+	k1 := Key{Source: SourceLastModified, URL: "a|b"}
+	k2 := Key{Source: SourceLastModified, Tag: "a", URL: "b"}
+
+	if _, _, err := c.Fetch(context.Background(), k1); err != nil {
+		t.Fatalf("Fetch k1: %v", err)
+	}
+	if _, _, err := c.Fetch(context.Background(), k2); err != nil {
+		t.Fatalf("Fetch k2: %v", err)
+	}
+	if got := cf.calls.Load(); got != 2 {
+		t.Errorf("inner Fetch called %d times, want 2 (keys must not collide)", got)
+	}
+}
+
 func TestCachedFetcher_ErrorsAreCached(t *testing.T) {
 	t.Parallel()
 	cf := &countingFetcher{err: errors.New("transient")}

--- a/internal/age/cache_test.go
+++ b/internal/age/cache_test.go
@@ -116,6 +116,43 @@ func TestCachedFetcher_SingleflightDedupsConcurrent(t *testing.T) {
 	}
 }
 
+// flakyFetcher returns errFirst on its first call and (ts, true, nil)
+// on every call after, so a test can prove whether the first result was
+// memoized (one call) or not (two calls).
+type flakyFetcher struct {
+	calls    atomic.Int64
+	errFirst error
+	ts       time.Time
+}
+
+func (f *flakyFetcher) Fetch(_ context.Context, _ Key) (time.Time, bool, error) {
+	if f.calls.Add(1) == 1 {
+		return time.Time{}, false, f.errFirst
+	}
+	return f.ts, true, nil
+}
+
+func TestCachedFetcher_ContextErrorsAreNotCached(t *testing.T) {
+	t.Parallel()
+	want := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	// First lookup fails with a context error; it must NOT be memoized,
+	// so a later lookup (fresh ctx) re-invokes inner and can succeed.
+	cf := &flakyFetcher{errFirst: context.DeadlineExceeded, ts: want}
+	c := &cachedFetcher{inner: cf, cache: make(map[Key]cacheEntry)}
+	k := Key{Source: SourceLastModified, URL: "https://example.com/ctx"}
+
+	if _, _, err := c.Fetch(context.Background(), k); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("first call err = %v, want DeadlineExceeded", err)
+	}
+	got, ok, err := c.Fetch(context.Background(), k)
+	if err != nil || !ok || !got.Equal(want) {
+		t.Fatalf("second call = (%v,%v,%v), want (%v,true,nil)", got, ok, err, want)
+	}
+	if n := cf.calls.Load(); n != 2 {
+		t.Errorf("inner Fetch called %d times, want 2 (ctx error must not cache)", n)
+	}
+}
+
 func TestCachedFetcher_WaiterAbortsOnContextCancel(t *testing.T) {
 	t.Parallel()
 	cf := &countingFetcher{

--- a/internal/age/lastmodified.go
+++ b/internal/age/lastmodified.go
@@ -14,7 +14,8 @@ import (
 
 // lastModifiedFetcher resolves SourceLastModified keys by HEAD'ing the
 // URL and reading the Last-Modified header. Falls back to a 1-byte
-// Range GET if the server returns 405 or 501.
+// Range GET when the HEAD returns 405/501, or succeeds (2xx) but omits
+// the Last-Modified header — some CDNs only emit it on body responses.
 type lastModifiedFetcher struct {
 	client        *http.Client
 	timeout       time.Duration

--- a/internal/age/lastmodified.go
+++ b/internal/age/lastmodified.go
@@ -1,0 +1,163 @@
+package age
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// lastModifiedFetcher resolves SourceLastModified keys by HEAD'ing the
+// URL and reading the Last-Modified header. Falls back to a 1-byte
+// Range GET if the server returns 405 or 501.
+type lastModifiedFetcher struct {
+	client        *http.Client
+	timeout       time.Duration
+	allowLoopback bool // test-only
+}
+
+// httpStatusError carries the HTTP status code from a non-2xx response
+// so callers can match on specific codes via errors.As. Used to
+// distinguish 405/501 (HEAD-not-supported, retry with GET) from other
+// failure modes that should propagate as-is.
+type httpStatusError struct{ Code int }
+
+func (e *httpStatusError) Error() string { return fmt.Sprintf("http %d", e.Code) }
+
+func (l *lastModifiedFetcher) Fetch(ctx context.Context, key Key) (time.Time, bool, error) {
+	if key.Source != SourceLastModified || key.URL == "" {
+		return time.Time{}, false, nil
+	}
+	// Entry SSRF gate — runs BEFORE any socket is opened. The
+	// http.Client's CheckRedirect covers redirect targets but the
+	// initial URL also needs to pass.
+	u, err := url.Parse(key.URL)
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("parse %q: %w", key.URL, err)
+	}
+	if err := validateRedirectURL(u, l.allowLoopback); err != nil {
+		return time.Time{}, false, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, l.timeout)
+	defer cancel()
+
+	// 1) HEAD
+	t, headErr := tryLastModified(ctx, l.client, http.MethodHead, key.URL, nil)
+	if headErr == nil && !t.IsZero() {
+		return t, true, nil
+	}
+	var herr *httpStatusError
+	switch {
+	case headErr != nil && !errors.As(headErr, &herr):
+		// Network / parse failure — surface as-is.
+		return time.Time{}, false, headErr
+	case headErr != nil && herr.Code != http.StatusMethodNotAllowed && herr.Code != http.StatusNotImplemented:
+		// Other 4xx/5xx — propagate.
+		return time.Time{}, false, headErr
+	}
+	// headErr is either nil (HEAD 2xx but no Last-Modified header) or
+	// 405/501. Either way try the Range GET — some CDNs only emit
+	// Last-Modified on body responses.
+	t, getErr := tryLastModified(ctx, l.client, http.MethodGet, key.URL,
+		http.Header{"Range": []string{"bytes=0-0"}})
+	if getErr != nil {
+		return time.Time{}, false, getErr
+	}
+	if t.IsZero() {
+		return time.Time{}, false, nil
+	}
+	return t, true, nil
+}
+
+// tryLastModified issues one HTTP request and extracts Last-Modified.
+// Returns the parsed time + nil err on a 2xx/206 response with a
+// well-formed header. Returns zero time + nil err on a 2xx/206 with no
+// Last-Modified (caller decides whether to retry with a different
+// method). Returns a wrapped *httpStatusError on any non-2xx/206 status.
+func tryLastModified(ctx context.Context, client *http.Client, method, rawURL string, hdr http.Header) (time.Time, error) {
+	req, err := http.NewRequestWithContext(ctx, method, rawURL, nil)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("create request: %w", err)
+	}
+	// maps.Copy preserves all values per key (Set + nested loop would
+	// silently drop all but the last; direct map assignment is what the
+	// modernize linter prefers via this helper). Today only
+	// Range: bytes=0-0 is sent, so it's effectively a single-key set.
+	maps.Copy(req.Header, hdr)
+	resp, err := client.Do(req)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("%s %s: %w", method, rawURL, err)
+	}
+	defer func() {
+		// Drain a small amount so the conn can be reused for Range GET
+		// fallback; ignore errors (we only care about headers).
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 64))
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
+		return time.Time{}, &httpStatusError{Code: resp.StatusCode}
+	}
+	lm := resp.Header.Get("Last-Modified")
+	if lm == "" {
+		return time.Time{}, nil
+	}
+	t, perr := http.ParseTime(lm)
+	if perr != nil {
+		return time.Time{}, fmt.Errorf("parse Last-Modified %q: %w", lm, perr)
+	}
+	return t, nil
+}
+
+// validateRedirectURL enforces the package's SSRF policy: HTTPS scheme
+// only, and reject IP literals that point at private / loopback /
+// link-local / multicast / unspecified ranges. DNS names are passed
+// through (no resolution — avoids TOCTOU and the latency of an extra
+// DNS round-trip; CUE manifests are trusted as the security boundary).
+//
+// Called both at the entry of lastModifiedFetcher.Fetch and from the
+// http.Client.CheckRedirect installed by New(). Single source of truth
+// for the gate.
+//
+// allowLoopback is set only by the test-only withAllowLoopback option
+// so httptest.NewTLSServer (which binds to 127.0.0.1) can be exercised
+// by happy-path tests. Production code paths never set it.
+func validateRedirectURL(u *url.URL, allowLoopback bool) error {
+	if u == nil {
+		return errors.New("nil url")
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("non-https scheme %q rejected", u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return errors.New("empty host")
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		// DNS name — pass through.
+		return nil
+	}
+	if allowLoopback && ip.IsLoopback() {
+		return nil
+	}
+	switch {
+	case ip.IsPrivate():
+		return fmt.Errorf("private IP %s rejected", ip)
+	case ip.IsLoopback():
+		return fmt.Errorf("loopback IP %s rejected", ip)
+	case ip.IsLinkLocalUnicast():
+		return fmt.Errorf("link-local IP %s rejected", ip)
+	case ip.IsMulticast():
+		return fmt.Errorf("multicast IP %s rejected", ip)
+	case ip.IsUnspecified():
+		return fmt.Errorf("unspecified IP %s rejected", ip)
+	}
+	return nil
+}

--- a/internal/age/lastmodified_test.go
+++ b/internal/age/lastmodified_test.go
@@ -1,0 +1,226 @@
+package age
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func mustURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse %q: %v", raw, err)
+	}
+	return u
+}
+
+func TestValidateRedirectURL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		raw     string
+		wantErr bool
+		errSub  string
+	}{
+		// Rejected — non-HTTPS / private / loopback / link-local / multicast / unspecified.
+		{raw: "http://example.com", wantErr: true, errSub: "non-https"},
+		{raw: "https://192.168.0.1", wantErr: true, errSub: "private"},
+		{raw: "https://10.0.0.1", wantErr: true, errSub: "private"},
+		{raw: "https://172.16.0.1", wantErr: true, errSub: "private"},
+		{raw: "https://127.0.0.1", wantErr: true, errSub: "loopback"},
+		{raw: "https://169.254.0.1", wantErr: true, errSub: "link-local"},
+		{raw: "https://224.0.0.1", wantErr: true, errSub: "multicast"},
+		{raw: "https://0.0.0.0", wantErr: true, errSub: "unspecified"},
+		{raw: "https://[::1]", wantErr: true, errSub: "loopback"},
+		{raw: "https://[fe80::1]", wantErr: true, errSub: "link-local"},
+		{raw: "https://[fc00::1]", wantErr: true, errSub: "private"},
+		{raw: "https://[ff02::1]", wantErr: true, errSub: "multicast"},
+		// Allowed — public IP, public DNS name.
+		{raw: "https://example.com"},
+		{raw: "https://8.8.8.8"},
+		{raw: "https://api.github.com/repos/x/y/releases/tags/v1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			t.Parallel()
+			err := validateRedirectURL(mustURL(t, tt.raw), false)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.errSub)
+				}
+				if !strings.Contains(err.Error(), tt.errSub) {
+					t.Errorf("err=%q, want containing %q", err, tt.errSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateRedirectURL_AllowLoopback(t *testing.T) {
+	t.Parallel()
+	// With allowLoopback=true (test-only escape), 127.0.0.1 / [::1] pass.
+	for _, raw := range []string{"https://127.0.0.1", "https://[::1]"} {
+		if err := validateRedirectURL(mustURL(t, raw), true); err != nil {
+			t.Errorf("%s should be allowed with loopback escape: %v", raw, err)
+		}
+	}
+	// allowLoopback does NOT bypass other rejections.
+	if err := validateRedirectURL(mustURL(t, "https://192.168.0.1"), true); err == nil {
+		t.Errorf("private IP must still be rejected even with allowLoopback")
+	}
+}
+
+// lastModifiedFetcherForTest constructs a fetcher pointed at a TLS test
+// server: uses the server's TLS-trusting client and allows loopback.
+func lastModifiedFetcherForTest(srv *httptest.Server) *lastModifiedFetcher {
+	return &lastModifiedFetcher{
+		client:        srv.Client(),
+		timeout:       5 * time.Second,
+		allowLoopback: true,
+	}
+}
+
+const fixedLastModified = "Wed, 21 Oct 2015 07:28:00 GMT"
+
+func mustParse(t *testing.T, layout, s string) time.Time {
+	t.Helper()
+	v, err := time.Parse(layout, s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return v
+}
+
+func TestLastModifiedFetcher_Fetch(t *testing.T) {
+	t.Parallel()
+	want := mustParse(t, http.TimeFormat, fixedLastModified)
+
+	t.Run("HEAD 200 with Last-Modified", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodHead {
+				t.Errorf("expected HEAD, got %s", r.Method)
+			}
+			w.Header().Set("Last-Modified", fixedLastModified)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+		f := lastModifiedFetcherForTest(srv)
+		got, ok, err := f.Fetch(context.Background(), Key{Source: SourceLastModified, URL: srv.URL})
+		if err != nil || !ok || !got.Equal(want) {
+			t.Errorf("got (%v,%v,%v), want (%v, true, nil)", got, ok, err, want)
+		}
+	})
+
+	t.Run("HEAD 405 → GET Range fallback", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodHead {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			w.Header().Set("Last-Modified", fixedLastModified)
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte{0})
+		}))
+		defer srv.Close()
+		f := lastModifiedFetcherForTest(srv)
+		got, ok, err := f.Fetch(context.Background(), Key{Source: SourceLastModified, URL: srv.URL})
+		if err != nil || !ok || !got.Equal(want) {
+			t.Errorf("got (%v,%v,%v), want (%v, true, nil)", got, ok, err, want)
+		}
+	})
+
+	t.Run("HEAD 501 → GET Range fallback", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodHead {
+				w.WriteHeader(http.StatusNotImplemented)
+				return
+			}
+			w.Header().Set("Last-Modified", fixedLastModified)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+		f := lastModifiedFetcherForTest(srv)
+		_, ok, err := f.Fetch(context.Background(), Key{Source: SourceLastModified, URL: srv.URL})
+		if err != nil || !ok {
+			t.Errorf("expected fallback success, got err=%v ok=%v", err, ok)
+		}
+	})
+
+	t.Run("HEAD 200 no header → GET fallback also no header", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+		f := lastModifiedFetcherForTest(srv)
+		_, ok, err := f.Fetch(context.Background(), Key{Source: SourceLastModified, URL: srv.URL})
+		if err != nil || ok {
+			t.Errorf("expected (ok=false, nil), got ok=%v err=%v", ok, err)
+		}
+	})
+
+	t.Run("HEAD 500 surfaces error", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+		f := lastModifiedFetcherForTest(srv)
+		_, ok, err := f.Fetch(context.Background(), Key{Source: SourceLastModified, URL: srv.URL})
+		if err == nil || ok {
+			t.Errorf("expected (false, err), got ok=%v err=%v", ok, err)
+		}
+	})
+
+	t.Run("malformed Last-Modified value returns error", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Last-Modified", "garbage")
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+		f := lastModifiedFetcherForTest(srv)
+		_, ok, err := f.Fetch(context.Background(), Key{Source: SourceLastModified, URL: srv.URL})
+		if err == nil || ok {
+			t.Errorf("expected (false, err), got ok=%v err=%v", ok, err)
+		}
+	})
+
+	t.Run("empty URL returns ok=false nil", func(t *testing.T) {
+		t.Parallel()
+		f := &lastModifiedFetcher{client: http.DefaultClient}
+		_, ok, err := f.Fetch(context.Background(), Key{Source: SourceLastModified})
+		if err != nil || ok {
+			t.Errorf("expected (false, nil), got ok=%v err=%v", ok, err)
+		}
+	})
+
+	t.Run("wrong source returns ok=false nil", func(t *testing.T) {
+		t.Parallel()
+		f := &lastModifiedFetcher{client: http.DefaultClient}
+		_, ok, err := f.Fetch(context.Background(), Key{Source: SourceAquaGitHubReleases, URL: "https://example.com"})
+		if err != nil || ok {
+			t.Errorf("expected (false, nil), got ok=%v err=%v", ok, err)
+		}
+	})
+
+	t.Run("HTTP scheme rejected by entry gate", func(t *testing.T) {
+		t.Parallel()
+		f := &lastModifiedFetcher{client: http.DefaultClient}
+		_, ok, err := f.Fetch(context.Background(), Key{Source: SourceLastModified, URL: "http://example.com"})
+		if err == nil || ok {
+			t.Errorf("expected SSRF rejection, got ok=%v err=%v", ok, err)
+		}
+	})
+}

--- a/internal/github/release.go
+++ b/internal/github/release.go
@@ -6,11 +6,22 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 )
 
 // releaseResponse represents a subset of the GitHub Releases API response.
 type releaseResponse struct {
-	TagName string `json:"tag_name"`
+	TagName     string    `json:"tag_name"`
+	PublishedAt time.Time `json:"published_at"`
+}
+
+// Release is the parsed form of a GitHub release returned to callers that
+// need both the tag and its publication time (e.g., release-age gating in
+// internal/age). encoding/json hydrates PublishedAt from the RFC3339
+// string GitHub returns.
+type Release struct {
+	TagName     string
+	PublishedAt time.Time
 }
 
 // GetLatestRelease fetches the latest release tag from a GitHub repository.

--- a/internal/github/release.go
+++ b/internal/github/release.go
@@ -17,8 +17,10 @@ type releaseResponse struct {
 
 // Release is the parsed form of a GitHub release returned to callers that
 // need both the tag and its publication time (e.g., release-age gating in
-// internal/age). encoding/json hydrates PublishedAt from the RFC3339
-// string GitHub returns.
+// internal/age). It is a plain return type with no JSON tags; decoding
+// from GitHub's RFC3339 payload happens via the response structs
+// (releaseResponse here, releaseByTagResponse in internal/registry/aqua),
+// which copy their fields into this type.
 type Release struct {
 	TagName     string
 	PublishedAt time.Time

--- a/internal/github/release_test.go
+++ b/internal/github/release_test.go
@@ -2,14 +2,28 @@ package github
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestReleaseResponse_PublishedAtDecodes(t *testing.T) {
+	t.Parallel()
+	// Confirms the new published_at JSON tag round-trips into time.Time
+	// without a custom UnmarshalJSON.
+	raw := []byte(`{"tag_name":"v1.2.3","published_at":"2024-09-13T15:42:08Z"}`)
+	var r releaseResponse
+	require.NoError(t, json.Unmarshal(raw, &r))
+	assert.Equal(t, "v1.2.3", r.TagName)
+	want := time.Date(2024, 9, 13, 15, 42, 8, 0, time.UTC)
+	assert.True(t, r.PublishedAt.Equal(want), "got %v want %v", r.PublishedAt, want)
+}
 
 func TestGetLatestRelease(t *testing.T) {
 	t.Parallel()

--- a/internal/registry/aqua/version_client.go
+++ b/internal/registry/aqua/version_client.go
@@ -8,6 +8,9 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"time"
+
+	"github.com/terassyi/tomei/internal/github"
 )
 
 const (
@@ -60,6 +63,60 @@ func (c *VersionClient) GetLatestRef(ctx context.Context) (string, error) {
 	}
 
 	return release.TagName, nil
+}
+
+// GetReleaseByTag fetches a specific release by tag from the GitHub
+// Releases API. Used by internal/age for publication-time lookups when
+// gating apply-time install on minimumReleaseAge.
+// Path: /repos/{owner}/{repo}/releases/tags/{tag}.
+func (c *VersionClient) GetReleaseByTag(ctx context.Context, repoOwner, repoName, tag string) (github.Release, error) {
+	if err := validatePathComponent(repoOwner); err != nil {
+		return github.Release{}, fmt.Errorf("invalid repo owner: %w", err)
+	}
+	if err := validatePathComponent(repoName); err != nil {
+		return github.Release{}, fmt.Errorf("invalid repo name: %w", err)
+	}
+	if err := validatePathComponent(tag); err != nil {
+		return github.Release{}, fmt.Errorf("invalid tag: %w", err)
+	}
+
+	apiURL := &url.URL{
+		Scheme: "https",
+		Host:   "api.github.com",
+		Path:   path.Join("/repos", repoOwner, repoName, "releases", "tags", tag),
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL.String(), nil)
+	if err != nil {
+		return github.Release{}, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return github.Release{}, fmt.Errorf("failed to fetch release by tag: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return github.Release{}, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var raw releaseByTagResponse
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return github.Release{}, fmt.Errorf("failed to decode response: %w", err)
+	}
+	if raw.TagName == "" {
+		return github.Release{}, fmt.Errorf("tag_name is empty")
+	}
+	return github.Release{TagName: raw.TagName, PublishedAt: raw.PublishedAt}, nil
+}
+
+// releaseByTagResponse mirrors the subset of GitHub's release-by-tag
+// payload we consume.
+type releaseByTagResponse struct {
+	TagName     string    `json:"tag_name"`
+	PublishedAt time.Time `json:"published_at"`
 }
 
 // GetLatestToolVersion fetches the latest version of the specified tool.

--- a/internal/registry/aqua/version_client.go
+++ b/internal/registry/aqua/version_client.go
@@ -80,10 +80,18 @@ func (c *VersionClient) GetReleaseByTag(ctx context.Context, repoOwner, repoName
 		return github.Release{}, fmt.Errorf("invalid tag: %w", err)
 	}
 
+	// path.Join would collapse a tag containing '/' (legal in git refs,
+	// e.g. "release/v1.0") into extra path segments, producing a wrong
+	// request. Escape the tag and carry it in RawPath while keeping the
+	// decoded form in Path, so url.URL.String() emits "%2F" for the slash
+	// instead of a path separator. validatePathComponent already rejects
+	// traversal sequences ("..") above.
+	basePath := path.Join("/repos", repoOwner, repoName, "releases", "tags") + "/"
 	apiURL := &url.URL{
-		Scheme: "https",
-		Host:   "api.github.com",
-		Path:   path.Join("/repos", repoOwner, repoName, "releases", "tags", tag),
+		Scheme:  "https",
+		Host:    "api.github.com",
+		Path:    basePath + tag,
+		RawPath: basePath + url.PathEscape(tag),
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL.String(), nil)

--- a/internal/registry/aqua/version_client_test.go
+++ b/internal/registry/aqua/version_client_test.go
@@ -143,16 +143,17 @@ func TestVersionClient_GetLatestToolVersion(t *testing.T) {
 func TestVersionClient_GetReleaseByTag(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name        string
-		owner       string
-		repo        string
-		tag         string
-		statusCode  int
-		body        string
-		wantTag     string
-		wantPubAt   time.Time
-		wantPubZero bool
-		wantErr     string
+		name            string
+		owner           string
+		repo            string
+		tag             string
+		statusCode      int
+		body            string
+		wantTag         string
+		wantPubAt       time.Time
+		wantPubZero     bool
+		wantURLContains string
+		wantErr         string
 	}{
 		{
 			name:       "success returns tag and publishedAt",
@@ -163,6 +164,17 @@ func TestVersionClient_GetReleaseByTag(t *testing.T) {
 			body:       `{"tag_name":"14.1.0","published_at":"2024-09-13T15:42:08Z"}`,
 			wantTag:    "14.1.0",
 			wantPubAt:  time.Date(2024, 9, 13, 15, 42, 8, 0, time.UTC),
+		},
+		{
+			name:            "tag with slash is url-escaped",
+			owner:           "o",
+			repo:            "r",
+			tag:             "release/v1.0",
+			statusCode:      http.StatusOK,
+			body:            `{"tag_name":"release/v1.0"}`,
+			wantTag:         "release/v1.0",
+			wantPubZero:     true,
+			wantURLContains: "/releases/tags/release%2Fv1.0",
 		},
 		{
 			name:        "missing published_at decodes to zero time",
@@ -222,6 +234,9 @@ func TestVersionClient_GetReleaseByTag(t *testing.T) {
 					handler: func(req *http.Request) (*http.Response, error) {
 						assert.Equal(t, "application/vnd.github.v3+json", req.Header.Get("Accept"))
 						assert.Contains(t, req.URL.String(), "/releases/tags/")
+						if tt.wantURLContains != "" {
+							assert.Contains(t, req.URL.String(), tt.wantURLContains)
+						}
 						return newMockResponse(tt.statusCode, tt.body), nil
 					},
 				},

--- a/internal/registry/aqua/version_client_test.go
+++ b/internal/registry/aqua/version_client_test.go
@@ -187,6 +187,19 @@ func TestVersionClient_GetReleaseByTag(t *testing.T) {
 			wantPubZero: true,
 		},
 		{
+			// time.Time.UnmarshalJSON treats a literal null as a no-op,
+			// so a draft/unpublished release's "published_at":null decodes
+			// to the zero time rather than erroring out.
+			name:        "null published_at decodes to zero time",
+			owner:       "o",
+			repo:        "r",
+			tag:         "v1",
+			statusCode:  http.StatusOK,
+			body:        `{"tag_name":"v1","published_at":null}`,
+			wantTag:     "v1",
+			wantPubZero: true,
+		},
+		{
 			name:    "invalid owner path component",
 			owner:   "../etc",
 			repo:    "r",

--- a/internal/registry/aqua/version_client_test.go
+++ b/internal/registry/aqua/version_client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -135,6 +136,111 @@ func TestVersionClient_GetLatestToolVersion(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestVersionClient_GetReleaseByTag(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		owner       string
+		repo        string
+		tag         string
+		statusCode  int
+		body        string
+		wantTag     string
+		wantPubAt   time.Time
+		wantPubZero bool
+		wantErr     string
+	}{
+		{
+			name:       "success returns tag and publishedAt",
+			owner:      "BurntSushi",
+			repo:       "ripgrep",
+			tag:        "14.1.0",
+			statusCode: http.StatusOK,
+			body:       `{"tag_name":"14.1.0","published_at":"2024-09-13T15:42:08Z"}`,
+			wantTag:    "14.1.0",
+			wantPubAt:  time.Date(2024, 9, 13, 15, 42, 8, 0, time.UTC),
+		},
+		{
+			name:        "missing published_at decodes to zero time",
+			owner:       "o",
+			repo:        "r",
+			tag:         "v1",
+			statusCode:  http.StatusOK,
+			body:        `{"tag_name":"v1"}`,
+			wantTag:     "v1",
+			wantPubZero: true,
+		},
+		{
+			name:    "invalid owner path component",
+			owner:   "../etc",
+			repo:    "r",
+			tag:     "v1",
+			wantErr: "invalid repo owner",
+		},
+		{
+			name:    "invalid repo path component",
+			owner:   "o",
+			repo:    "../etc",
+			tag:     "v1",
+			wantErr: "invalid repo name",
+		},
+		{
+			name:    "invalid tag path component",
+			owner:   "o",
+			repo:    "r",
+			tag:     "../etc",
+			wantErr: "invalid tag",
+		},
+		{
+			name:       "non-2xx returns error",
+			owner:      "o",
+			repo:       "r",
+			tag:        "v1",
+			statusCode: http.StatusNotFound,
+			body:       "",
+			wantErr:    "unexpected status code",
+		},
+		{
+			name:       "empty tag_name returns error",
+			owner:      "o",
+			repo:       "r",
+			tag:        "v1",
+			statusCode: http.StatusOK,
+			body:       `{"tag_name":""}`,
+			wantErr:    "tag_name is empty",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mockClient := &http.Client{
+				Transport: &mockRoundTripper{
+					handler: func(req *http.Request) (*http.Response, error) {
+						assert.Equal(t, "application/vnd.github.v3+json", req.Header.Get("Accept"))
+						assert.Contains(t, req.URL.String(), "/releases/tags/")
+						return newMockResponse(tt.statusCode, tt.body), nil
+					},
+				},
+			}
+			client := NewVersionClient(mockClient)
+			got, err := client.GetReleaseByTag(context.Background(), tt.owner, tt.repo, tt.tag)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantTag, got.TagName)
+			if tt.wantPubZero {
+				assert.True(t, got.PublishedAt.IsZero(), "expected zero PublishedAt, got %v", got.PublishedAt)
+				return
+			}
+			assert.True(t, got.PublishedAt.Equal(tt.wantPubAt),
+				"PublishedAt = %v, want %v", got.PublishedAt, tt.wantPubAt)
 		})
 	}
 }


### PR DESCRIPTION
Foundation sub-task for the minimumReleaseAge supply-chain defense
(parent tracking issue #257). Introduces internal/age/, a reusable
release-publication-time lookup layer that both the apply-time gate
(#254) and the plan-time advisory display (#255) will consume.

Public surface (internal/age/age.go):
- Fetcher.Fetch(ctx, key) returns (publishedAt, ok, err) — ok=false
  with nil err signals "this source can't supply a timestamp for this
  key", distinct from a network/parse failure.
- Two backends, dispatched by Key.Source:
  * SourceAquaGitHubReleases — calls aqua.VersionClient.GetReleaseByTag,
    decodes the new github.Release.PublishedAt field.
  * SourceLastModified — HTTP HEAD on a raw URL, parses Last-Modified
    via http.ParseTime, with Range: bytes=0-0 GET fallback for servers
    that return 405 or 501 on HEAD.
- New() builds a cached, SSRF-hardened Fetcher; FetchAll() runs N keys
  in parallel under a bounded semaphore and aggregated batch timeout,
  with results returned in input order.

SSRF gate (lastmodified.go validateRedirectURL):
- HTTPS scheme only.
- Reject IP literals that resolve to private / loopback / link-local /
  multicast / unspecified ranges (IPv4 and IPv6 via net.ParseIP +
  IsPrivate/IsLoopback/IsLinkLocalUnicast/IsMulticast/IsUnspecified).
  IPv4-mapped IPv6 like ::ffff:192.168.0.1 canonicalize correctly and
  are rejected.
- Re-validate every redirect hop via http.Client.CheckRedirect, capped
  at 5 hops. DNS names are passed through (no resolve — avoids TOCTOU
  and the latency hit; CUE manifests are the trust boundary).
- The validator is unit-tested directly so the SSRF-rejection cases
  don't need a synthetic http:// test server.

Cache (cache.go):
- map[Key]cacheEntry guarded by sync.Mutex, scoped to the Fetcher's
  lifetime (one tomei plan/apply invocation; callers are expected to
  build a fresh Fetcher per invocation).
- singleflight.Group dedups concurrent calls for the same key to a
  single inner Fetch. Errors are cached so a transient failure on key
  K returns the same error for subsequent K lookups in the same
  invocation (intentional — the package does not retry).

Concurrency (FetchAll in age.go):
- semaphore.NewWeighted bound (default 5), aggregated
  context.WithTimeout for the whole batch (default 60s). Options set
  on New propagate through configurableFetcher so callers don't have
  to re-pass WithConcurrency/WithBatchTimeout at every FetchAll;
  options on FetchAll override per-call.

Supporting changes:
- internal/github/release.go gains an exported Release struct and the
  released published_at field on releaseResponse. Existing
  GetLatestRelease callers are unaffected (still return string).
- internal/registry/aqua/version_client.go gains GetReleaseByTag
  hitting /repos/{owner}/{repo}/releases/tags/{tag} and returning the
  full github.Release. Path-component validation mirrors
  GetLatestToolVersion.

Test coverage:
- aqua_test.go: AquaReleaseClient fake exercises propagation, missing
  fields, nil-client disable, GetReleaseByTag errors, zero PublishedAt.
- lastmodified_test.go: validateRedirectURL table covers every
  rejected/allowed branch (IPv4 + IPv6, scheme, DNS, public IP);
  httptest.NewTLSServer drives HEAD success, 405/501 fallback to GET
  Range, no-header fallback, 5xx, malformed Last-Modified.
- cache_test.go: same-key dedup, different-key isolation, singleflight
  proven by a start-gate + entered-channel synchronization (no
  time.Sleep guesswork; reliable under -race on slow CIs), cached
  errors honored.
- age_test.go: dispatch by Source, New(nil, nil) builds a usable
  Fetcher, FetchAll preserves order, empty + pre-canceled context,
  WithBatchTimeout from New is honored by FetchAll.
- release_test.go: released published_at round-trips into time.Time.
- version_client_test.go: GetReleaseByTag covers success, missing
  PublishedAt, invalid path components on owner/repo/tag, non-2xx,
  empty tag_name.

Scope strictly foundation: no engine.Apply gate, no plan display, no
template-var threading (#253-#256). E2E suite was not run locally — the
host's Nix-glibc-linked binary can't load in the Ubuntu test container
(pre-existing environment quirk, unrelated to this PR). CI will run
E2E on GitHub-hosted runners.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
