### PR TITLE
feat(installer): thread minimumReleaseAge into delegation install command vars

### DIFF
--- a/cuemodule/schema/schema.cue
+++ b/cuemodule/schema/schema.cue
@@ -90,10 +90,13 @@ package schema
 		// duration. Go duration string (e.g. "168h" for 1 week). Empty =
 		// disabled.
 		//
-		// Go-side parses and validates the value; the schema accepts any
-		// string and defers semantic checks to Validate(). Enforcement is
-		// performed at apply time by the installer engine (see issue
-		// #257); declaring this field before that gate lands is a no-op.
+		// Schema accepts any string; semantic validation (Go duration shape,
+		// non-negative) is deferred to the Go-side ParsedMinimumReleaseAge(),
+		// the authoritative validator on the apply path for both CUE and
+		// JSON/YAML manifests — the schema layer does not duplicate the parser.
+		// For delegation installs the value is exposed to commands as
+		// {{.MinimumReleaseAge}}; tomei's own apply-time gate for aqua/download
+		// is issue #257.
 		minimumReleaseAge?: string
 
 		// Conditional required fields
@@ -135,10 +138,13 @@ package schema
 		// duration. Go duration string (e.g. "168h" for 1 week). Empty =
 		// disabled.
 		//
-		// Go-side parses and validates the value; the schema accepts any
-		// string and defers semantic checks to Validate(). Enforcement is
-		// performed at apply time by the installer engine (see issue
-		// #257); declaring this field before that gate lands is a no-op.
+		// Schema accepts any string; semantic validation (Go duration shape,
+		// non-negative) is deferred to the Go-side ParsedMinimumReleaseAge(),
+		// the authoritative validator on the apply path for both CUE and
+		// JSON/YAML manifests — the schema layer does not duplicate the parser.
+		// For delegation installs the value is exposed to commands as
+		// {{.MinimumReleaseAge}}; tomei's own apply-time gate for aqua/download
+		// is issue #257.
 		minimumReleaseAge?: string
 
 		// Conditional required fields

--- a/internal/installer/command/executor.go
+++ b/internal/installer/command/executor.go
@@ -53,10 +53,11 @@ type Vars struct {
 	Args string
 	// MinimumReleaseAge is the Go duration string declared on the owning
 	// Installer/Runtime spec (e.g., "168h"). Empty when unset. Threaded by
-	// the installer engine; currently a no-op until issue #257's apply-time
-	// gate consumes it. The slot exists here so delegation commands can
-	// reference {{.MinimumReleaseAge}} without further plumbing once the
-	// gate lands.
+	// the installer engine and rendered into delegation install commands as
+	// {{.MinimumReleaseAge}}. For delegation paths tomei does NOT itself gate
+	// the install — honoring the value is the user command's responsibility.
+	// (tomei's own apply-time gate for aqua/download installers is issue #257.)
+	// Validated as a Go duration before it reaches the command template.
 	MinimumReleaseAge string
 }
 

--- a/internal/installer/command/executor.go
+++ b/internal/installer/command/executor.go
@@ -57,7 +57,9 @@ type Vars struct {
 	// {{.MinimumReleaseAge}}. For delegation paths tomei does NOT itself gate
 	// the install — honoring the value is the user command's responsibility.
 	// (tomei's own apply-time gate for aqua/download installers is issue #257.)
-	// Validated as a Go duration before it reaches the command template.
+	// The duration is validated upstream (InstallerSpec.Validate /
+	// RuntimeSpec.ParsedMinimumReleaseAge in engine.Apply) before threading;
+	// this package performs no validation of its own.
 	MinimumReleaseAge string
 }
 

--- a/internal/installer/engine/engine.go
+++ b/internal/installer/engine/engine.go
@@ -370,6 +370,24 @@ func (e *Engine) Apply(ctx context.Context, resources []resource.Resource) error
 	// Build resource maps for quick lookup
 	resourceMap := buildResourceMap(resources)
 
+	// Collect the spec-declared minimumReleaseAge per runtime, keyed by name, so the
+	// runtime-delegation tool-install path can expose it as {{.MinimumReleaseAge}}.
+	// Sourced from the live manifest (not persisted state) and validated here, since
+	// RuntimeSpec.Validate() is otherwise not called on the apply path (unlike
+	// InstallerSpec, validated below) — this keeps an unparseable/negative duration
+	// from reaching a delegation shell command.
+	runtimeMinReleaseAge := make(map[string]string)
+	for _, rt := range extractByKind[*resource.Runtime](resources) {
+		if rt.RuntimeSpec == nil {
+			continue
+		}
+		// Parse to validate; the value is threaded as a raw string below.
+		if _, err := rt.RuntimeSpec.ParsedMinimumReleaseAge(); err != nil {
+			return fmt.Errorf("invalid runtime %q: %w", rt.Name(), err)
+		}
+		runtimeMinReleaseAge[rt.Name()] = rt.RuntimeSpec.MinimumReleaseAge
+	}
+
 	// Register installers for delegation type and save to state
 	for _, res := range resources {
 		if inst, ok := res.(*resource.Installer); ok && inst.InstallerSpec != nil {
@@ -377,9 +395,10 @@ func (e *Engine) Apply(ctx context.Context, resources []resource.Resource) error
 				return fmt.Errorf("invalid installer %q: %w", inst.Name(), err)
 			}
 			e.toolInstaller.RegisterInstaller(inst.Name(), &tool.InstallerInfo{
-				Type:     inst.InstallerSpec.Type,
-				ToolRef:  inst.InstallerSpec.ToolRef,
-				Commands: inst.InstallerSpec.Commands,
+				Type:              inst.InstallerSpec.Type,
+				ToolRef:           inst.InstallerSpec.ToolRef,
+				Commands:          inst.InstallerSpec.Commands,
+				MinimumReleaseAge: inst.InstallerSpec.MinimumReleaseAge,
 			})
 			// Persist installer state (including ToolRef and BinDir) for removal lookup and env
 			if st.Installers == nil {
@@ -465,6 +484,8 @@ func (e *Engine) Apply(ctx context.Context, resources []resource.Resource) error
 				ToolBinPath: runtimeState.ToolBinPath,
 				Env:         runtimeState.Env,
 				Commands:    runtimeState.Commands,
+				// Spec-sourced (live manifest), not state — see runtimeMinReleaseAge above.
+				MinimumReleaseAge: runtimeMinReleaseAge[name],
 			})
 		}
 	}

--- a/internal/installer/engine/engine_test.go
+++ b/internal/installer/engine/engine_test.go
@@ -26,6 +26,14 @@ import (
 type mockToolInstaller struct {
 	installFunc func(ctx context.Context, res *resource.Tool, name string) (*resource.ToolState, error)
 	removeFunc  func(ctx context.Context, st *resource.ToolState, name string) error
+
+	// registeredRuntimes/registeredInstallers capture the Info passed to
+	// RegisterRuntime/RegisterInstaller so tests can assert what the engine
+	// threaded from the resource specs (e.g. MinimumReleaseAge). No mutex:
+	// the engine only registers on the serial Apply goroutine between layers,
+	// never from parallel node execution (mirrors the unlocked production type).
+	registeredRuntimes   map[string]*tool.RuntimeInfo
+	registeredInstallers map[string]*tool.InstallerInfo
 }
 
 func (m *mockToolInstaller) Install(ctx context.Context, res *resource.Tool, name string) (*resource.ToolState, error) {
@@ -47,9 +55,19 @@ func (m *mockToolInstaller) Remove(ctx context.Context, st *resource.ToolState, 
 	return nil
 }
 
-func (m *mockToolInstaller) RegisterRuntime(_ string, _ *tool.RuntimeInfo) {}
+func (m *mockToolInstaller) RegisterRuntime(name string, info *tool.RuntimeInfo) {
+	if m.registeredRuntimes == nil {
+		m.registeredRuntimes = make(map[string]*tool.RuntimeInfo)
+	}
+	m.registeredRuntimes[name] = info
+}
 
-func (m *mockToolInstaller) RegisterInstaller(_ string, _ *tool.InstallerInfo) {}
+func (m *mockToolInstaller) RegisterInstaller(name string, info *tool.InstallerInfo) {
+	if m.registeredInstallers == nil {
+		m.registeredInstallers = make(map[string]*tool.InstallerInfo)
+	}
+	m.registeredInstallers[name] = info
+}
 
 func (m *mockToolInstaller) SetToolBinPaths(_ map[string]string) {}
 
@@ -376,6 +394,106 @@ tool: {
 	require.NoError(t, err)
 	assert.NotNil(t, st.Runtimes["myruntime"])
 	assert.NotNil(t, st.Tools["test-tool"])
+}
+
+// TestEngine_Apply_ThreadsMinimumReleaseAge verifies the engine populates
+// RuntimeInfo/InstallerInfo.MinimumReleaseAge from each resource's spec. Two
+// runtimes (one set, one unset) catch map mis-keying that a single runtime would
+// hide; the installer hop is asserted too.
+func TestEngine_Apply_ThreadsMinimumReleaseAge(t *testing.T) {
+	t.Parallel()
+
+	stateDir := t.TempDir()
+	store, err := state.NewStore[state.UserState](stateDir)
+	require.NoError(t, err)
+
+	toolMock := &mockToolInstaller{}
+	runtimeMock := &mockRuntimeInstaller{}
+	eng := NewEngine(toolMock, runtimeMock, &mockInstallerRepositoryInstaller{}, store)
+
+	resources := []resource.Resource{
+		&resource.Runtime{
+			BaseResource: resource.BaseResource{APIVersion: resource.GroupVersion, ResourceKind: resource.KindRuntime, Metadata: resource.Metadata{Name: "rt-set"}},
+			RuntimeSpec: &resource.RuntimeSpec{
+				Type:              resource.InstallTypeDownload,
+				Version:           "1.0.0",
+				Binaries:          []string{"rt-set"},
+				ToolBinPath:       "~/rt-set/bin",
+				MinimumReleaseAge: "168h",
+				Source: &resource.DownloadSource{
+					URL:      "https://example.com/rt-set.tar.gz",
+					Checksum: &resource.Checksum{Value: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+				},
+			},
+		},
+		&resource.Runtime{
+			BaseResource: resource.BaseResource{APIVersion: resource.GroupVersion, ResourceKind: resource.KindRuntime, Metadata: resource.Metadata{Name: "rt-unset"}},
+			RuntimeSpec: &resource.RuntimeSpec{
+				Type:        resource.InstallTypeDownload,
+				Version:     "1.0.0",
+				Binaries:    []string{"rt-unset"},
+				ToolBinPath: "~/rt-unset/bin",
+				Source: &resource.DownloadSource{
+					URL:      "https://example.com/rt-unset.tar.gz",
+					Checksum: &resource.Checksum{Value: "sha256:1111111111111111111111111111111111111111111111111111111111111111"},
+				},
+			},
+		},
+		&resource.Installer{
+			BaseResource: resource.BaseResource{APIVersion: resource.GroupVersion, ResourceKind: resource.KindInstaller, Metadata: resource.Metadata{Name: "myinst"}},
+			InstallerSpec: &resource.InstallerSpec{
+				Type:              resource.InstallTypeDelegation,
+				MinimumReleaseAge: "72h",
+				Commands:          &resource.CommandsSpec{Install: []string{"echo {{.MinimumReleaseAge}}"}},
+			},
+		},
+	}
+
+	err = eng.Apply(context.Background(), resources)
+	require.NoError(t, err)
+
+	require.Contains(t, toolMock.registeredRuntimes, "rt-set")
+	require.Contains(t, toolMock.registeredRuntimes, "rt-unset")
+	assert.Equal(t, "168h", toolMock.registeredRuntimes["rt-set"].MinimumReleaseAge)
+	assert.Empty(t, toolMock.registeredRuntimes["rt-unset"].MinimumReleaseAge)
+
+	require.Contains(t, toolMock.registeredInstallers, "myinst")
+	assert.Equal(t, "72h", toolMock.registeredInstallers["myinst"].MinimumReleaseAge)
+}
+
+// TestEngine_Apply_RejectsInvalidRuntimeMinimumReleaseAge verifies the Go-side
+// guard: RuntimeSpec.Validate() is not called on the apply path, so the engine
+// validates the duration itself before it could reach a delegation shell command
+// (the CUE regex is the boundary for CUE manifests; this guards JSON/YAML bypass).
+func TestEngine_Apply_RejectsInvalidRuntimeMinimumReleaseAge(t *testing.T) {
+	t.Parallel()
+
+	stateDir := t.TempDir()
+	store, err := state.NewStore[state.UserState](stateDir)
+	require.NoError(t, err)
+
+	eng := NewEngine(&mockToolInstaller{}, &mockRuntimeInstaller{}, &mockInstallerRepositoryInstaller{}, store)
+
+	resources := []resource.Resource{
+		&resource.Runtime{
+			BaseResource: resource.BaseResource{APIVersion: resource.GroupVersion, ResourceKind: resource.KindRuntime, Metadata: resource.Metadata{Name: "bad-rt"}},
+			RuntimeSpec: &resource.RuntimeSpec{
+				Type:              resource.InstallTypeDownload,
+				Version:           "1.0.0",
+				Binaries:          []string{"bad-rt"},
+				ToolBinPath:       "~/bad-rt/bin",
+				MinimumReleaseAge: "; rm -rf ~ #",
+				Source: &resource.DownloadSource{
+					URL:      "https://example.com/bad-rt.tar.gz",
+					Checksum: &resource.Checksum{Value: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+				},
+			},
+		},
+	}
+
+	err = eng.Apply(context.Background(), resources)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid runtime")
 }
 
 func TestEngine_TaintDependentTools(t *testing.T) {

--- a/internal/installer/runtime/installer.go
+++ b/internal/installer/runtime/installer.go
@@ -431,8 +431,11 @@ func (i *Installer) installDelegation(ctx context.Context, spec *resource.Runtim
 		errAction = "update"
 	}
 
-	// Execute bootstrap command
-	vars := command.Vars{Version: resolvedVersion}
+	// Execute bootstrap command.
+	// MinimumReleaseAge is exposed to bootstrap/check commands as {{.MinimumReleaseAge}}
+	// for symmetry with the tool-delegation path; tomei does not enforce it here (this is
+	// the runtime's own self-install), so honoring it is the bootstrap command's choice.
+	vars := command.Vars{Version: resolvedVersion, MinimumReleaseAge: spec.MinimumReleaseAge}
 	if err := i.executeBootstrap(ctx, cmds, vars, env); err != nil {
 		return nil, fmt.Errorf("bootstrap %s failed: %w", errAction, err)
 	}

--- a/internal/installer/runtime/installer_test.go
+++ b/internal/installer/runtime/installer_test.go
@@ -1914,6 +1914,66 @@ func TestRuntimeInstaller_ProgressCallback_Priority(t *testing.T) {
 
 // --- test helpers for delegation tests ---
 
+// TestInstallDelegation_MinimumReleaseAgeVarExposed verifies the runtime spec's
+// MinimumReleaseAge is threaded into the bootstrap install AND check command Vars
+// (a single Vars feeds both), so {{.MinimumReleaseAge}} resolves. This is the
+// runtime's own self-install; tomei does not enforce the value here.
+func TestInstallDelegation_MinimumReleaseAgeVarExposed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		minAge string
+		want   string
+	}{
+		{name: "set", minAge: "168h", want: "168h"},
+		{name: "unset", minAge: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			runner := &mockCommandRunner{checkResult: true}
+			installer, runtimesDir := newTestInstaller(t, runner)
+			binDir := filepath.Join(runtimesDir, "bin")
+
+			rt := newDelegationSpec(binDir, func(s *resource.RuntimeSpec) {
+				s.MinimumReleaseAge = tt.minAge
+				s.Bootstrap.Remove = nil
+			})
+
+			_, err := installer.Install(context.Background(), rt, "mock")
+			require.NoError(t, err)
+
+			require.Len(t, runner.executeWithEnvCalls, 1)
+			assert.Equal(t, tt.want, runner.executeWithEnvCalls[0].vars.MinimumReleaseAge)
+			require.Len(t, runner.checkCalls, 1)
+			assert.Equal(t, tt.want, runner.checkCalls[0].vars.MinimumReleaseAge)
+		})
+	}
+
+	t.Run("upgrade update branch", func(t *testing.T) {
+		t.Parallel()
+		runner := &mockCommandRunner{checkResult: true}
+		installer, runtimesDir := newTestInstaller(t, runner)
+		binDir := filepath.Join(runtimesDir, "bin")
+
+		rt := newDelegationSpec(binDir, func(s *resource.RuntimeSpec) {
+			s.MinimumReleaseAge = "168h"
+			s.Bootstrap.Update = []string{"update-cmd {{.MinimumReleaseAge}}"}
+			s.Bootstrap.Remove = nil
+		})
+
+		ctx := executor.WithAction(context.Background(), resource.ActionUpgrade)
+		_, err := installer.Install(ctx, rt, "mock")
+		require.NoError(t, err)
+
+		require.Len(t, runner.executeWithEnvCalls, 1)
+		assert.Equal(t, []string{"update-cmd {{.MinimumReleaseAge}}"}, runner.executeWithEnvCalls[0].cmds)
+		assert.Equal(t, "168h", runner.executeWithEnvCalls[0].vars.MinimumReleaseAge)
+	})
+}
+
 // newDelegationSpec creates a base delegation Runtime with functional options for customization.
 // Default spec: Type=Delegation, Version="1.0.0", ToolBinPath=<binDir>,
 // Bootstrap={Install: ["install-cmd {{.Version}}"], Check: ["check-cmd"], Remove: ["remove-cmd"]}.

--- a/internal/installer/tool/installer.go
+++ b/internal/installer/tool/installer.go
@@ -32,6 +32,9 @@ type RuntimeInfo struct {
 	ToolBinPath string            // Path where tools should be installed (e.g., ~/go/bin)
 	Env         map[string]string // Environment variables (e.g., GOROOT, GOBIN)
 	Commands    *resource.CommandsSpec
+	// MinimumReleaseAge is the Go duration string from the Runtime spec, exposed
+	// to delegation install commands as {{.MinimumReleaseAge}}. Empty when unset.
+	MinimumReleaseAge string
 }
 
 // InstallerInfo contains the information needed to install tools via installer delegation.
@@ -39,6 +42,9 @@ type InstallerInfo struct {
 	Type     resource.InstallType // "download" or "delegation"
 	ToolRef  string               // Reference to tool (optional, e.g., cargo-binstall)
 	Commands *resource.CommandsSpec
+	// MinimumReleaseAge is the Go duration string from the Installer spec, exposed
+	// to delegation install commands as {{.MinimumReleaseAge}}. Empty when unset.
+	MinimumReleaseAge string
 }
 
 // CommandRunner is the interface for executing shell commands.
@@ -795,11 +801,12 @@ func (i *Installer) installByRuntime(ctx context.Context, res *resource.Tool, na
 		versionSlot = spec.SHA
 	}
 	vars := command.Vars{
-		Package: spec.Package.String(),
-		Version: versionSlot,
-		Name:    name,
-		BinPath: filepath.Join(info.ToolBinPath, binName),
-		Args:    strings.Join(spec.Args, " "),
+		Package:           spec.Package.String(),
+		Version:           versionSlot,
+		Name:              name,
+		BinPath:           filepath.Join(info.ToolBinPath, binName),
+		Args:              strings.Join(spec.Args, " "),
+		MinimumReleaseAge: info.MinimumReleaseAge,
 	}
 
 	// Build environment with PATH including runtime's bin directory
@@ -866,11 +873,12 @@ func (i *Installer) installByInstaller(ctx context.Context, res *resource.Tool, 
 	}
 
 	vars := command.Vars{
-		Package: pkg,
-		Version: spec.Version,
-		Name:    name,
-		BinPath: "", // installer manages the path
-		Args:    strings.Join(spec.Args, " "),
+		Package:           pkg,
+		Version:           spec.Version,
+		Name:              name,
+		BinPath:           "", // installer manages the path
+		Args:              strings.Join(spec.Args, " "),
+		MinimumReleaseAge: info.MinimumReleaseAge,
 	}
 
 	// Build environment with PATH including the installer's toolRef binary directory

--- a/internal/installer/tool/installer_test.go
+++ b/internal/installer/tool/installer_test.go
@@ -847,6 +847,99 @@ func TestToolInstaller_Install_Args(t *testing.T) {
 	}
 }
 
+// TestInstallByRuntime_MinimumReleaseAgeVarExposed verifies the runtime spec's
+// MinimumReleaseAge is threaded into the delegation install command's Vars, so a
+// preset can reference {{.MinimumReleaseAge}}. tomei does not enforce it here.
+func TestInstallByRuntime_MinimumReleaseAgeVarExposed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		minAge string
+		want   string
+	}{
+		{name: "set", minAge: "168h", want: "168h"},
+		{name: "unset", minAge: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			runner := &mockCommandRunner{checkResult: true}
+			inst := NewInstallerWithRunner(download.NewDownloader(), &mockPlacer{}, "/bin", "/system-bin", runner)
+			inst.RegisterRuntime("rt", &RuntimeInfo{
+				ToolBinPath:       t.TempDir(),
+				MinimumReleaseAge: tt.minAge,
+				Commands: &resource.CommandsSpec{
+					Install: []string{"echo {{.MinimumReleaseAge}}"},
+				},
+			})
+
+			tool := &resource.Tool{
+				BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "mytool"}},
+				ToolSpec: &resource.ToolSpec{
+					RuntimeRef: "rt",
+					Version:    "1.0.0",
+					Package:    &resource.Package{Name: "mytool"},
+				},
+			}
+
+			_, err := inst.Install(context.Background(), tool, tool.Name())
+			require.NoError(t, err)
+			// Exactly one command (install); index [0] is unambiguous and a
+			// future Check on this path would fail here rather than silently shift.
+			require.Len(t, runner.executedVars, 1)
+			assert.Equal(t, tt.want, runner.executedVars[0].MinimumReleaseAge)
+		})
+	}
+}
+
+// TestInstallByInstaller_MinimumReleaseAgeVarExposed mirrors the runtime case for
+// the installer-delegation path.
+func TestInstallByInstaller_MinimumReleaseAgeVarExposed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		minAge string
+		want   string
+	}{
+		{name: "set", minAge: "168h", want: "168h"},
+		{name: "unset", minAge: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			runner := &mockCommandRunner{checkResult: true}
+			inst := NewInstallerWithRunner(download.NewDownloader(), &mockPlacer{}, "/bin", "/system-bin", runner)
+			inst.RegisterInstaller("inst", &InstallerInfo{
+				Type:              resource.InstallTypeDelegation,
+				MinimumReleaseAge: tt.minAge,
+				Commands: &resource.CommandsSpec{
+					Install: []string{"echo {{.MinimumReleaseAge}}"},
+				},
+			})
+
+			tool := &resource.Tool{
+				BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "mytool"}},
+				ToolSpec: &resource.ToolSpec{
+					InstallerRef: "inst",
+					Version:      "1.0.0",
+					Package:      &resource.Package{Name: "mytool"},
+				},
+			}
+
+			_, err := inst.Install(context.Background(), tool, tool.Name())
+			require.NoError(t, err)
+			// Exactly one command (install); index [0] is unambiguous and a
+			// future Check on this path would fail here rather than silently shift.
+			require.Len(t, runner.executedVars, 1)
+			assert.Equal(t, tt.want, runner.executedVars[0].MinimumReleaseAge)
+		})
+	}
+}
+
 // TestToolInstaller_RuntimeRef_SubstitutesIntoVersion locks the install-time
 // invariant: when ToolSpec.SHA is set, the SHA is substituted into the
 // {{.Version}} template slot so the preset's "go install pkg@{{.Version}}"


### PR DESCRIPTION
Expose the spec-declared `minimumReleaseAge` as the `{{.MinimumReleaseAge}}`
template variable inside delegation install commands (sub-task #253 of the
minimumReleaseAge tracking issue #257). tomei does NOT enforce the gate for
delegation paths — honoring the value is the user command's responsibility;
tomei's own apply-time gate for aqua/download is a later sub-task (#254).

- tool: add MinimumReleaseAge to RuntimeInfo/InstallerInfo and populate the
  command.Vars at the installByRuntime / installByInstaller sites.
- engine: populate InstallerInfo from InstallerSpec; for runtimes, source the
  value from the live manifest (RuntimeInfo is otherwise built from persisted
  RuntimeState) via a name-keyed map. Validate the duration there with
  ParsedMinimumReleaseAge — RuntimeSpec.Validate() is not called on the apply
  path (unlike InstallerSpec at registration), so this keeps an unparseable or
  negative duration from reaching a delegation shell command.
- runtime: thread the value into the bootstrap install/check command vars for
  symmetry (runtime self-install; a no-op for tomei here).
- command: correct the now-stale Vars.MinimumReleaseAge doc comment.

The CUE schema keeps `minimumReleaseAge?: string`; semantic validation stays
on the Go side per the existing convention (the schema layer does not duplicate
the duration parser).

Tests: structured-Vars assertions on both delegation paths (set/unset), the
runtime bootstrap path (install + check + upgrade/update branch), and an
engine-level test that drives a real Apply with two runtimes (one set, one
unset, catching map mis-keying) plus a delegation installer, and rejects an
invalid runtime duration.

Refs #257
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
