### PR TITLE
feat(installer): add apply-time minimumReleaseAge gate to engine.Apply

### DIFF
--- a/cmd/tomei/apply.go
+++ b/cmd/tomei/apply.go
@@ -379,7 +379,7 @@ func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 		fmt.Fprintf(w, "\n%d tool(s) skipped (release younger than minimumReleaseAge):\n", len(skips))
 		for _, s := range skips {
 			fmt.Fprintf(w, "  - %s: released %s ago, requires %s (source: %s)\n",
-				s.Name, s.ActualAge.Round(time.Hour), s.MinAge, s.Source)
+				s.Name, s.ActualAge.Truncate(time.Minute), s.MinAge, s.Source)
 		}
 		fmt.Fprintln(w, "Use --ignore-min-release-age to override.")
 	}

--- a/cmd/tomei/apply.go
+++ b/cmd/tomei/apply.go
@@ -19,6 +19,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
+	"github.com/terassyi/tomei/internal/age"
 	"github.com/terassyi/tomei/internal/config"
 	"github.com/terassyi/tomei/internal/github"
 	"github.com/terassyi/tomei/internal/installer/download"
@@ -38,10 +39,11 @@ import (
 // applyConfig holds configuration for the apply command.
 type applyConfig struct {
 	loadConfig
-	quiet    bool
-	parallel int
-	yes      bool
-	timeout  time.Duration
+	quiet               bool
+	parallel            int
+	yes                 bool
+	timeout             time.Duration
+	ignoreMinReleaseAge bool
 }
 
 var applyCfg applyConfig
@@ -94,6 +96,7 @@ func init() {
 	applyCmd.Flags().IntVar(&applyCfg.parallel, "parallel", engine.DefaultParallelism, "Maximum number of parallel installations (1-20)")
 	applyCmd.Flags().BoolVarP(&applyCfg.yes, "yes", "y", false, "Skip confirmation prompt")
 	applyCmd.Flags().DurationVar(&applyCfg.timeout, "timeout", download.DefaultDownloadTimeout, "Per-download timeout (e.g., 5m, 10m, 1h)")
+	applyCmd.Flags().BoolVar(&applyCfg.ignoreMinReleaseAge, "ignore-min-release-age", false, "Bypass the minimumReleaseAge gate and install regardless of upstream release age (aqua gating is best-effort: tag mismatches fail open)")
 }
 
 func runApply(cmd *cobra.Command, args []string) error {
@@ -231,9 +234,10 @@ func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 
 	// Show plan and ask for confirmation when there are changes
 	updCfg := engine.UpdateConfig{
-		SyncMode:       cfg.syncRegistry,
-		UpdateTools:    cfg.updateTools || cfg.updateAll,
-		UpdateRuntimes: cfg.updateRuntimes || cfg.updateAll,
+		SyncMode:            cfg.syncRegistry,
+		UpdateTools:         cfg.updateTools || cfg.updateAll,
+		UpdateRuntimes:      cfg.updateRuntimes || cfg.updateAll,
+		IgnoreMinReleaseAge: cfg.ignoreMinReleaseAge,
 	}
 	// Show plan with all resources (system + user) for complete picture
 	hasChanges, err := planForResources(w, resources, cfg.noColor, updCfg, scope)
@@ -267,6 +271,13 @@ func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 	eng := engine.NewEngine(toolInstaller, runtimeInstaller, repoInstaller, store)
 	eng.SetParallelism(cfg.parallel)
 	eng.SetUpdateConfig(updCfg)
+	// minimumReleaseAge gate. Pass a nil httpClient so age builds its own
+	// SSRF-hardened client for arbitrary Last-Modified hosts — the
+	// token-bearing dlClient must not be reused (PAT-leak hazard). The aqua
+	// client only ever talks to api.github.com.
+	if !cfg.ignoreMinReleaseAge {
+		eng.SetAgeFetcher(age.New(aqua.NewVersionClient(ghClient), nil))
+	}
 	// Under --system-only, filterNonPrivilegedWithLog stripped non-priv
 	// resources from userResources before the engine sees them, so the
 	// reconciler would otherwise emit ActionRemove for their state
@@ -362,6 +373,22 @@ func executeApply(ctx context.Context, paths []string, w io.Writer, cfg *applyCo
 	// the desired resource list but still intended to be installed).
 	if n := eng.SkippedPrivileged(); n > 0 && !cfg.quiet {
 		fmt.Fprintf(w, "\n%d privileged resource action(s) skipped (%s). Use 'tomei apply --system' or 'tomei apply --system-only' to manage privileged resources.\n", n, privilegedSkipReasonsFragment)
+	}
+
+	if skips := eng.SkippedReleaseAge(); len(skips) > 0 && !cfg.quiet {
+		fmt.Fprintf(w, "\n%d tool(s) skipped (release younger than minimumReleaseAge):\n", len(skips))
+		for _, s := range skips {
+			fmt.Fprintf(w, "  - %s: released %s ago, requires %s (source: %s)\n",
+				s.Name, s.ActualAge.Round(time.Hour), s.MinAge, s.Source)
+		}
+		fmt.Fprintln(w, "Use --ignore-min-release-age to override.")
+	}
+
+	if unv := eng.UnverifiedReleaseAge(); len(unv) > 0 && !cfg.quiet {
+		fmt.Fprintf(w, "\n%d tool(s): minimumReleaseAge could not be verified, installed anyway:\n", len(unv))
+		for _, u := range unv {
+			fmt.Fprintf(w, "  - %s (source: %s): %s\n", u.Name, u.Source, u.Reason)
+		}
 	}
 
 	return applyErr

--- a/internal/age/age.go
+++ b/internal/age/age.go
@@ -172,7 +172,7 @@ func New(aquaClient AquaReleaseClient, httpClient *http.Client, opts ...Option) 
 		}
 	}
 	inner := &dispatchFetcher{
-		aqua:         &aquaFetcher{client: aquaClient},
+		aqua:         &aquaFetcher{client: aquaClient, timeout: cfg.perRequestTimeout},
 		lastModified: &lastModifiedFetcher{client: httpClient, timeout: cfg.perRequestTimeout, allowLoopback: cfg.allowLoopback},
 	}
 	return &cachedFetcher{inner: inner, cache: make(map[Key]cacheEntry), cfg: cfg}

--- a/internal/age/aqua.go
+++ b/internal/age/aqua.go
@@ -10,6 +10,9 @@ import (
 // (all aqua keys return ok=false, nil).
 type aquaFetcher struct {
 	client AquaReleaseClient
+	// timeout bounds a single GetReleaseByTag call. Zero means no per-request
+	// bound is applied here (the client's own Timeout, if any, still applies).
+	timeout time.Duration
 }
 
 func (a *aquaFetcher) Fetch(ctx context.Context, key Key) (time.Time, bool, error) {
@@ -18,6 +21,11 @@ func (a *aquaFetcher) Fetch(ctx context.Context, key Key) (time.Time, bool, erro
 	}
 	if key.Owner == "" || key.Repo == "" || key.Tag == "" {
 		return time.Time{}, false, nil
+	}
+	if a.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, a.timeout)
+		defer cancel()
 	}
 	rel, err := a.client.GetReleaseByTag(ctx, key.Owner, key.Repo, key.Tag)
 	if err != nil {

--- a/internal/installer/engine/engine.go
+++ b/internal/installer/engine/engine.go
@@ -101,6 +101,10 @@ const (
 // install via direct download (no delegation, no runtime).
 const MethodDownload = "download"
 
+// MethodCommands is the value reported in Event.Method for self-managed
+// tools using the commands pattern.
+const MethodCommands = "commands"
+
 // Event represents an engine event for progress reporting.
 type Event struct {
 	Type       EventType
@@ -1223,7 +1227,7 @@ func (e *Engine) determineInstallMethod(t *resource.Tool) string {
 
 	// Self-managed tool (commands pattern)
 	if spec.Commands != nil {
-		return "commands"
+		return MethodCommands
 	}
 
 	// Runtime delegation (e.g., "go install")

--- a/internal/installer/engine/engine.go
+++ b/internal/installer/engine/engine.go
@@ -13,6 +13,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/terassyi/tomei/internal/age"
 	"github.com/terassyi/tomei/internal/graph"
 	"github.com/terassyi/tomei/internal/installer/download"
 	"github.com/terassyi/tomei/internal/installer/executor"
@@ -164,6 +165,35 @@ type Engine struct {
 	// Counterpart of the privilegeHandler==nil skip for priv tools.
 	skipUserKindRemovals   bool
 	skippedUserKindRemoves int // count of user-kind removals skipped (--system-only)
+
+	// ageFetcher resolves upstream release publication time for the
+	// minimumReleaseAge gate. nil disables the gate entirely.
+	ageFetcher age.Fetcher
+	// skipMu guards skippedReleaseAge and unverifiedReleaseAge, which are
+	// appended from parallel tool-node goroutines during Apply.
+	skipMu               sync.Mutex
+	skippedReleaseAge    []SkipInfo
+	unverifiedReleaseAge []UnverifiedInfo
+}
+
+// SkipInfo records a tool whose install was skipped because its upstream
+// release is younger than the configured minimumReleaseAge.
+type SkipInfo struct {
+	Kind      resource.Kind
+	Name      string
+	MinAge    time.Duration
+	ActualAge time.Duration
+	Source    age.Source
+}
+
+// UnverifiedInfo records a tool whose minimumReleaseAge gate was enabled but
+// could not be evaluated (fetch error or no upstream timestamp available), and
+// which was therefore installed anyway (fail-open). Surfaced so a configured
+// supply-chain control failing open is visible rather than silent.
+type UnverifiedInfo struct {
+	Name   string
+	Source age.Source
+	Reason string
 }
 
 // UpdateConfig holds update-related flags for apply and plan commands.
@@ -174,6 +204,8 @@ type UpdateConfig struct {
 	UpdateTools bool
 	// UpdateRuntimes taints runtimes with VersionKind=alias or latest (for --update-runtimes).
 	UpdateRuntimes bool
+	// IgnoreMinReleaseAge bypasses the minimumReleaseAge gate (for --ignore-min-release-age).
+	IgnoreMinReleaseAge bool
 }
 
 // NewEngine creates a new Engine.
@@ -249,6 +281,30 @@ func (e *Engine) SkippedPrivileged() int {
 	return e.skippedPrivileged
 }
 
+// SetAgeFetcher sets the release-age fetcher backing the minimumReleaseAge
+// gate. A nil fetcher (the default) disables the gate entirely.
+func (e *Engine) SetAgeFetcher(f age.Fetcher) {
+	e.ageFetcher = f
+}
+
+// SkippedReleaseAge returns tools whose install was skipped because their
+// upstream release was younger than the configured minimumReleaseAge. Call
+// after Apply() completes.
+func (e *Engine) SkippedReleaseAge() []SkipInfo {
+	e.skipMu.Lock()
+	defer e.skipMu.Unlock()
+	return slices.Clone(e.skippedReleaseAge)
+}
+
+// UnverifiedReleaseAge returns tools whose minimumReleaseAge gate was enabled
+// but could not be evaluated (and which were installed anyway). Call after
+// Apply() completes.
+func (e *Engine) UnverifiedReleaseAge() []UnverifiedInfo {
+	e.skipMu.Lock()
+	defer e.skipMu.Unlock()
+	return slices.Clone(e.unverifiedReleaseAge)
+}
+
 // SetSkipUserKindRemovals enables the symmetric counterpart of the priv-
 // removal skip for --system-only mode. When true, handleRemovals filters
 // out ActionRemove for non-privileged Tools, Runtimes, and
@@ -307,6 +363,12 @@ func (e *Engine) Apply(ctx context.Context, resources []resource.Resource) error
 	// when the Engine instance is reused (e.g., in tests or orchestration).
 	e.skippedPrivileged = 0
 	e.skippedUserKindRemoves = 0
+	// Guards a concurrent SkippedReleaseAge()/UnverifiedReleaseAge() reader;
+	// Apply itself is not re-entrant (store.Lock + wg.Wait serialize it).
+	e.skipMu.Lock()
+	e.skippedReleaseAge = nil
+	e.unverifiedReleaseAge = nil
+	e.skipMu.Unlock()
 
 	// Expand set resources (ToolSet, etc.) into individual resources
 	var err error
@@ -731,7 +793,7 @@ func (e *Engine) executeNode(
 	case resource.KindInstallerRepository:
 		return e.executeInstallerRepositoryNode(ctx, res.(*resource.InstallerRepository), totalActions)
 	case resource.KindTool:
-		return e.executeToolNode(ctx, res.(*resource.Tool), totalActions)
+		return e.executeToolNode(ctx, res.(*resource.Tool), resourceMap, totalActions)
 	default:
 		slog.Debug("skipping unknown resource kind", "kind", node.Kind, "name", node.Name)
 		return nil
@@ -926,6 +988,7 @@ func (e *Engine) executeInstallerRepositoryNode(
 func (e *Engine) executeToolNode(
 	ctx context.Context,
 	t *resource.Tool,
+	resourceMap map[string]resource.Resource,
 	totalActions *int,
 ) error {
 	// Build a single-tool state map to avoid removing other tools
@@ -949,6 +1012,16 @@ func (e *Engine) executeToolNode(
 	action := actions[0]
 	if action.Type == resource.ActionNone {
 		return nil
+	}
+
+	// minimumReleaseAge gate: skip installs/upgrades/reinstalls whose upstream
+	// release is younger than the configured threshold. Skipped tools are not
+	// executed, not written to state, and not counted (no error).
+	switch action.Type {
+	case resource.ActionInstall, resource.ActionUpgrade, resource.ActionReinstall:
+		if e.checkReleaseAgeGate(ctx, t, resourceMap) {
+			return nil
+		}
 	}
 
 	// Determine install method
@@ -996,6 +1069,142 @@ func (e *Engine) executeToolNode(
 	return nil
 }
 
+// lookupInstaller resolves the Installer resource a tool references by name.
+// Returns nil for an un-overridden builtin (aqua/download), which is absent
+// from resources (and thus from resourceMap).
+func lookupInstaller(ref string, resourceMap map[string]resource.Resource) *resource.Installer {
+	if ref == "" {
+		return nil
+	}
+	if res, ok := resourceMap[graph.NewNodeID(resource.KindInstaller, ref).String()]; ok {
+		if inst, ok := res.(*resource.Installer); ok {
+			return inst
+		}
+	}
+	return nil
+}
+
+// releaseAgeKeyAndThreshold classifies a tool for the minimumReleaseAge gate.
+// It is pure (no I/O). enabled is false when the gate does not apply: commands
+// pattern, runtime delegation, delegation installer, no fetchable source, or a
+// zero/unset threshold.
+//
+// Classification is by installer TYPE, not name: any download-type installer
+// (builtin aqua/download, an override, or a user-declared type:download
+// installer) is gateable. The source is chosen by what the tool carries — a
+// registry package (owner/repo) uses the GitHub Releases published_at; an
+// explicit Source.URL uses the HTTP Last-Modified header.
+//
+// v1 limitation: the aqua tag is taken directly from spec.Version. aqua
+// registries often apply version_prefix/trimV, so the GitHub tag may differ;
+// on mismatch GetReleaseByTag 404s and the gate fails open (surfaced via
+// UnverifiedReleaseAge). Registry-based tag resolution is a follow-up.
+func (e *Engine) releaseAgeKeyAndThreshold(
+	t *resource.Tool,
+	resourceMap map[string]resource.Resource,
+) (age.Key, time.Duration, bool) {
+	spec := t.ToolSpec
+
+	// Commands pattern and runtime delegation are the tool's own / the user
+	// command's responsibility (#253), never gated here.
+	if spec.Commands != nil || spec.RuntimeRef != "" {
+		return age.Key{}, 0, false
+	}
+
+	inst := lookupInstaller(spec.InstallerRef, resourceMap)
+	if inst != nil && inst.InstallerSpec != nil && inst.InstallerSpec.Type.IsDelegation() {
+		return age.Key{}, 0, false
+	}
+
+	var key age.Key
+	switch {
+	case spec.Package.IsRegistry():
+		key = age.Key{
+			Source: age.SourceAquaGitHubReleases,
+			Owner:  spec.Package.Owner,
+			Repo:   spec.Package.Repo,
+			Tag:    spec.Version,
+		}
+	case spec.Source != nil && spec.Source.URL != "":
+		key = age.Key{Source: age.SourceLastModified, URL: spec.Source.URL}
+	default:
+		return age.Key{}, 0, false
+	}
+
+	// Threshold comes from the referenced installer's spec. An un-overridden
+	// builtin (inst == nil) carries no threshold, so the gate is opt-in.
+	if inst == nil || inst.InstallerSpec == nil {
+		return age.Key{}, 0, false
+	}
+	minAge, err := inst.InstallerSpec.ParsedMinimumReleaseAge()
+	if err != nil || minAge == 0 {
+		return age.Key{}, 0, false
+	}
+	return key, minAge, true
+}
+
+// checkReleaseAgeGate reports whether a tool install should be SKIPPED because
+// its upstream release is younger than the configured minimumReleaseAge.
+//
+// Fail-open: if the gate is enabled but the release time cannot be fetched
+// (network error, 404 tag mismatch, missing header), the install proceeds and
+// the tool is recorded via UnverifiedReleaseAge so the failure is visible
+// rather than silent.
+func (e *Engine) checkReleaseAgeGate(
+	ctx context.Context,
+	t *resource.Tool,
+	resourceMap map[string]resource.Resource,
+) bool {
+	if e.ageFetcher == nil || e.updateCfg.IgnoreMinReleaseAge {
+		return false
+	}
+	key, minAge, enabled := e.releaseAgeKeyAndThreshold(t, resourceMap)
+	if !enabled {
+		return false
+	}
+
+	publishedAt, ok, err := e.ageFetcher.Fetch(ctx, key)
+	if err != nil {
+		slog.Warn("minimumReleaseAge gate could not be evaluated; installing anyway",
+			"tool", t.Name(), "source", key.Source, "error", err)
+		e.recordUnverified(UnverifiedInfo{Name: t.Name(), Source: key.Source, Reason: "fetch error: " + err.Error()})
+		return false
+	}
+	if !ok {
+		slog.Warn("minimumReleaseAge gate could not be evaluated; installing anyway",
+			"tool", t.Name(), "source", key.Source, "reason", "no release timestamp available")
+		e.recordUnverified(UnverifiedInfo{Name: t.Name(), Source: key.Source, Reason: "no release timestamp available"})
+		return false
+	}
+
+	actualAge := time.Since(publishedAt)
+	if actualAge >= minAge {
+		return false
+	}
+
+	// Warn (not Info) so a fired gate is never wholly silent under --quiet,
+	// which suppresses the fmt summary but not Warn-level logs.
+	slog.Warn("skipping install: release younger than minimumReleaseAge",
+		"tool", t.Name(), "source", key.Source, "minAge", minAge, "actualAge", actualAge)
+	e.recordSkip(SkipInfo{
+		Kind: resource.KindTool, Name: t.Name(),
+		MinAge: minAge, ActualAge: actualAge, Source: key.Source,
+	})
+	return true
+}
+
+func (e *Engine) recordSkip(s SkipInfo) {
+	e.skipMu.Lock()
+	defer e.skipMu.Unlock()
+	e.skippedReleaseAge = append(e.skippedReleaseAge, s)
+}
+
+func (e *Engine) recordUnverified(u UnverifiedInfo) {
+	e.skipMu.Lock()
+	defer e.skipMu.Unlock()
+	e.unverifiedReleaseAge = append(e.unverifiedReleaseAge, u)
+}
+
 // determineInstallMethod returns the install method string for a tool.
 func (e *Engine) determineInstallMethod(t *resource.Tool) string {
 	spec := t.ToolSpec
@@ -1033,13 +1242,9 @@ func delegationKeyForTool(t *resource.Tool, resourceMap map[string]resource.Reso
 	}
 	// Check InstallerRef for delegation-type installers via resource map
 	if ref := t.ToolSpec.InstallerRef; ref != "" {
-		instID := graph.NewNodeID(resource.KindInstaller, ref).String()
-		if inst, ok := resourceMap[instID]; ok {
-			if installer, ok := inst.(*resource.Installer); ok && installer.InstallerSpec != nil {
-				if installer.InstallerSpec.Type.IsDelegation() {
-					return "installer:" + ref
-				}
-			}
+		if inst := lookupInstaller(ref, resourceMap); inst != nil &&
+			inst.InstallerSpec != nil && inst.InstallerSpec.Type.IsDelegation() {
+			return "installer:" + ref
 		}
 	}
 	return "" // download pattern

--- a/internal/installer/engine/engine.go
+++ b/internal/installer/engine/engine.go
@@ -1163,17 +1163,21 @@ func (e *Engine) checkReleaseAgeGate(
 		return false
 	}
 
+	// Pre-flight: an aqua key whose tag is unresolved (empty / "latest") can
+	// never match a GitHub release, so the fetcher would just fail open with a
+	// generic reason. Surface a precise one instead, without a pointless call.
+	if key.Source == age.SourceAquaGitHubReleases && resource.ClassifyVersion(key.Tag) != resource.VersionExact {
+		e.failOpenReleaseAge(t.Name(), key.Source, "tool version is unresolved (e.g. latest); cannot determine the GitHub release tag")
+		return false
+	}
+
 	publishedAt, ok, err := e.ageFetcher.Fetch(ctx, key)
 	if err != nil {
-		slog.Warn("minimumReleaseAge gate could not be evaluated; installing anyway",
-			"tool", t.Name(), "source", key.Source, "error", err)
-		e.recordUnverified(UnverifiedInfo{Name: t.Name(), Source: key.Source, Reason: "fetch error: " + err.Error()})
+		e.failOpenReleaseAge(t.Name(), key.Source, "fetch error: "+err.Error())
 		return false
 	}
 	if !ok {
-		slog.Warn("minimumReleaseAge gate could not be evaluated; installing anyway",
-			"tool", t.Name(), "source", key.Source, "reason", "no release timestamp available")
-		e.recordUnverified(UnverifiedInfo{Name: t.Name(), Source: key.Source, Reason: "no release timestamp available"})
+		e.failOpenReleaseAge(t.Name(), key.Source, "no release timestamp available")
 		return false
 	}
 
@@ -1203,6 +1207,14 @@ func (e *Engine) recordUnverified(u UnverifiedInfo) {
 	e.skipMu.Lock()
 	defer e.skipMu.Unlock()
 	e.unverifiedReleaseAge = append(e.unverifiedReleaseAge, u)
+}
+
+// failOpenReleaseAge records that an enabled gate could not be evaluated and
+// warns (Warn so it survives --quiet), so the fail-open is visible, not silent.
+func (e *Engine) failOpenReleaseAge(name string, source age.Source, reason string) {
+	slog.Warn("minimumReleaseAge gate could not be evaluated; installing anyway",
+		"tool", name, "source", source, "reason", reason)
+	e.recordUnverified(UnverifiedInfo{Name: name, Source: source, Reason: reason})
 }
 
 // determineInstallMethod returns the install method string for a tool.

--- a/internal/installer/engine/engine_test.go
+++ b/internal/installer/engine/engine_test.go
@@ -809,6 +809,21 @@ func TestApply_ReleaseAgeGate_FailOpenVisible(t *testing.T) {
 		assert.True(t, rec.installed("gh"))
 		require.Len(t, eng.UnverifiedReleaseAge(), 1)
 	})
+	// An unresolved aqua tag (empty / "latest") is reported as unverified
+	// without consulting the fetcher.
+	t.Run("unresolved version pre-flight", func(t *testing.T) {
+		t.Parallel()
+		rec := &installRecorder{}
+		fetcher := &fakeFetcher{}
+		eng := newGateEngine(t, rec, fetcher)
+		require.NoError(t, eng.Apply(context.Background(), []resource.Resource{
+			aquaInstallerOverride(), aquaToolResource("gh", "cli", "cli", "latest"),
+		}))
+		assert.True(t, rec.installed("gh"))
+		require.Len(t, eng.UnverifiedReleaseAge(), 1)
+		assert.Contains(t, eng.UnverifiedReleaseAge()[0].Reason, "unresolved")
+		assert.Equal(t, int64(0), fetcher.calls.Load(), "pre-flight must not call the fetcher")
+	})
 }
 
 func TestReleaseAgeKeyAndThreshold(t *testing.T) {

--- a/internal/installer/engine/engine_test.go
+++ b/internal/installer/engine/engine_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/terassyi/tomei/internal/age"
 	"github.com/terassyi/tomei/internal/config"
 	"github.com/terassyi/tomei/internal/graph"
 	"github.com/terassyi/tomei/internal/installer/download"
@@ -494,6 +495,374 @@ func TestEngine_Apply_RejectsInvalidRuntimeMinimumReleaseAge(t *testing.T) {
 	err = eng.Apply(context.Background(), resources)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid runtime")
+}
+
+// --- minimumReleaseAge apply-time gate (#254) ---
+
+// fakeFetcher is an age.Fetcher whose answers are keyed by age.Key (an
+// all-string, comparable struct). It returns absolute timestamps and counts
+// calls so tests can assert the classifier short-circuits before any I/O.
+type fakeFetcher struct {
+	times  map[age.Key]time.Time
+	errs   map[age.Key]error
+	misses map[age.Key]bool // ok=false, nil err
+	calls  atomic.Int64
+}
+
+func (f *fakeFetcher) Fetch(_ context.Context, k age.Key) (time.Time, bool, error) {
+	f.calls.Add(1)
+	if e, ok := f.errs[k]; ok {
+		return time.Time{}, false, e
+	}
+	if f.misses[k] {
+		return time.Time{}, false, nil
+	}
+	if t, ok := f.times[k]; ok {
+		return t, true, nil
+	}
+	return time.Time{}, false, nil
+}
+
+// installRecorder captures which tools the engine actually installed. Install
+// runs on parallel node goroutines, so access is mutex-guarded.
+type installRecorder struct {
+	mu    sync.Mutex
+	names map[string]bool
+}
+
+func (r *installRecorder) toolMock() *mockToolInstaller {
+	return &mockToolInstaller{
+		installFunc: func(_ context.Context, res *resource.Tool, name string) (*resource.ToolState, error) {
+			r.mu.Lock()
+			if r.names == nil {
+				r.names = make(map[string]bool)
+			}
+			r.names[name] = true
+			r.mu.Unlock()
+			return &resource.ToolState{
+				InstallerRef: res.ToolSpec.InstallerRef,
+				Version:      res.ToolSpec.Version,
+				InstallPath:  "/tools/" + name,
+				BinPath:      "/bin/" + name,
+			}, nil
+		},
+	}
+}
+
+func (r *installRecorder) installed(name string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.names[name]
+}
+
+func aquaInstallerOverride() *resource.Installer {
+	return &resource.Installer{
+		BaseResource:  resource.BaseResource{APIVersion: resource.GroupVersion, ResourceKind: resource.KindInstaller, Metadata: resource.Metadata{Name: resource.InstallerNameAqua}},
+		InstallerSpec: &resource.InstallerSpec{Type: resource.InstallTypeDownload, MinimumReleaseAge: "168h"},
+	}
+}
+
+func aquaToolResource(name, owner, repo, version string) *resource.Tool {
+	return &resource.Tool{
+		BaseResource: resource.BaseResource{APIVersion: resource.GroupVersion, ResourceKind: resource.KindTool, Metadata: resource.Metadata{Name: name}},
+		ToolSpec:     &resource.ToolSpec{InstallerRef: resource.InstallerNameAqua, Version: version, Package: &resource.Package{Owner: owner, Repo: repo}},
+	}
+}
+
+func downloadInstallerResource(name, minAge string) *resource.Installer {
+	return &resource.Installer{
+		BaseResource:  resource.BaseResource{APIVersion: resource.GroupVersion, ResourceKind: resource.KindInstaller, Metadata: resource.Metadata{Name: name}},
+		InstallerSpec: &resource.InstallerSpec{Type: resource.InstallTypeDownload, MinimumReleaseAge: minAge},
+	}
+}
+
+func downloadToolResource(name, installerRef, url, version string) *resource.Tool {
+	return &resource.Tool{
+		BaseResource: resource.BaseResource{APIVersion: resource.GroupVersion, ResourceKind: resource.KindTool, Metadata: resource.Metadata{Name: name}},
+		ToolSpec: &resource.ToolSpec{
+			InstallerRef: installerRef,
+			Version:      version,
+			Source: &resource.DownloadSource{
+				URL:      url,
+				Checksum: &resource.Checksum{Value: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+			},
+		},
+	}
+}
+
+func newGateEngine(t *testing.T, rec *installRecorder, fetcher age.Fetcher) *Engine {
+	t.Helper()
+	store, err := state.NewStore[state.UserState](t.TempDir())
+	require.NoError(t, err)
+	eng := NewEngine(rec.toolMock(), &mockRuntimeInstaller{}, &mockInstallerRepositoryInstaller{}, store)
+	eng.SetAgeFetcher(fetcher)
+	return eng
+}
+
+func TestApply_ReleaseAgeGate_Aqua(t *testing.T) {
+	t.Parallel()
+	rec := &installRecorder{}
+	key := age.Key{Source: age.SourceAquaGitHubReleases, Owner: "cli", Repo: "cli", Tag: "v2.0.0"}
+	fetcher := &fakeFetcher{times: map[age.Key]time.Time{key: time.Now().Add(-1 * time.Hour)}}
+	eng := newGateEngine(t, rec, fetcher)
+
+	resources := []resource.Resource{
+		aquaInstallerOverride(),
+		aquaToolResource("gh", "cli", "cli", "v2.0.0"),
+	}
+	require.NoError(t, eng.Apply(context.Background(), resources))
+
+	assert.False(t, rec.installed("gh"), "young aqua release must be skipped")
+	skips := eng.SkippedReleaseAge()
+	require.Len(t, skips, 1)
+	assert.Equal(t, "gh", skips[0].Name)
+	assert.Equal(t, age.SourceAquaGitHubReleases, skips[0].Source)
+	assert.Equal(t, 168*time.Hour, skips[0].MinAge)
+	// fetcher returned now-1h; loose bounds keep the assertion deterministic.
+	assert.Greater(t, skips[0].ActualAge, 30*time.Minute)
+	assert.Less(t, skips[0].ActualAge, 168*time.Hour)
+	assert.Empty(t, eng.UnverifiedReleaseAge())
+}
+
+func TestApply_ReleaseAgeGate_LastModified(t *testing.T) {
+	t.Parallel()
+	rec := &installRecorder{}
+	url := "https://example.com/tool.tar.gz"
+	key := age.Key{Source: age.SourceLastModified, URL: url}
+	fetcher := &fakeFetcher{times: map[age.Key]time.Time{key: time.Now().Add(-1 * time.Hour)}}
+	eng := newGateEngine(t, rec, fetcher)
+
+	resources := []resource.Resource{
+		downloadInstallerResource(resource.InstallerNameDownload, "168h"),
+		downloadToolResource("rg", resource.InstallerNameDownload, url, "14.0.0"),
+	}
+	require.NoError(t, eng.Apply(context.Background(), resources))
+
+	assert.False(t, rec.installed("rg"))
+	require.Len(t, eng.SkippedReleaseAge(), 1)
+	assert.Equal(t, age.SourceLastModified, eng.SkippedReleaseAge()[0].Source)
+}
+
+// Proves classification is by installer TYPE, not the literal name "download":
+// a user-declared type:download installer with a custom name is gated too.
+func TestApply_ReleaseAgeGate_CustomDownloadInstaller(t *testing.T) {
+	t.Parallel()
+	rec := &installRecorder{}
+	url := "https://example.com/mytool.tar.gz"
+	key := age.Key{Source: age.SourceLastModified, URL: url}
+	fetcher := &fakeFetcher{times: map[age.Key]time.Time{key: time.Now().Add(-2 * time.Hour)}}
+	eng := newGateEngine(t, rec, fetcher)
+
+	resources := []resource.Resource{
+		downloadInstallerResource("mydl", "168h"),
+		downloadToolResource("mytool", "mydl", url, "1.0.0"),
+	}
+	require.NoError(t, eng.Apply(context.Background(), resources))
+
+	assert.False(t, rec.installed("mytool"))
+	require.Len(t, eng.SkippedReleaseAge(), 1)
+}
+
+func TestApply_ReleaseAgeGate_OverThreshold(t *testing.T) {
+	t.Parallel()
+	rec := &installRecorder{}
+	key := age.Key{Source: age.SourceAquaGitHubReleases, Owner: "cli", Repo: "cli", Tag: "v2.0.0"}
+	fetcher := &fakeFetcher{times: map[age.Key]time.Time{key: time.Now().Add(-1000 * time.Hour)}}
+	eng := newGateEngine(t, rec, fetcher)
+
+	resources := []resource.Resource{
+		aquaInstallerOverride(),
+		aquaToolResource("gh", "cli", "cli", "v2.0.0"),
+	}
+	require.NoError(t, eng.Apply(context.Background(), resources))
+
+	assert.True(t, rec.installed("gh"), "release older than threshold must install")
+	assert.Empty(t, eng.SkippedReleaseAge())
+}
+
+// The gate must also fire on the upgrade path (not just first install), and a
+// skipped upgrade must NOT advance persisted state.
+func TestApply_ReleaseAgeGate_Upgrade(t *testing.T) {
+	t.Parallel()
+	rec := &installRecorder{}
+	stateDir := t.TempDir()
+	store, err := state.NewStore[state.UserState](stateDir)
+	require.NoError(t, err)
+	require.NoError(t, store.Lock())
+	initial := state.NewUserState()
+	initial.Tools["gh"] = &resource.ToolState{InstallerRef: resource.InstallerNameAqua, Version: "v1.0.0", InstallPath: "/tools/gh/v1.0.0", BinPath: "/bin/gh"}
+	require.NoError(t, store.Save(initial))
+	_ = store.Unlock()
+
+	key := age.Key{Source: age.SourceAquaGitHubReleases, Owner: "cli", Repo: "cli", Tag: "v2.0.0"}
+	eng := NewEngine(rec.toolMock(), &mockRuntimeInstaller{}, &mockInstallerRepositoryInstaller{}, store)
+	eng.SetAgeFetcher(&fakeFetcher{times: map[age.Key]time.Time{key: time.Now().Add(-1 * time.Hour)}})
+
+	resources := []resource.Resource{
+		aquaInstallerOverride(),
+		aquaToolResource("gh", "cli", "cli", "v2.0.0"),
+	}
+	require.NoError(t, eng.Apply(context.Background(), resources))
+
+	assert.False(t, rec.installed("gh"), "young upgrade must be skipped")
+	require.Len(t, eng.SkippedReleaseAge(), 1)
+
+	require.NoError(t, store.Lock())
+	defer func() { _ = store.Unlock() }()
+	st, err := store.Load()
+	require.NoError(t, err)
+	assert.Equal(t, "v1.0.0", st.Tools["gh"].Version, "skipped upgrade must not advance state")
+}
+
+// Locks the `actualAge >= minAge` boundary direction (at/over threshold installs).
+func TestApply_ReleaseAgeGate_ThresholdBoundary(t *testing.T) {
+	t.Parallel()
+	key := age.Key{Source: age.SourceAquaGitHubReleases, Owner: "cli", Repo: "cli", Tag: "v2.0.0"}
+	tests := []struct {
+		name        string
+		publishedAt time.Time
+		wantInstall bool
+	}{
+		{"just over threshold installs", time.Now().Add(-168*time.Hour - time.Minute), true},
+		{"just under threshold skips", time.Now().Add(-167 * time.Hour), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rec := &installRecorder{}
+			eng := newGateEngine(t, rec, &fakeFetcher{times: map[age.Key]time.Time{key: tt.publishedAt}})
+			require.NoError(t, eng.Apply(context.Background(), []resource.Resource{
+				aquaInstallerOverride(), aquaToolResource("gh", "cli", "cli", "v2.0.0"),
+			}))
+			assert.Equal(t, tt.wantInstall, rec.installed("gh"))
+		})
+	}
+}
+
+func TestApply_ReleaseAgeGate_DelegationNoOp(t *testing.T) {
+	t.Parallel()
+	rec := &installRecorder{}
+	fetcher := &fakeFetcher{} // any Fetch would be a bug
+	eng := newGateEngine(t, rec, fetcher)
+
+	resources := []resource.Resource{
+		&resource.Installer{
+			BaseResource:  resource.BaseResource{APIVersion: resource.GroupVersion, ResourceKind: resource.KindInstaller, Metadata: resource.Metadata{Name: "brew"}},
+			InstallerSpec: &resource.InstallerSpec{Type: resource.InstallTypeDelegation, MinimumReleaseAge: "168h", Commands: &resource.CommandsSpec{Install: []string{"brew install {{.Name}}"}}},
+		},
+		&resource.Tool{
+			BaseResource: resource.BaseResource{APIVersion: resource.GroupVersion, ResourceKind: resource.KindTool, Metadata: resource.Metadata{Name: "jq"}},
+			ToolSpec:     &resource.ToolSpec{InstallerRef: "brew", Version: "1.7", Package: &resource.Package{Name: "jq"}},
+		},
+	}
+	require.NoError(t, eng.Apply(context.Background(), resources))
+
+	assert.True(t, rec.installed("jq"), "delegation installs are never gated")
+	assert.Empty(t, eng.SkippedReleaseAge())
+	assert.Equal(t, int64(0), fetcher.calls.Load(), "classifier must short-circuit before any fetch")
+}
+
+func TestApply_IgnoreMinReleaseAge(t *testing.T) {
+	t.Parallel()
+	rec := &installRecorder{}
+	key := age.Key{Source: age.SourceAquaGitHubReleases, Owner: "cli", Repo: "cli", Tag: "v2.0.0"}
+	fetcher := &fakeFetcher{times: map[age.Key]time.Time{key: time.Now().Add(-1 * time.Hour)}} // would gate
+	eng := newGateEngine(t, rec, fetcher)
+	eng.SetUpdateConfig(UpdateConfig{IgnoreMinReleaseAge: true})
+
+	resources := []resource.Resource{
+		aquaInstallerOverride(),
+		aquaToolResource("gh", "cli", "cli", "v2.0.0"),
+	}
+	require.NoError(t, eng.Apply(context.Background(), resources))
+
+	assert.True(t, rec.installed("gh"), "--ignore-min-release-age installs regardless")
+	assert.Empty(t, eng.SkippedReleaseAge())
+}
+
+// Fail-open must be VISIBLE: an enabled gate that can't be evaluated installs
+// anyway but is recorded in UnverifiedReleaseAge.
+func TestApply_ReleaseAgeGate_FailOpenVisible(t *testing.T) {
+	t.Parallel()
+	t.Run("fetch error", func(t *testing.T) {
+		t.Parallel()
+		rec := &installRecorder{}
+		key := age.Key{Source: age.SourceAquaGitHubReleases, Owner: "cli", Repo: "cli", Tag: "v2.0.0"}
+		fetcher := &fakeFetcher{errs: map[age.Key]error{key: fmt.Errorf("boom")}}
+		eng := newGateEngine(t, rec, fetcher)
+		require.NoError(t, eng.Apply(context.Background(), []resource.Resource{
+			aquaInstallerOverride(), aquaToolResource("gh", "cli", "cli", "v2.0.0"),
+		}))
+		assert.True(t, rec.installed("gh"))
+		require.Len(t, eng.UnverifiedReleaseAge(), 1)
+		assert.Equal(t, "gh", eng.UnverifiedReleaseAge()[0].Name)
+	})
+	t.Run("source unavailable", func(t *testing.T) {
+		t.Parallel()
+		rec := &installRecorder{}
+		key := age.Key{Source: age.SourceAquaGitHubReleases, Owner: "cli", Repo: "cli", Tag: "v2.0.0"}
+		fetcher := &fakeFetcher{misses: map[age.Key]bool{key: true}}
+		eng := newGateEngine(t, rec, fetcher)
+		require.NoError(t, eng.Apply(context.Background(), []resource.Resource{
+			aquaInstallerOverride(), aquaToolResource("gh", "cli", "cli", "v2.0.0"),
+		}))
+		assert.True(t, rec.installed("gh"))
+		require.Len(t, eng.UnverifiedReleaseAge(), 1)
+	})
+}
+
+func TestReleaseAgeKeyAndThreshold(t *testing.T) {
+	t.Parallel()
+	url := "https://example.com/x.tar.gz"
+	resources := []resource.Resource{
+		aquaInstallerOverride(),
+		downloadInstallerResource(resource.InstallerNameDownload, "72h"),
+		downloadInstallerResource("mydl", "24h"),
+		&resource.Installer{
+			BaseResource:  resource.BaseResource{APIVersion: resource.GroupVersion, ResourceKind: resource.KindInstaller, Metadata: resource.Metadata{Name: "brew"}},
+			InstallerSpec: &resource.InstallerSpec{Type: resource.InstallTypeDelegation, MinimumReleaseAge: "168h", Commands: &resource.CommandsSpec{Install: []string{"x"}}},
+		},
+	}
+	rm := buildResourceMap(resources)
+	eng := &Engine{ageFetcher: &fakeFetcher{}} // ageFetcher non-nil so the helper isn't bypassed
+
+	tests := []struct {
+		name        string
+		tool        *resource.Tool
+		wantEnabled bool
+		wantSource  age.Source
+		wantMinAge  time.Duration
+	}{
+		{"aqua", aquaToolResource("gh", "cli", "cli", "v2.0.0"), true, age.SourceAquaGitHubReleases, 168 * time.Hour},
+		{"download builtin", downloadToolResource("rg", resource.InstallerNameDownload, url, "1.0.0"), true, age.SourceLastModified, 72 * time.Hour},
+		{"custom download", downloadToolResource("c", "mydl", url, "1.0.0"), true, age.SourceLastModified, 24 * time.Hour},
+		{"delegation", &resource.Tool{BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "jq"}}, ToolSpec: &resource.ToolSpec{InstallerRef: "brew", Version: "1.7", Package: &resource.Package{Name: "jq"}}}, false, "", 0},
+		{"runtime", &resource.Tool{BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "gopls"}}, ToolSpec: &resource.ToolSpec{RuntimeRef: "go", Version: "v1", Package: &resource.Package{Name: "x"}}}, false, "", 0},
+		{"commands", &resource.Tool{BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "cm"}}, ToolSpec: &resource.ToolSpec{Commands: &resource.ToolCommandSet{}, Version: "1"}}, false, "", 0},
+		{"aqua override different repo", aquaToolResource("other", "o", "r", "v1"), true, age.SourceAquaGitHubReleases, 168 * time.Hour}, // resolves the Installer/aqua override in rm
+		// download installer referenced but neither registry package nor Source.URL → no fetchable source → disabled.
+		{"download no source", &resource.Tool{BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "ns"}}, ToolSpec: &resource.ToolSpec{InstallerRef: resource.InstallerNameDownload, Version: "1", Package: &resource.Package{Name: "ns"}}}, false, "", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			key, minAge, enabled := eng.releaseAgeKeyAndThreshold(tt.tool, rm)
+			assert.Equal(t, tt.wantEnabled, enabled)
+			if tt.wantEnabled {
+				assert.Equal(t, tt.wantSource, key.Source)
+				assert.Equal(t, tt.wantMinAge, minAge)
+			}
+		})
+	}
+
+	// Opt-in contract: an aqua tool with NO Installer/aqua override (builtin,
+	// absent from the resource map) is disabled — the gate never fires by default.
+	t.Run("aqua builtin no override disabled", func(t *testing.T) {
+		t.Parallel()
+		rmNoOverride := buildResourceMap([]resource.Resource{}) // no Installer/aqua
+		_, _, enabled := eng.releaseAgeKeyAndThreshold(aquaToolResource("gh", "cli", "cli", "v2.0.0"), rmNoOverride)
+		assert.False(t, enabled)
+	})
 }
 
 func TestEngine_TaintDependentTools(t *testing.T) {

--- a/tests/release_age_integration_test.go
+++ b/tests/release_age_integration_test.go
@@ -1,0 +1,64 @@
+//go:build integration
+
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/terassyi/tomei/internal/age"
+	"github.com/terassyi/tomei/internal/github"
+	"github.com/terassyi/tomei/internal/registry/aqua"
+)
+
+// TestReleaseAgeFetcher_Aqua_RealGitHub exercises the minimumReleaseAge gate's
+// aqua backend end-to-end against the real GitHub Releases API: the path the
+// engine takes is age.New(aqua.NewVersionClient(...)) → GetReleaseByTag →
+// published_at decode.
+//
+// It asserts only the time-monotonic direction to avoid rot: a long-ago release
+// resolves a real publication time before a hard-coded past date. (Gate-hit /
+// "younger than threshold" decisions are covered deterministically by the unit
+// fake in internal/installer/engine; a live "recent release" assertion would
+// invert as the release ages.)
+func TestReleaseAgeFetcher_Aqua_RealGitHub(t *testing.T) {
+	token := github.TokenFromEnv()
+	if token == "" {
+		t.Skip("real-GitHub release-age test requires GITHUB_TOKEN or GH_TOKEN (unauthenticated rate limit is 60/h)")
+	}
+
+	fetcher := age.New(aqua.NewVersionClient(github.NewHTTPClient(token)), nil)
+
+	// cli/cli v1.0.0 was published 2020-09-16; this fact never changes.
+	key := age.Key{Source: age.SourceAquaGitHubReleases, Owner: "cli", Repo: "cli", Tag: "v1.0.0"}
+	publishedAt, ok, err := fetcher.Fetch(context.Background(), key)
+	require.NoError(t, err)
+	require.True(t, ok, "a known release must resolve a publication time")
+
+	cutoff := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	assert.True(t, publishedAt.Before(cutoff),
+		"cli/cli v1.0.0 should resolve a 2020 publish time, got %s", publishedAt)
+	// And it is comfortably older than any realistic threshold → would install.
+	assert.Greater(t, time.Since(publishedAt), 8760*time.Hour, "release should be >1y old")
+}
+
+// TestReleaseAgeFetcher_Aqua_TagMismatch_FailsOpen documents the v1 limitation:
+// when the GitHub tag cannot be found (e.g. version_prefix mismatch), the
+// fetcher reports the failure rather than a timestamp, and the engine gate
+// fails open (surfaced via UnverifiedReleaseAge).
+func TestReleaseAgeFetcher_Aqua_TagMismatch_FailsOpen(t *testing.T) {
+	token := github.TokenFromEnv()
+	if token == "" {
+		t.Skip("real-GitHub release-age test requires GITHUB_TOKEN or GH_TOKEN")
+	}
+
+	fetcher := age.New(aqua.NewVersionClient(github.NewHTTPClient(token)), nil)
+	key := age.Key{Source: age.SourceAquaGitHubReleases, Owner: "cli", Repo: "cli", Tag: "v0.0.0-does-not-exist"}
+	_, ok, err := fetcher.Fetch(context.Background(), key)
+	assert.False(t, ok, "a nonexistent tag must not resolve a timestamp")
+	assert.Error(t, err, "a 404 surfaces as an error → gate fails open")
+}


### PR DESCRIPTION
Core enforcement for the minimumReleaseAge supply-chain gate (sub-task #254
of tracking issue #257). engine.Apply consults the release-age fetcher (#252)
for each Install/Upgrade/Reinstall tool action and skips tools whose upstream
release is younger than the configured threshold.

- engine: classify each tool by installer TYPE (not name) — any download-type
  installer is gateable; a registry package uses the GitHub Releases
  published_at, an explicit Source.URL uses HTTP Last-Modified. Delegation
  installers, runtime delegation, and the commands pattern are never gated
  (#253's template-var territory). The threshold comes from the referenced
  Installer's spec, so the gate is opt-in via an explicit Installer/aqua or
  Installer/download (or custom type:download) override; builtins carry none.
- The gate is wired into executeToolNode only. The taint-reinstall path
  (handleTaintedTools) is intentionally not gated: it only ever reinstalls
  runtime-delegation tools, which the gate disables anyway, so a gate there
  would be unreachable; the gateable Reinstalls (--update/--sync) flow through
  executeToolNode.
- Fail-open but VISIBLE: when an enabled gate can't be evaluated (network
  error, 404 tag mismatch, missing header) the install proceeds and the tool
  is surfaced via UnverifiedReleaseAge + a Warn log, rather than silently. A
  fired gate also logs at Warn so it is never silent under --quiet.
- cmd: --ignore-min-release-age escape hatch; fetcher injected with a nil
  httpClient so age uses its own SSRF-hardened client for arbitrary
  Last-Modified hosts (the GitHub-token client only ever reaches
  api.github.com). Two post-apply summary blocks for skipped/unverified tools.
- age: aquaFetcher now applies its own per-request timeout, matching
  lastModifiedFetcher, so the bound holds independent of the injected client.

v1 limitation: the aqua tag is taken from spec.Version; aqua registries often
apply version_prefix/trimV, so a mismatched GitHub tag 404s and the gate fails
open (surfaced via UnverifiedReleaseAge). Registry-based tag resolution and a
fail-closed --strict mode are follow-ups.

Tests: unit coverage for aqua/last-modified/custom-download gating, over- and
at-threshold boundaries, the upgrade path (state not advanced), delegation
no-op (no fetch), --ignore, visible fail-open, the opt-in no-override default,
and a pure classifier table; plus a durable real-GitHub integration test
(skips without a token).

Refs #257
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
