### PR TITLE
feat(plan): plan-time minimumReleaseAge advisory + delegation lint

### DIFF
--- a/cmd/tomei/plan.go
+++ b/cmd/tomei/plan.go
@@ -8,10 +8,12 @@ import (
 	"log/slog"
 	"os"
 	"slices"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
+	"github.com/terassyi/tomei/internal/age"
 	"github.com/terassyi/tomei/internal/config"
 	"github.com/terassyi/tomei/internal/github"
 	"github.com/terassyi/tomei/internal/graph"
@@ -132,6 +134,14 @@ func runPlan(cmd *cobra.Command, args []string) error {
 	// Inject disabled resource info into the plan
 	addDisabledResourceInfo(result.resourceInfo, disabledResources)
 
+	// Delegation lint (non-fatal): warn when minimumReleaseAge is declared but
+	// no install command references it. Emitted to stderr regardless of output
+	// format so machine-readable plan output stays clean.
+	errW := cmd.ErrOrStderr()
+	for _, w := range resource.LintMinimumReleaseAge(resources) {
+		fmt.Fprintf(errW, "warning: %s\n", w)
+	}
+
 	// Output based on format
 	switch planCfg.outputFormat {
 	case outputJSON:
@@ -143,6 +153,13 @@ func runPlan(cmd *cobra.Command, args []string) error {
 	case outputText:
 		fallthrough
 	default:
+		// minimumReleaseAge advisory annotation (text path only — Note is not
+		// serialized into JSON/YAML, and fetching there would be wasted).
+		ctx := cmd.Context()
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		annotateReleaseAgeAdvisory(ctx, errW, resources, result.resourceInfo)
 		return printTextPlan(cmd, args, resources, result)
 	}
 }
@@ -717,4 +734,92 @@ func syncRegistryForPlan(ctx context.Context) error {
 
 	ghClient := github.NewHTTPClient(github.TokenFromEnv())
 	return aqua.SyncRegistry(ctx, store, ghClient)
+}
+
+// advisoryEntry pairs a tool's plan node with its release-age gate key and
+// per-tool threshold (two tools may share a key but carry different thresholds).
+type advisoryEntry struct {
+	nodeID graph.NodeID
+	key    age.Key
+	minAge time.Duration
+}
+
+// annotateReleaseAgeAdvisory annotates ResourceInfo.Note for change-action
+// Tools whose upstream release is younger than a configured minimumReleaseAge.
+// Informational only — apply re-fetches and re-decides. It builds the real
+// release-age fetcher (token only reaches api.github.com; nil httpClient gives
+// age its SSRF-hardened client for arbitrary Last-Modified hosts) and delegates
+// to annotateReleaseAgeAdvisoryWith, which is the testable seam.
+func annotateReleaseAgeAdvisory(ctx context.Context, errW io.Writer, resources []resource.Resource, info map[graph.NodeID]graph.ResourceInfo) {
+	f := age.New(aqua.NewVersionClient(github.NewHTTPClient(github.TokenFromEnv())), nil)
+	annotateReleaseAgeAdvisoryWith(ctx, errW, resources, info, f)
+}
+
+func annotateReleaseAgeAdvisoryWith(ctx context.Context, errW io.Writer, resources []resource.Resource, info map[graph.NodeID]graph.ResourceInfo, f age.Fetcher) {
+	resourceMap := engine.BuildResourceMap(resources)
+
+	var entries []advisoryEntry
+	seen := make(map[age.Key]bool)
+	var keys []age.Key
+	for _, res := range resources {
+		tool, ok := res.(*resource.Tool)
+		if !ok {
+			continue
+		}
+		nodeID := graph.NewNodeID(resource.KindTool, tool.Name())
+		ri, ok := info[nodeID]
+		if !ok {
+			continue
+		}
+		switch ri.Action {
+		case resource.ActionInstall, resource.ActionUpgrade, resource.ActionReinstall:
+		default:
+			continue // Skip/None/Remove are never gated (matches apply)
+		}
+		key, minAge, enabled := engine.ReleaseAgeKeyAndThreshold(tool, resourceMap)
+		if !enabled {
+			continue
+		}
+		// Pre-flight: an unresolved aqua tag (empty/"latest") can't match a
+		// release — don't fetch (mirrors the engine gate).
+		if key.Source == age.SourceAquaGitHubReleases && resource.ClassifyVersion(key.Tag) != resource.VersionExact {
+			continue
+		}
+		entries = append(entries, advisoryEntry{nodeID: nodeID, key: key, minAge: minAge})
+		if !seen[key] {
+			seen[key] = true
+			keys = append(keys, key)
+		}
+	}
+	if len(keys) == 0 {
+		return // opt-in fast path: no gated tools → no network
+	}
+
+	// The fetch can take up to age.FetchAll's batch timeout on a slow network;
+	// give the user feedback rather than a silent pause before the tree prints.
+	fmt.Fprintf(errW, "checking minimum release ages for %d tool(s)...\n", len(keys))
+	results := age.FetchAll(ctx, f, keys)
+	byKey := make(map[age.Key]age.Result, len(results))
+	for _, r := range results {
+		byKey[r.Key] = r
+	}
+
+	unverified := 0
+	for _, e := range entries {
+		r, ok := byKey[e.key]
+		if !ok || !r.OK || r.Err != nil {
+			unverified++ // gate configured but couldn't be evaluated
+			continue
+		}
+		if actual := time.Since(r.PublishedAt); actual < e.minAge {
+			ri := info[e.nodeID]
+			ri.Note = fmt.Sprintf("released %s ago, requires %s", actual.Truncate(time.Minute), e.minAge)
+			info[e.nodeID] = ri
+		}
+	}
+	if unverified > 0 {
+		// Visible fail-open: a configured gate that couldn't be evaluated must
+		// not be silent (parity with apply's UnverifiedReleaseAge).
+		fmt.Fprintf(errW, "note: minimumReleaseAge advisory could not be computed for %d tool(s) (network/token unavailable); apply will re-check\n", unverified)
+	}
 }

--- a/cmd/tomei/plan.go
+++ b/cmd/tomei/plan.go
@@ -821,6 +821,6 @@ func annotateReleaseAgeAdvisoryWith(ctx context.Context, errW io.Writer, resourc
 	if unverified > 0 {
 		// Visible fail-open: a configured gate that couldn't be evaluated must
 		// not be silent (parity with apply's UnverifiedReleaseAge).
-		fmt.Fprintf(errW, "note: minimumReleaseAge advisory could not be computed for %d tool(s) (network/token unavailable); apply will re-check\n", unverified)
+		fmt.Fprintf(errW, "note: minimumReleaseAge advisory could not be computed for %d tool(s) (release date unavailable); apply will re-check\n", unverified)
 	}
 }

--- a/cmd/tomei/plan.go
+++ b/cmd/tomei/plan.go
@@ -797,7 +797,8 @@ func annotateReleaseAgeAdvisoryWith(ctx context.Context, errW io.Writer, resourc
 
 	// The fetch can take up to age.FetchAll's batch timeout on a slow network;
 	// give the user feedback rather than a silent pause before the tree prints.
-	fmt.Fprintf(errW, "checking minimum release ages for %d tool(s)...\n", len(keys))
+	// Count tools (entries), not keys — tools sharing a release dedup to one fetch.
+	fmt.Fprintf(errW, "checking minimum release ages for %d tool(s)...\n", len(entries))
 	results := age.FetchAll(ctx, f, keys)
 	byKey := make(map[age.Key]age.Result, len(results))
 	for _, r := range results {

--- a/cmd/tomei/plan_advisory_test.go
+++ b/cmd/tomei/plan_advisory_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/terassyi/tomei/internal/age"
+	"github.com/terassyi/tomei/internal/graph"
+	"github.com/terassyi/tomei/internal/resource"
+)
+
+// fakeFetcher is a deterministic age.Fetcher for advisory tests (copied from the
+// engine's pattern — cross-package unexported types can't be reused).
+type fakeFetcher struct {
+	times map[age.Key]time.Time
+	errs  map[age.Key]error
+	calls atomic.Int64
+}
+
+func (f *fakeFetcher) Fetch(_ context.Context, k age.Key) (time.Time, bool, error) {
+	f.calls.Add(1)
+	if e, ok := f.errs[k]; ok {
+		return time.Time{}, false, e
+	}
+	if t, ok := f.times[k]; ok {
+		return t, true, nil
+	}
+	return time.Time{}, false, nil
+}
+
+func aquaOverride() *resource.Installer {
+	return &resource.Installer{
+		BaseResource:  resource.BaseResource{APIVersion: resource.GroupVersion, ResourceKind: resource.KindInstaller, Metadata: resource.Metadata{Name: resource.InstallerNameAqua}},
+		InstallerSpec: &resource.InstallerSpec{Type: resource.InstallTypeDownload, MinimumReleaseAge: "168h"},
+	}
+}
+
+// aquaTool builds a registry (aqua) tool for cli/cli at the given version.
+func aquaTool(name, version string) *resource.Tool {
+	return &resource.Tool{
+		BaseResource: resource.BaseResource{APIVersion: resource.GroupVersion, ResourceKind: resource.KindTool, Metadata: resource.Metadata{Name: name}},
+		ToolSpec:     &resource.ToolSpec{InstallerRef: resource.InstallerNameAqua, Version: version, Package: &resource.Package{Owner: "cli", Repo: "cli"}},
+	}
+}
+
+func infoWith(action resource.ActionType) (graph.NodeID, map[graph.NodeID]graph.ResourceInfo) {
+	id := graph.NewNodeID(resource.KindTool, "gh")
+	return id, map[graph.NodeID]graph.ResourceInfo{
+		id: {Kind: resource.KindTool, Name: "gh", Action: action},
+	}
+}
+
+func TestAnnotateAdvisory_SetsNote_WhenYounger(t *testing.T) {
+	t.Parallel()
+	key := age.Key{Source: age.SourceAquaGitHubReleases, Owner: "cli", Repo: "cli", Tag: "v2.0.0"}
+	f := &fakeFetcher{times: map[age.Key]time.Time{key: time.Now().Add(-24 * time.Hour)}}
+	id, info := infoWith(resource.ActionInstall)
+	resources := []resource.Resource{aquaOverride(), aquaTool("gh", "v2.0.0")}
+
+	annotateReleaseAgeAdvisoryWith(context.Background(), io.Discard, resources, info, f)
+
+	assert.NotEmpty(t, info[id].Note)
+	assert.Contains(t, info[id].Note, "released")
+	assert.Contains(t, info[id].Note, "requires 168h0m0s")
+}
+
+func TestAnnotateAdvisory_SetsNote_DownloadLastModified(t *testing.T) {
+	t.Parallel()
+	url := "https://example.com/rg.tar.gz"
+	key := age.Key{Source: age.SourceLastModified, URL: url}
+	f := &fakeFetcher{times: map[age.Key]time.Time{key: time.Now().Add(-1 * time.Hour)}}
+	id := graph.NewNodeID(resource.KindTool, "rg")
+	info := map[graph.NodeID]graph.ResourceInfo{id: {Kind: resource.KindTool, Name: "rg", Action: resource.ActionInstall}}
+	resources := []resource.Resource{
+		&resource.Installer{BaseResource: resource.BaseResource{ResourceKind: resource.KindInstaller, Metadata: resource.Metadata{Name: resource.InstallerNameDownload}}, InstallerSpec: &resource.InstallerSpec{Type: resource.InstallTypeDownload, MinimumReleaseAge: "168h"}},
+		&resource.Tool{BaseResource: resource.BaseResource{ResourceKind: resource.KindTool, Metadata: resource.Metadata{Name: "rg"}}, ToolSpec: &resource.ToolSpec{InstallerRef: resource.InstallerNameDownload, Version: "14.0.0", Source: &resource.DownloadSource{URL: url}}},
+	}
+
+	annotateReleaseAgeAdvisoryWith(context.Background(), io.Discard, resources, info, f)
+	assert.NotEmpty(t, info[id].Note)
+}
+
+func TestAnnotateAdvisory_SetsNote_OnUpgrade(t *testing.T) {
+	t.Parallel()
+	key := age.Key{Source: age.SourceAquaGitHubReleases, Owner: "cli", Repo: "cli", Tag: "v2.0.0"}
+	f := &fakeFetcher{times: map[age.Key]time.Time{key: time.Now().Add(-24 * time.Hour)}}
+	id, info := infoWith(resource.ActionUpgrade)
+	annotateReleaseAgeAdvisoryWith(context.Background(), io.Discard, []resource.Resource{aquaOverride(), aquaTool("gh", "v2.0.0")}, info, f)
+	assert.NotEmpty(t, info[id].Note)
+}
+
+func TestAnnotateAdvisory_NoNote_WhenOlder(t *testing.T) {
+	t.Parallel()
+	key := age.Key{Source: age.SourceAquaGitHubReleases, Owner: "cli", Repo: "cli", Tag: "v2.0.0"}
+	f := &fakeFetcher{times: map[age.Key]time.Time{key: time.Now().Add(-200 * time.Hour)}}
+	id, info := infoWith(resource.ActionInstall)
+	annotateReleaseAgeAdvisoryWith(context.Background(), io.Discard, []resource.Resource{aquaOverride(), aquaTool("gh", "v2.0.0")}, info, f)
+	assert.Empty(t, info[id].Note)
+}
+
+func TestAnnotateAdvisory_NoFetch_WhenNoGatedTools(t *testing.T) {
+	t.Parallel()
+	// No Installer/aqua override → no threshold → gate disabled.
+	f := &fakeFetcher{}
+	id, info := infoWith(resource.ActionInstall)
+	annotateReleaseAgeAdvisoryWith(context.Background(), io.Discard, []resource.Resource{aquaTool("gh", "v2.0.0")}, info, f)
+	assert.Empty(t, info[id].Note)
+	assert.Equal(t, int64(0), f.calls.Load())
+}
+
+func TestAnnotateAdvisory_NoFetch_WhenActionNone(t *testing.T) {
+	t.Parallel()
+	f := &fakeFetcher{}
+	for _, action := range []resource.ActionType{resource.ActionNone, resource.ActionSkip} {
+		id, info := infoWith(action)
+		annotateReleaseAgeAdvisoryWith(context.Background(), io.Discard, []resource.Resource{aquaOverride(), aquaTool("gh", "v2.0.0")}, info, f)
+		assert.Empty(t, info[id].Note)
+	}
+	assert.Equal(t, int64(0), f.calls.Load(), "non-change actions must not fetch")
+}
+
+func TestAnnotateAdvisory_SkipsUnresolvedTag(t *testing.T) {
+	t.Parallel()
+	f := &fakeFetcher{}
+	id, info := infoWith(resource.ActionInstall)
+	annotateReleaseAgeAdvisoryWith(context.Background(), io.Discard, []resource.Resource{aquaOverride(), aquaTool("gh", "latest")}, info, f)
+	assert.Empty(t, info[id].Note)
+	assert.Equal(t, int64(0), f.calls.Load(), "unresolved tag must not fetch")
+}
+
+// On a fetch error the install proceeds (no Note) AND the fail-open is made
+// visible via the aggregate stderr note — it must not be silent.
+func TestAnnotateAdvisory_FailOpen_OnError(t *testing.T) {
+	t.Parallel()
+	key := age.Key{Source: age.SourceAquaGitHubReleases, Owner: "cli", Repo: "cli", Tag: "v2.0.0"}
+	f := &fakeFetcher{errs: map[age.Key]error{key: assert.AnError}}
+	id, info := infoWith(resource.ActionInstall)
+	var errW bytes.Buffer
+	annotateReleaseAgeAdvisoryWith(context.Background(), &errW, []resource.Resource{aquaOverride(), aquaTool("gh", "v2.0.0")}, info, f)
+	assert.Empty(t, info[id].Note)
+	assert.Contains(t, errW.String(), "could not be computed for 1 tool(s)")
+}
+
+// A clean fetch that reports ok=false (source has no timestamp) is also a
+// fail-open: no Note, surfaced as unverified — distinct from the error path.
+func TestAnnotateAdvisory_NoNote_WhenSourceUnavailable(t *testing.T) {
+	t.Parallel()
+	// Key mapped into neither times nor errs → fakeFetcher returns (zero, false, nil).
+	f := &fakeFetcher{}
+	id, info := infoWith(resource.ActionInstall)
+	var errW bytes.Buffer
+	annotateReleaseAgeAdvisoryWith(context.Background(), &errW, []resource.Resource{aquaOverride(), aquaTool("gh", "v2.0.0")}, info, f)
+	assert.Empty(t, info[id].Note)
+	assert.Equal(t, int64(1), f.calls.Load(), "source-unavailable still fetches once")
+	assert.Contains(t, errW.String(), "could not be computed")
+}
+
+func TestAnnotateAdvisory_DedupsSharedKey_AnnotatesBoth(t *testing.T) {
+	t.Parallel()
+	key := age.Key{Source: age.SourceAquaGitHubReleases, Owner: "cli", Repo: "cli", Tag: "v2.0.0"}
+	f := &fakeFetcher{times: map[age.Key]time.Time{key: time.Now().Add(-24 * time.Hour)}}
+	idA := graph.NewNodeID(resource.KindTool, "gh-a")
+	idB := graph.NewNodeID(resource.KindTool, "gh-b")
+	info := map[graph.NodeID]graph.ResourceInfo{
+		idA: {Kind: resource.KindTool, Name: "gh-a", Action: resource.ActionInstall},
+		idB: {Kind: resource.KindTool, Name: "gh-b", Action: resource.ActionInstall},
+	}
+	resources := []resource.Resource{aquaOverride(), aquaTool("gh-a", "v2.0.0"), aquaTool("gh-b", "v2.0.0")}
+
+	annotateReleaseAgeAdvisoryWith(context.Background(), io.Discard, resources, info, f)
+
+	assert.NotEmpty(t, info[idA].Note)
+	assert.NotEmpty(t, info[idB].Note)
+	assert.Equal(t, int64(1), f.calls.Load(), "shared key must be fetched once")
+}

--- a/cmd/tomei/plan_advisory_test.go
+++ b/cmd/tomei/plan_advisory_test.go
@@ -173,9 +173,12 @@ func TestAnnotateAdvisory_DedupsSharedKey_AnnotatesBoth(t *testing.T) {
 	}
 	resources := []resource.Resource{aquaOverride(), aquaTool("gh-a", "v2.0.0"), aquaTool("gh-b", "v2.0.0")}
 
-	annotateReleaseAgeAdvisoryWith(context.Background(), io.Discard, resources, info, f)
+	var errW bytes.Buffer
+	annotateReleaseAgeAdvisoryWith(context.Background(), &errW, resources, info, f)
 
 	assert.NotEmpty(t, info[idA].Note)
 	assert.NotEmpty(t, info[idB].Note)
 	assert.Equal(t, int64(1), f.calls.Load(), "shared key must be fetched once")
+	// Progress message counts tools (2), not the deduped key (1).
+	assert.Contains(t, errW.String(), "2 tool(s)")
 }

--- a/cmd/tomei/validate.go
+++ b/cmd/tomei/validate.go
@@ -104,6 +104,12 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	cmd.Printf("  %s No circular dependencies\n", style.SuccessMark)
 	cmd.Println()
 
+	// Delegation lint (non-fatal): minimumReleaseAge declared but no install
+	// command references it. To stderr so it doesn't disturb success output.
+	for _, w := range resource.LintMinimumReleaseAge(resources) {
+		fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s\n", w)
+	}
+
 	cmd.Printf("%s Validation successful (%d resources)\n", style.SuccessMark, len(resources))
 	return nil
 }

--- a/internal/graph/tree.go
+++ b/internal/graph/tree.go
@@ -22,6 +22,10 @@ type ResourceInfo struct {
 	SHA        string
 	Action     resource.ActionType
 	Privileged bool
+	// Note is an informational advisory suffix rendered after the action tag
+	// for change actions (e.g. plan-time minimumReleaseAge would-skip). It
+	// never affects Action or apply behavior. Empty = no annotation.
+	Note string
 }
 
 // TreePrinter prints dependency graphs as ASCII trees with colors.
@@ -207,6 +211,16 @@ func (p *TreePrinter) formatNode(nodeID NodeID, info ResourceInfo, hasInfo bool)
 			sb.WriteString(actionColor.Sprint(nodeName + versionStr + actionStr))
 		} else {
 			sb.WriteString(nodeName + versionStr)
+		}
+
+		// Advisory note (e.g. plan-time minimumReleaseAge would-skip). Rendered
+		// only for change actions and colored separately from the action so it
+		// stays readable; informational, never affects apply.
+		if info.Note != "" &&
+			(info.Action == resource.ActionInstall ||
+				info.Action == resource.ActionUpgrade ||
+				info.Action == resource.ActionReinstall) {
+			sb.WriteString(p.skipColor.Sprintf(" [⚠ would-skip: %s]", info.Note))
 		}
 	} else {
 		sb.WriteString(nodeName)

--- a/internal/graph/tree_test.go
+++ b/internal/graph/tree_test.go
@@ -27,6 +27,50 @@ func TestShortSHA(t *testing.T) {
 	}
 }
 
+// TestFormatNode_NoteRendering pins the plan-time minimumReleaseAge advisory:
+// a Note renders as " [⚠ would-skip: <note>]" after the action tag for change
+// actions.
+func TestFormatNode_NoteRendering(t *testing.T) {
+	t.Parallel()
+	const note = "released 24h0m0s ago, requires 168h0m0s"
+	for _, action := range []resource.ActionType{
+		resource.ActionInstall, resource.ActionUpgrade, resource.ActionReinstall,
+	} {
+		t.Run(string(action), func(t *testing.T) {
+			t.Parallel()
+			p := NewTreePrinter(&bytes.Buffer{}, true)
+			info := ResourceInfo{Kind: resource.KindTool, Name: "gh", Version: "v2.0.0", Action: action, Note: note}
+			out := p.formatNode(NewNodeID(resource.KindTool, "gh"), info, true)
+			assert.Contains(t, out, "[⚠ would-skip: "+note+"]")
+		})
+	}
+}
+
+// TestFormatNode_Note_NotRenderedForSkipRemoveNone: the advisory is only for
+// change actions; Skip/Remove/None never render a note even if one is set.
+func TestFormatNode_Note_NotRenderedForSkipRemoveNone(t *testing.T) {
+	t.Parallel()
+	for _, action := range []resource.ActionType{
+		resource.ActionSkip, resource.ActionRemove, resource.ActionNone,
+	} {
+		t.Run(string(action), func(t *testing.T) {
+			t.Parallel()
+			p := NewTreePrinter(&bytes.Buffer{}, true)
+			info := ResourceInfo{Kind: resource.KindTool, Name: "gh", Version: "v2.0.0", Action: action, Note: "should not show"}
+			out := p.formatNode(NewNodeID(resource.KindTool, "gh"), info, true)
+			assert.NotContains(t, out, "would-skip")
+		})
+	}
+}
+
+func TestFormatNode_NoNote(t *testing.T) {
+	t.Parallel()
+	p := NewTreePrinter(&bytes.Buffer{}, true)
+	info := ResourceInfo{Kind: resource.KindTool, Name: "gh", Version: "v2.0.0", Action: resource.ActionInstall}
+	out := p.formatNode(NewNodeID(resource.KindTool, "gh"), info, true)
+	assert.NotContains(t, out, "would-skip")
+}
+
 // TestFormatNode_SHARendering pins the tree's sha display: SHA-pinned tools
 // render as " (sha: <12chars>…)" instead of the usual " (version)" slot,
 // preserving the full SHA only in state (not in the rendered tree).

--- a/internal/installer/engine/engine.go
+++ b/internal/installer/engine/engine.go
@@ -434,7 +434,7 @@ func (e *Engine) Apply(ctx context.Context, resources []resource.Resource) error
 	applyUpdateTaints(st, e.updateCfg)
 
 	// Build resource maps for quick lookup
-	resourceMap := buildResourceMap(resources)
+	resourceMap := BuildResourceMap(resources)
 
 	// Collect the spec-declared minimumReleaseAge per runtime, keyed by name, so the
 	// runtime-delegation tool-install path can expose it as {{.MinimumReleaseAge}}.
@@ -1088,8 +1088,9 @@ func lookupInstaller(ref string, resourceMap map[string]resource.Resource) *reso
 	return nil
 }
 
-// releaseAgeKeyAndThreshold classifies a tool for the minimumReleaseAge gate.
-// It is pure (no I/O). enabled is false when the gate does not apply: commands
+// ReleaseAgeKeyAndThreshold classifies a tool for the minimumReleaseAge gate.
+// It is pure (no I/O) and shared between apply (the engine gate) and plan (the
+// advisory display). enabled is false when the gate does not apply: commands
 // pattern, runtime delegation, delegation installer, no fetchable source, or a
 // zero/unset threshold.
 //
@@ -1103,7 +1104,7 @@ func lookupInstaller(ref string, resourceMap map[string]resource.Resource) *reso
 // registries often apply version_prefix/trimV, so the GitHub tag may differ;
 // on mismatch GetReleaseByTag 404s and the gate fails open (surfaced via
 // UnverifiedReleaseAge). Registry-based tag resolution is a follow-up.
-func (e *Engine) releaseAgeKeyAndThreshold(
+func ReleaseAgeKeyAndThreshold(
 	t *resource.Tool,
 	resourceMap map[string]resource.Resource,
 ) (age.Key, time.Duration, bool) {
@@ -1162,7 +1163,7 @@ func (e *Engine) checkReleaseAgeGate(
 	if e.ageFetcher == nil || e.updateCfg.IgnoreMinReleaseAge {
 		return false
 	}
-	key, minAge, enabled := e.releaseAgeKeyAndThreshold(t, resourceMap)
+	key, minAge, enabled := ReleaseAgeKeyAndThreshold(t, resourceMap)
 	if !enabled {
 		return false
 	}
@@ -1520,8 +1521,8 @@ func (e *Engine) handleTaintedTools(
 	return nil
 }
 
-// buildResourceMap creates a map of resources by their node ID.
-func buildResourceMap(resources []resource.Resource) map[string]resource.Resource {
+// BuildResourceMap creates a map of resources by their node ID.
+func BuildResourceMap(resources []resource.Resource) map[string]resource.Resource {
 	m := make(map[string]resource.Resource)
 	for _, res := range resources {
 		id := graph.NewNodeID(res.Kind(), res.Name())
@@ -1659,7 +1660,7 @@ func (e *Engine) handleRemovals(ctx context.Context, resources []resource.Resour
 	}
 
 	// Update tool bin paths for InstallerRepository remove commands (e.g., helm repo remove)
-	e.updateToolBinPaths(buildResourceMap(resources), st)
+	e.updateToolBinPaths(BuildResourceMap(resources), st)
 
 	if err := executeRemovals(ctx, e, resource.KindInstallerRepository, repoActions, e.installerRepoExecutor, totalActions); err != nil {
 		return err

--- a/internal/installer/engine/engine_test.go
+++ b/internal/installer/engine/engine_test.go
@@ -838,8 +838,7 @@ func TestReleaseAgeKeyAndThreshold(t *testing.T) {
 			InstallerSpec: &resource.InstallerSpec{Type: resource.InstallTypeDelegation, MinimumReleaseAge: "168h", Commands: &resource.CommandsSpec{Install: []string{"x"}}},
 		},
 	}
-	rm := buildResourceMap(resources)
-	eng := &Engine{ageFetcher: &fakeFetcher{}} // ageFetcher non-nil so the helper isn't bypassed
+	rm := BuildResourceMap(resources)
 
 	tests := []struct {
 		name        string
@@ -861,7 +860,7 @@ func TestReleaseAgeKeyAndThreshold(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			key, minAge, enabled := eng.releaseAgeKeyAndThreshold(tt.tool, rm)
+			key, minAge, enabled := ReleaseAgeKeyAndThreshold(tt.tool, rm)
 			assert.Equal(t, tt.wantEnabled, enabled)
 			if tt.wantEnabled {
 				assert.Equal(t, tt.wantSource, key.Source)
@@ -874,8 +873,8 @@ func TestReleaseAgeKeyAndThreshold(t *testing.T) {
 	// absent from the resource map) is disabled — the gate never fires by default.
 	t.Run("aqua builtin no override disabled", func(t *testing.T) {
 		t.Parallel()
-		rmNoOverride := buildResourceMap([]resource.Resource{}) // no Installer/aqua
-		_, _, enabled := eng.releaseAgeKeyAndThreshold(aquaToolResource("gh", "cli", "cli", "v2.0.0"), rmNoOverride)
+		rmNoOverride := BuildResourceMap([]resource.Resource{}) // no Installer/aqua
+		_, _, enabled := ReleaseAgeKeyAndThreshold(aquaToolResource("gh", "cli", "cli", "v2.0.0"), rmNoOverride)
 		assert.False(t, enabled)
 	})
 }

--- a/internal/installer/engine/system_engine.go
+++ b/internal/installer/engine/system_engine.go
@@ -155,7 +155,7 @@ func (e *SystemEngine) Apply(ctx context.Context, resources []resource.Resource)
 	e.stateCache.Init(st)
 
 	// Build resource map for quick lookup
-	resourceMap := buildResourceMap(resources)
+	resourceMap := BuildResourceMap(resources)
 
 	totalActions := 0
 

--- a/internal/resource/lint.go
+++ b/internal/resource/lint.go
@@ -1,0 +1,90 @@
+package resource
+
+import (
+	"fmt"
+	"strings"
+)
+
+// minReleaseAgeVarRef is the template variable a delegation install command
+// must reference for its declared minimumReleaseAge to be honored (#253). Shown
+// in the warning as the canonical form users should write.
+const minReleaseAgeVarRef = "{{.MinimumReleaseAge}}"
+
+// minReleaseAgeFieldRef is the substring actually matched. Matching the field
+// reference rather than the full delimited action tolerates legitimate template
+// forms — `{{ .MinimumReleaseAge }}`, `{{- .MinimumReleaseAge -}}`,
+// `{{.MinimumReleaseAge | quote}}` — that a delimiter-literal match would miss.
+const minReleaseAgeFieldRef = ".MinimumReleaseAge"
+
+// LintMinimumReleaseAge returns advisory (non-fatal) warnings for delegation
+// Installers and Runtimes that declare minimumReleaseAge but whose install
+// command(s) never reference {{.MinimumReleaseAge}} — i.e. a supply-chain
+// policy that is declared but cannot be enforced (tomei does not gate
+// delegation/runtime install paths; #253 only exposes the value as a template
+// variable, and the user's command must honor it).
+//
+// Download-type Installers (builtin aqua/download) are excluded: tomei enforces
+// those itself at apply time (#254). Runtimes are linted regardless of type
+// because tomei never gates runtime installs — the template var is the only
+// enforcement path. Warnings are returned in resource iteration order.
+func LintMinimumReleaseAge(resources []Resource) []string {
+	var warnings []string
+	for _, res := range resources {
+		switch r := res.(type) {
+		case *Installer:
+			if r.InstallerSpec == nil || !r.InstallerSpec.Type.IsDelegation() {
+				continue
+			}
+			if d, err := r.InstallerSpec.ParsedMinimumReleaseAge(); err != nil || d == 0 {
+				continue
+			}
+			if !referencesMinReleaseAge(installerInstallCommands(r.InstallerSpec)) {
+				warnings = append(warnings, lintWarning(KindInstaller, r.Name()))
+			}
+		case *Runtime:
+			if r.RuntimeSpec == nil {
+				continue
+			}
+			if d, err := r.RuntimeSpec.ParsedMinimumReleaseAge(); err != nil || d == 0 {
+				continue
+			}
+			if !referencesMinReleaseAge(runtimeInstallCommands(r.RuntimeSpec)) {
+				warnings = append(warnings, lintWarning(KindRuntime, r.Name()))
+			}
+		}
+	}
+	return warnings
+}
+
+func lintWarning(kind Kind, name string) string {
+	return fmt.Sprintf("%s/%s declares minimumReleaseAge but no install command references %s; the policy is not enforced",
+		kind, name, minReleaseAgeVarRef)
+}
+
+// referencesMinReleaseAge reports whether any of the given command strings
+// references the {{.MinimumReleaseAge}} template variable, tolerating spacing,
+// trim markers, and pipelines by matching the field reference.
+func referencesMinReleaseAge(cmds []string) bool {
+	return strings.Contains(strings.Join(cmds, "\n"), minReleaseAgeFieldRef)
+}
+
+func installerInstallCommands(spec *InstallerSpec) []string {
+	if spec.Commands == nil {
+		return nil
+	}
+	return spec.Commands.Install
+}
+
+// runtimeInstallCommands gathers every install command the runtime exposes the
+// variable to: tool-install (Commands.Install) and delegation self-install
+// (Bootstrap.Install). Either referencing the var satisfies the lint.
+func runtimeInstallCommands(spec *RuntimeSpec) []string {
+	var cmds []string
+	if spec.Commands != nil {
+		cmds = append(cmds, spec.Commands.Install...)
+	}
+	if spec.Bootstrap != nil {
+		cmds = append(cmds, spec.Bootstrap.Install...)
+	}
+	return cmds
+}

--- a/internal/resource/lint.go
+++ b/internal/resource/lint.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -10,11 +11,13 @@ import (
 // in the warning as the canonical form users should write.
 const minReleaseAgeVarRef = "{{.MinimumReleaseAge}}"
 
-// minReleaseAgeFieldRef is the substring actually matched. Matching the field
-// reference rather than the full delimited action tolerates legitimate template
-// forms — `{{ .MinimumReleaseAge }}`, `{{- .MinimumReleaseAge -}}`,
-// `{{.MinimumReleaseAge | quote}}` — that a delimiter-literal match would miss.
-const minReleaseAgeFieldRef = ".MinimumReleaseAge"
+// minReleaseAgeRefRe matches a reference to the .MinimumReleaseAge template
+// field. Matching the field reference (not the full delimited action) tolerates
+// legitimate forms — `{{ .MinimumReleaseAge }}`, `{{- .MinimumReleaseAge -}}`,
+// `{{.MinimumReleaseAge | quote}}`. The trailing \b word boundary ensures an
+// exact field match, so a typo or longer identifier like
+// `{{.MinimumReleaseAgeFoo}}` does NOT count as a reference (and still warns).
+var minReleaseAgeRefRe = regexp.MustCompile(`\.MinimumReleaseAge\b`)
 
 // LintMinimumReleaseAge returns advisory (non-fatal) warnings for delegation
 // Installers and Runtimes that declare minimumReleaseAge but whose install
@@ -63,9 +66,9 @@ func lintWarning(kind Kind, name string) string {
 
 // referencesMinReleaseAge reports whether any of the given command strings
 // references the {{.MinimumReleaseAge}} template variable, tolerating spacing,
-// trim markers, and pipelines by matching the field reference.
+// trim markers, and pipelines while rejecting longer-identifier typos.
 func referencesMinReleaseAge(cmds []string) bool {
-	return strings.Contains(strings.Join(cmds, "\n"), minReleaseAgeFieldRef)
+	return minReleaseAgeRefRe.MatchString(strings.Join(cmds, "\n"))
 }
 
 func installerInstallCommands(spec *InstallerSpec) []string {

--- a/internal/resource/lint_test.go
+++ b/internal/resource/lint_test.go
@@ -48,6 +48,7 @@ func TestLintMinimumReleaseAge_Installer(t *testing.T) {
 		{"delegation whitespace variant", delegationInstaller("168h", []string{"x {{ .MinimumReleaseAge }}"}), false},
 		{"delegation trim-marker variant", delegationInstaller("168h", []string{"x {{- .MinimumReleaseAge -}}"}), false},
 		{"delegation pipeline variant", delegationInstaller("168h", []string{`x {{.MinimumReleaseAge | printf "%s"}}`}), false},
+		{"delegation longer-identifier typo still warns", delegationInstaller("168h", []string{"x {{.MinimumReleaseAgeFoo}}"}), true},
 		{"delegation no threshold", delegationInstaller("", []string{"brew install {{.Name}}"}), false},
 		{"download type excluded", &Installer{
 			BaseResource:  BaseResource{ResourceKind: KindInstaller, Metadata: Metadata{Name: "aqua"}},

--- a/internal/resource/lint_test.go
+++ b/internal/resource/lint_test.go
@@ -1,0 +1,117 @@
+package resource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func delegationInstaller(minAge string, install []string) *Installer {
+	return &Installer{
+		BaseResource: BaseResource{APIVersion: GroupVersion, ResourceKind: KindInstaller, Metadata: Metadata{Name: "brew"}},
+		InstallerSpec: &InstallerSpec{
+			Type:              InstallTypeDelegation,
+			MinimumReleaseAge: minAge,
+			Commands:          &CommandsSpec{Install: install},
+		},
+	}
+}
+
+func runtimeRes(name, typ, minAge string, commands []string, bootstrap []string) *Runtime {
+	spec := &RuntimeSpec{
+		Type:              InstallType(typ),
+		Version:           "1.0.0",
+		MinimumReleaseAge: minAge,
+	}
+	if commands != nil {
+		spec.Commands = &CommandsSpec{Install: commands}
+	}
+	if bootstrap != nil {
+		spec.Bootstrap = &RuntimeBootstrapSpec{CommandSet: CommandSet{Install: bootstrap}}
+	}
+	return &Runtime{
+		BaseResource: BaseResource{APIVersion: GroupVersion, ResourceKind: KindRuntime, Metadata: Metadata{Name: name}},
+		RuntimeSpec:  spec,
+	}
+}
+
+func TestLintMinimumReleaseAge_Installer(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		res      Resource
+		wantWarn bool
+	}{
+		{"delegation missing ref", delegationInstaller("168h", []string{"brew install {{.Name}}"}), true},
+		{"delegation present ref", delegationInstaller("168h", []string{"brew install --min-age={{.MinimumReleaseAge}} {{.Name}}"}), false},
+		{"delegation whitespace variant", delegationInstaller("168h", []string{"x {{ .MinimumReleaseAge }}"}), false},
+		{"delegation trim-marker variant", delegationInstaller("168h", []string{"x {{- .MinimumReleaseAge -}}"}), false},
+		{"delegation pipeline variant", delegationInstaller("168h", []string{`x {{.MinimumReleaseAge | printf "%s"}}`}), false},
+		{"delegation no threshold", delegationInstaller("", []string{"brew install {{.Name}}"}), false},
+		{"download type excluded", &Installer{
+			BaseResource:  BaseResource{ResourceKind: KindInstaller, Metadata: Metadata{Name: "aqua"}},
+			InstallerSpec: &InstallerSpec{Type: InstallTypeDownload, MinimumReleaseAge: "168h"},
+		}, false},
+		{"delegation nil commands + threshold", &Installer{
+			BaseResource:  BaseResource{ResourceKind: KindInstaller, Metadata: Metadata{Name: "brew"}},
+			InstallerSpec: &InstallerSpec{Type: InstallTypeDelegation, MinimumReleaseAge: "168h"},
+		}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			warns := LintMinimumReleaseAge([]Resource{tt.res})
+			if tt.wantWarn {
+				require.Len(t, warns, 1)
+				assert.Contains(t, warns[0], "minimumReleaseAge")
+			} else {
+				assert.Empty(t, warns)
+			}
+		})
+	}
+}
+
+// Ordering contract: warnings are returned in resource iteration order, and a
+// non-Installer/Runtime resource (Tool) is ignored.
+func TestLintMinimumReleaseAge_MultipleInIterationOrder(t *testing.T) {
+	t.Parallel()
+	resources := []Resource{
+		delegationInstaller("168h", []string{"brew install {{.Name}}"}),                                                       // bad → warns (Installer/brew)
+		&Tool{BaseResource: BaseResource{ResourceKind: KindTool, Metadata: Metadata{Name: "ignored"}}, ToolSpec: &ToolSpec{}}, // ignored
+		runtimeRes("go", "delegation", "168h", []string{"go install x"}, []string{"boot"}),                                    // bad → warns (Runtime/go)
+	}
+	warns := LintMinimumReleaseAge(resources)
+	require.Len(t, warns, 2)
+	assert.Contains(t, warns[0], "Installer/brew")
+	assert.Contains(t, warns[1], "Runtime/go")
+}
+
+func TestLintMinimumReleaseAge_Runtime(t *testing.T) {
+	t.Parallel()
+	ref := []string{"go install {{.Package}} {{.MinimumReleaseAge}}"}
+	noRef := []string{"go install {{.Package}}"}
+	tests := []struct {
+		name     string
+		res      Resource
+		wantWarn bool
+	}{
+		{"neither refs", runtimeRes("go", "delegation", "168h", noRef, noRef), true},
+		{"ref in commands only", runtimeRes("go", "delegation", "168h", ref, noRef), false},
+		{"ref in bootstrap only", runtimeRes("rust", "delegation", "168h", noRef, ref), false},
+		{"download type, commands ref", runtimeRes("go", "download", "168h", ref, nil), false},
+		{"download type, commands no-ref + threshold", runtimeRes("go", "download", "168h", noRef, nil), true},
+		{"no threshold", runtimeRes("go", "delegation", "", noRef, noRef), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			warns := LintMinimumReleaseAge([]Resource{tt.res})
+			if tt.wantWarn {
+				require.Len(t, warns, 1)
+			} else {
+				assert.Empty(t, warns)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Sub-task #255 of the minimumReleaseAge feature (tracking #257). Two UX
features so users see the supply-chain gate before apply:

1. Plan advisory: tomei plan annotates a change action the apply-time gate
   would skip — `Tool/foo (v1.2.3) [+ install] [⚠ would-skip: released 24h0m0s
   ago, requires 168h0m0s]`. Informational only (apply re-fetches and
   re-decides). Network fetch happens only when a tool's gate is actually
   configured (opt-in); zero gated tools → no network, plan stays fast. A
   configured gate that can't be evaluated fails open VISIBLY (an aggregate
   stderr note), mirroring apply's UnverifiedReleaseAge. Text output only —
   the Note is not serialized into JSON/YAML.
2. Delegation lint: plan and validate warn (non-fatal, stderr) when a
   delegation Installer or a Runtime declares minimumReleaseAge but no install
   command references {{.MinimumReleaseAge}} — a policy declared but not
   enforced (tomei does not gate delegation/runtime paths; #253 only exposes
   the var). The match keys on the field reference so trim markers and
   pipelines (`{{- .X -}}`, `{{.X | q}}`) are recognized. Download-type
   installers are excluded (tomei enforces those itself).

- engine: export ReleaseAgeKeyAndThreshold and BuildResourceMap so plan and
  apply share one classifier/keying and classify identically (no drift).
- graph/tree: ResourceInfo.Note + formatNode rendering for change actions only.
- resource/lint.go: LintMinimumReleaseAge helper, shared by plan and validate.
- cmd: stderr output routed through cmd.ErrOrStderr() (testable, keeps -o json
  stdout clean); a "checking minimum release ages…" hint before the fetch so
  plan doesn't pause silently on a slow network.

Tests: tree note rendering (change actions / not-skip-remove-none / none);
lint installer+runtime tables incl. trim-marker/pipeline/download-excluded/
nil-commands/iteration-order; advisory set/unset, download last-modified,
upgrade, no-fetch-when-no-gated-tools/ActionNone/unresolved-tag, dedup shared
key, and visible fail-open (error + source-unavailable) asserting the stderr
note via an injected writer.

Refs #257
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
