### PR TITLE
docs: document minimumReleaseAge feature, threat model, and escape hatch

### DIFF
--- a/docs/cue-schema.md
+++ b/docs/cue-schema.md
@@ -102,6 +102,7 @@ spec: {
 | `spec.binDir` | string | no | Directory containing runtime binaries |
 | `spec.commands` | [CommandSet](#commandset) | no | Commands for installing tools via this runtime |
 | `spec.env` | map[string]string | no | Environment variables (e.g., `GOROOT`, `GOBIN`) |
+| `spec.minimumReleaseAge` | string | no | Go duration (e.g. `"168h"`); not enforced for runtimes — exposed to the runtime's install/bootstrap commands as `{{.MinimumReleaseAge}}`. See [Minimum release age](#minimum-release-age) |
 
 ### Tool
 
@@ -271,6 +272,60 @@ spec: {
 | `spec.bootstrap` | [CommandSet](#commandset) | no | Self-installation commands |
 | `spec.commands` | [CommandSet](#commandset) | delegation only | Commands for installing tools |
 | `spec.binDir` | string | no | Directory where delegation installers place binaries. Used by `tomei env` to include in PATH. Must start with `~/` or `/`. Only meaningful for delegation type |
+| `spec.minimumReleaseAge` | string | no | Go duration (e.g. `"168h"`); refuse installs whose upstream release is younger. Empty disables. See [Minimum release age](#minimum-release-age) |
+
+#### Minimum release age
+
+`minimumReleaseAge` is a supply-chain defense: refuse to install a tool version
+whose upstream release is younger than the threshold, giving the community time
+to flag a compromised release before you pull it. It is set on the
+`Installer`/`Runtime` spec and applies to tools that reference it. See the
+[threat model](design.md#minimum-release-age) for the rationale and limitations.
+
+```cue
+// Enable the gate for all aqua-installed tools by overriding the builtin
+// "aqua" installer. The override MUST keep type: "download".
+aqua: {
+    apiVersion: "tomei.terassyi.net/v1beta1"
+    kind:       "Installer"
+    metadata: name: "aqua"
+    spec: {
+        type:              "download"
+        minimumReleaseAge: "168h" // 1 week
+    }
+}
+```
+
+- **Format**: a [Go duration](https://pkg.go.dev/time#ParseDuration) string.
+  There is **no day unit** — use `"24h"` for a day and `"168h"` for a week
+  (`"7d"` is invalid). Decimals are allowed (`"1.5h"`). An empty string, `"0"`,
+  or `"0h"` all disable the gate; negative values are rejected at validate time.
+- **Opt-in**: the gate is off unless you declare it. The builtin `aqua` and
+  `download` installers carry no threshold, so you enable enforcement by
+  declaring an override (as above) — or a custom `type: "download"` installer —
+  that sets `minimumReleaseAge`. There is no global default.
+- **Where tomei enforces.** Whether the gate is *active* depends on the
+  installer's *type* (any `type: "download"` installer with a threshold), not its
+  name. Which timestamp *source* is used is then chosen by the **tool**, not the
+  installer: a registry `package` (owner/repo) uses the GitHub Releases
+  `published_at`; otherwise an explicit `source.url` uses the HTTP `Last-Modified`
+  header.
+
+| Tool's install path | Enforcement |
+|---|---|
+| via a `type: "download"` installer (incl. the builtin `aqua`, when overridden with a threshold), with a registry `package` | tomei enforces — GitHub `published_at` (**best-effort**: see limitations) |
+| via a `type: "download"` installer (incl. the builtin `download`), with an explicit `source.url` | tomei enforces — HTTP `Last-Modified` (**best-effort**: see limitations) |
+| via a delegation installer (binstall, brew, custom) | **Not enforced by tomei** — the user's `commands.install` must honor the `{{.MinimumReleaseAge}}` template var |
+| via `runtimeRef` (any runtime — `go`, `cargo`, `uv`, … — regardless of the runtime's `type`) | **Not enforced by tomei** — `runtimeRef` installs are never gated; the runtime's install commands must honor the var |
+| Commands pattern (Tool with `commands:`) | Out of scope — not gated |
+
+- For delegation paths the value is exposed only as the `{{.MinimumReleaseAge}}`
+  [command template variable](#commandset) (rendered as the literal duration
+  string, e.g. `168h`); tomei performs no release-age check itself. `tomei plan`
+  and `tomei validate` emit a lint warning when the field is set but no install
+  command references the variable. See [usage](usage.md#minimum-release-age-gate).
+
+Tracking issue: [#257](https://github.com/terassyi/tomei/issues/257).
 
 ### InstallerRepository
 
@@ -538,7 +593,7 @@ package: {name: "golang.org/x/tools/gopls"}
 }
 ```
 
-Commands support Go template variables: `{{.Package}}`, `{{.Version}}`, `{{.Name}}`, `{{.BinPath}}`.
+Commands support Go template variables: `{{.Package}}`, `{{.Version}}`, `{{.Name}}`, `{{.BinPath}}`, `{{.MinimumReleaseAge}}` (the configured [minimum release age](#minimum-release-age), rendered as the literal duration string; tomei does not act on it for delegation paths).
 
 ### Aqua Template Variables
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -171,6 +171,70 @@ Mode:  headless (server, CI, container, SSH), desktop (GUI)
 - No shell injection — `exec.Command` with explicit arguments
 - Atomic state writes (tmp + rename)
 
+### Minimum release age
+
+`minimumReleaseAge` defends against the "fresh malicious release" supply-chain
+window: an attacker compromises a maintainer account, pushes a malicious
+version, and downstream users pull it before the community detects the
+compromise (chalk/debug, ua-parser-js, etc.). The defense is simple — refuse to
+install a release younger than a configured threshold (e.g. a week), so a
+compromised upload has time to be flagged before you take it. Enforcement runs
+at apply time (not plan time) so the plan→apply TOCTOU window is minimized: the
+plan advisory is best-effort and apply re-fetches and re-decides.
+
+It is a speed bump, not a fence. The limitations are deliberate and worth
+understanding before relying on it:
+
+- **Fail-open by design.** Any condition that prevents fetching the release time
+  — a network error, an aqua tag that doesn't match the GitHub release (see
+  below), an unresolved `latest` version, or a missing `Last-Modified` header —
+  lets the install **proceed**, not abort. An attacker who can make the
+  timestamp unfetchable bypasses the gate. tomei surfaces this (a `WARN` log that
+  survives `--quiet`, plus an "installed anyway" summary line), so treat that
+  line as a security signal — the absence of a skip message is not proof the
+  gate held. A fail-closed `--strict` mode is a possible future addition.
+- **Delegation and runtime installs are not enforced by tomei at all.** For
+  delegation installers (binstall, brew, custom) and runtimes (go, cargo, uv),
+  tomei only exposes the threshold as the `{{.MinimumReleaseAge}}` template
+  variable; it performs no release-age check. Setting the field there protects
+  nothing unless the user's own install command implements the check. `tomei
+  plan`/`validate` lint-warn when the field is set on such a resource but no
+  install command references the variable.
+- **Timestamps are publisher-controlled, not cryptographic.** GitHub
+  `published_at` and HTTP `Last-Modified` are not attestations. `Last-Modified`
+  in particular is the object's storage modification time — reset by any
+  re-upload or mirror sync and fully controlled by whoever serves the object —
+  so download-URL gating is a weaker signal than the aqua `published_at` check,
+  not equivalent to it. (Cryptographic provenance — cosign / SLSA — is a
+  separate, complementary concern.)
+- **aqua tag derivation is best-effort.** The release tag is taken directly from
+  `spec.version`. aqua-registry packages commonly apply a `version_prefix` /
+  `trimV`, so the GitHub tag can differ from `spec.version`; on mismatch the
+  lookup 404s and the gate fails open. Registry-based tag resolution is a
+  possible future improvement.
+- **First installs are gated**, not exempt — new tools are exactly what an
+  attacker introduces. Plan accordingly when bootstrapping a fresh environment
+  (or use `--ignore-min-release-age`).
+
+Operational notes:
+
+- **Recommended initial value: `24h`–`168h`** (one day to one week). The right
+  value is per-tool and depends on your attacker-detection window: a longer gate
+  maximizes that window but means you always lag fast-moving tools by that much.
+  Set it per installer override; there is no global default.
+- The aqua check hits the GitHub API (60 requests/hour unauthenticated,
+  5000/hour authenticated). Set `GITHUB_TOKEN` (or `GH_TOKEN`) for production
+  use; the token is sent only to GitHub hosts, and the raw-download
+  `Last-Modified` check uses no token, so configuring it adds no credential
+  exposure. The download check is HTTPS-only and rejects URLs whose host is an IP
+  literal in a private, loopback, link-local, multicast, or unspecified range
+  (on the initial request and every redirect hop). Host *names* are not resolved,
+  so a DNS name is not range-checked — the CUE manifest is the trust boundary.
+
+See [usage](usage.md#minimum-release-age-gate) and the
+[schema reference](cue-schema.md#minimum-release-age). Tracking issue:
+[#257](https://github.com/terassyi/tomei/issues/257).
+
 ## 8. Schema Versioning
 
 The CUE schema is published as part of the `tomei.terassyi.net@v0` module on the OCI registry (`ghcr.io/terassyi`). User manifests can `import "tomei.terassyi.net/schema"` for explicit type validation and editor completion via CUE LSP.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -274,6 +274,126 @@ Constraints:
 - `tomei plan` displays the SHA truncated to 12 characters; state retains
   the full SHA.
 
+### Minimum release age gate
+
+`minimumReleaseAge` refuses to install a tool version whose upstream release is
+younger than a configured threshold — a supply-chain defense against freshly
+compromised releases. It is **opt-in**: declare it on an `Installer`/`Runtime`
+spec (the builtin installers carry no threshold). Format is a
+[Go duration](https://pkg.go.dev/time#ParseDuration) — note there is no day
+unit, so use `"168h"` for a week and `"24h"` for a day. See the
+[schema reference](cue-schema.md#minimum-release-age) for the full enforcement
+matrix.
+
+**aqua-installed tools** — override the builtin `aqua` installer (the override
+must keep `type: "download"`); tomei checks the GitHub release `published_at`:
+
+```cue
+aqua: {
+    apiVersion: "tomei.terassyi.net/v1beta1"
+    kind:       "Installer"
+    metadata: name: "aqua"
+    spec: {
+        type:              "download"
+        minimumReleaseAge: "168h"
+    }
+}
+```
+
+**Raw-download tools** — the gate attaches to a `type: "download"` installer and
+fires for any tool that installs from a `source.url`, using the HTTP
+`Last-Modified` header. You need both the installer (with the threshold) and a
+tool that references it:
+
+```cue
+download: {
+    apiVersion: "tomei.terassyi.net/v1beta1"
+    kind:       "Installer"
+    metadata: name: "download"
+    spec: {
+        type:              "download"
+        minimumReleaseAge: "168h"
+    }
+}
+
+jq: {
+    apiVersion: "tomei.terassyi.net/v1beta1"
+    kind:       "Tool"
+    metadata: name: "jq"
+    spec: {
+        installerRef: "download"
+        version:      "1.7.1"
+        source: url: "https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64"
+    }
+}
+```
+
+(`jq-linux-amd64` is platform-specific; real manifests typically template the
+asset name by OS/arch.)
+
+> `Last-Modified` reflects the object's storage modification time, not
+> necessarily the release date (a re-upload resets it). Treat download-URL
+> gating as a weaker signal than the aqua `published_at` check.
+
+**Delegation installers and runtimes are NOT gated by tomei.** Setting
+`minimumReleaseAge` on a delegation `Installer`, or on any `Runtime` (tools
+installed via `runtimeRef` are never gated, regardless of the runtime's `type`),
+does not make tomei check anything — it only renders the value as the
+`{{.MinimumReleaseAge}}` template variable (the literal duration string, e.g.
+`168h`) for your install commands. No mainstream installer (`cargo binstall`,
+`brew`, `go install`, `uv`) accepts a release-age flag, so honoring it requires a
+shell guard you write yourself:
+
+```cue
+binstall: {
+    apiVersion: "tomei.terassyi.net/v1beta1"
+    kind:       "Installer"
+    metadata: name: "binstall"
+    spec: {
+        type:    "delegation"
+        toolRef: "cargo-binstall"
+        minimumReleaseAge: "168h"
+        // tomei does NOT enforce this — your command must. {{.MinimumReleaseAge}}
+        // renders to the raw string "168h"; a real guard would resolve the
+        // upstream release date and compare before delegating the install.
+        commands: install: "your-release-age-guard {{.MinimumReleaseAge}} && cargo binstall -y {{.Package}}@{{.Version}}"
+    }
+}
+```
+
+`tomei plan` and `tomei validate` emit a lint warning when `minimumReleaseAge`
+is set on a delegation installer or runtime but no install command references
+`{{.MinimumReleaseAge}}` — i.e. a policy declared but not enforced.
+
+**When a tool is gated**, `tomei apply` skips it and prints a summary:
+
+```text
+1 tool(s) skipped (release younger than minimumReleaseAge):
+  - rg: released 18h0m0s ago, requires 168h0m0s (source: aqua-github-release)
+Use --ignore-min-release-age to override.
+```
+
+If the release age can't be determined (network error, an aqua tag that doesn't
+match the GitHub release, a missing `Last-Modified` header), the gate **fails
+open** — the tool installs anyway and is reported separately. A *missing* skip
+line is therefore not proof the gate held:
+
+```text
+1 tool(s): minimumReleaseAge could not be verified, installed anyway:
+  - gh (source: aqua-github-release): no release timestamp available
+```
+
+`tomei plan` shows the same intent ahead of apply, annotating a change action
+with `[⚠ would-skip: …]` (best-effort; apply re-fetches and re-decides).
+
+- **First installs are gated too.** Bootstrapping a fresh environment, or adding
+  a tool on its release day, will skip any tool younger than its threshold.
+- `--ignore-min-release-age` (on `tomei apply` only) bypasses the gate for every
+  tool in that run — use it for intentional fresh bootstraps, CI, or emergency
+  restores. There is no `tomei plan` flag; plan only previews.
+- Set `GITHUB_TOKEN` (or `GH_TOKEN`) for the aqua check: the GitHub API rate
+  limit is 60/h unauthenticated vs 5000/h with a token.
+
 ### Self-Managed Tools (Commands Pattern)
 
 Tools with `spec.commands` manage their own installation via shell commands, without needing a runtime or installer dependency.


### PR DESCRIPTION
Final sub-task of the minimumReleaseAge feature (tracking #257). User-facing
docs across three files, matching the behavior shipped in #251–#255.

- docs/cue-schema.md: minimumReleaseAge rows on the Runtime/Installer spec
  tables and a "Minimum release age" deep-dive — Go-duration format (no day
  unit; empty/0 disable), opt-in-via-override semantics, and the enforcement
  matrix keyed on the tool's install path (type-based enablement; source
  chosen by registry package vs source.url; runtimeRef installs never gated).
  Adds {{.MinimumReleaseAge}} to the CommandSet template-var list.
- docs/usage.md: "Minimum release age gate" under tomei apply — validated
  aqua-override and download installer+tool examples, an honest delegation
  example (tomei does not enforce; the user's command must), the apply skip
  and "installed anyway" summaries, the plan [⚠ would-skip] advisory, the
  delegation lint, first-install/bootstrap caveat, and --ignore-min-release-age.
- docs/design.md: "Minimum release age" threat model under §7 Security —
  attack scenario, defense, and limitations framed as security properties
  (fail-open, delegation not enforced, publisher-controlled timestamps,
  Last-Modified resettable, aqua tag best-effort, first-install gated),
  recommended values with a cadence caveat, GitHub rate limits / token scope,
  and the HTTPS-only IP-literal SSRF guard.

Refs #257
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
