### PR TITLE
docs: document --system-only, --ignore-min-release-age, and rustup preset components

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Presets provide ready-made definitions for common runtimes and tools. Available 
 | Import | Provides |
 |--------|----------|
 | `tomei.terassyi.net/presets/go` | `#GoRuntime`, `#GoTool`, `#GoToolSet` |
-| `tomei.terassyi.net/presets/rust` | `#RustRuntime`, `#CargoBinstall`, `#BinstallInstaller`, `#BinstallToolSet` |
+| `tomei.terassyi.net/presets/rust` | `#RustRuntime`, `#CargoBinstall`, `#BinstallInstaller`, `#BinstallToolSet`, `#RustupComponentInstaller`, `#RustupComponentToolSet` |
 | `tomei.terassyi.net/presets/aqua` | `#AquaTool`, `#AquaToolSet` |
 | `tomei.terassyi.net/presets/node` | `#PnpmRuntime`, `#PnpmTool`, `#PnpmToolSet` |
 | `tomei.terassyi.net/presets/python` | `#UvRuntime`, `#UvTool`, `#UvToolSet` |
@@ -118,6 +118,26 @@ cliTools: aqua.#AquaToolSet & {
 	spec: tools: {
 		rg: {package: "BurntSushi/ripgrep", version: "latest"}
 		jq: {package: "jqlang/jq", version: "latest"}
+	}
+}
+```
+
+Rustup-managed components (e.g. `rust-analyzer`, `rust-src`) install via `#RustupComponentToolSet`, which requires `#RustRuntime` and `#RustupComponentInstaller` to be declared alongside it:
+
+```cue
+package tomei
+
+import "tomei.terassyi.net/presets/rust"
+
+rustRuntime: rust.#RustRuntime & {spec: version: "stable"}
+
+rustupComponentInstaller: rust.#RustupComponentInstaller
+
+rustComponents: rust.#RustupComponentToolSet & {
+	metadata: name: "rust-components"
+	spec: tools: {
+		"rust-analyzer": {}
+		"rust-src":      {}
 	}
 }
 ```

--- a/docs/cue-schema.md
+++ b/docs/cue-schema.md
@@ -387,18 +387,18 @@ spec: {
 
 #### Fields
 
-The CUE schema requires `spec.pattern`, `spec.privileged`, and `spec.commands` (with `commands` as an open struct). Beyond that, current Go-side validation only checks `spec.pattern`, and the engine validates `SystemInstaller` resources by checking that the named package manager exists on the host (see error list above). The `commands.*` entries below are not consumed by the engine at apply time; they are documented here as the conventional shape for `SystemPackageRepository` / `SystemPackageSet` reconciliation, which will start consuming them once the concrete installers land.
+The CUE schema requires `spec.pattern`, `spec.privileged`, and `spec.commands` (with `commands` as an open struct). Beyond that, current Go-side validation only checks `spec.pattern`, and the engine validates `SystemInstaller` resources by checking that the named package manager exists on the host (see error list above). The concrete installer is APT-based and hardcodes its `apt-get` / `dpkg-query` invocations (see [SystemPackageRepository](#systempackagerepository) and [SystemPackageSet](#systempackageset)); it does **not** read `spec.commands.*`. The `commands.*` entries below are therefore inert at apply time — they remain required by the schema and document the conventional shape a future non-`apt` installer would follow.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `spec.pattern` | string | yes | Installer pattern. Currently only `"delegation"` is meaningful |
 | `spec.privileged` | bool | yes | Whether package operations require elevated privileges |
-| `spec.commands.install` | object | recommended | `{command: string}` — used by future package operations |
-| `spec.commands.remove` | object | recommended | `{command: string}` — used by future package operations |
-| `spec.commands.check` | object | recommended | `{command: string}` — used by future package operations |
-| `spec.commands.update` | string | no | Optional update command |
+| `spec.commands.install` | object | required by schema | `{command: string}` — inert; the APT installer hardcodes `apt-get install` and ignores this |
+| `spec.commands.remove` | object | required by schema | `{command: string}` — inert; the APT installer hardcodes `apt-get remove` and ignores this |
+| `spec.commands.check` | object | required by schema | `{command: string}` — inert; the APT installer probes via `dpkg-query` and ignores this |
+| `spec.commands.update` | string | no | Optional update command; inert for the APT installer (which runs `apt-get update` directly) |
 
-The `spec.commands.*` declarations are not consumed by the engine at apply time today; once concrete installers are implemented, the engine is expected to append package names per [SystemPackageSet](#systempackageset), and any Go template variable conventions for these commands will be documented as part of that implementation.
+Because the only wired-in installer (`apt`) hardcodes its package operations, these `commands.*` declarations are inert for `apt` today. They are kept schema-required for forward compatibility; if a non-`apt` installer is added later, any Go template-variable conventions for these commands will be documented as part of that work.
 
 ### SystemPackageRepository
 
@@ -416,9 +416,8 @@ at `/etc/apt/sources.list.d/<metadata.name>.list`, then refreshes the APT
 index. If the just-added repository fails to fetch
 (`W: Failed to fetch …` against the configured URL), the helper rolls
 back both files automatically so the host state does not regress.
-Engine wiring of the concrete installer is tracked in a separate issue
-(#196); declared repositories run through the installer once the engine
-is updated to construct it.
+Declared repositories run through this installer at apply time; the
+engine wiring shipped in [#196](https://github.com/terassyi/tomei/issues/196).
 
 ```cue
 apiVersion: "tomei.terassyi.net/v1beta1"

--- a/docs/cue-schema.md
+++ b/docs/cue-schema.md
@@ -388,18 +388,18 @@ spec: {
 
 #### Fields
 
-The CUE schema requires `spec.pattern`, `spec.privileged`, and `spec.commands` (with `commands` as an open struct). Beyond that, current Go-side validation only checks `spec.pattern`, and the engine validates `SystemInstaller` resources by checking that the named package manager exists on the host (see error list above). The concrete installer is APT-based and hardcodes its `apt-get` / `dpkg-query` invocations (see [SystemPackageRepository](#systempackagerepository) and [SystemPackageSet](#systempackageset)); it does **not** read `spec.commands.*`. The `commands.*` entries below are therefore inert at apply time — they remain required by the schema and document the conventional shape a future non-`apt` installer would follow.
+The CUE schema requires `spec.pattern`, `spec.privileged`, and `spec.commands` (with `commands` as an open struct). Beyond that, current Go-side validation only checks `spec.pattern`, and the engine validates `SystemInstaller` resources by checking that the named package manager exists on the host (see error list above). The concrete installer is APT-based and hardcodes its `apt-get` / `dpkg-query` invocations (see [SystemPackageRepository](#systempackagerepository) and [SystemPackageSet](#systempackageset)); it does **not** read `spec.commands.*`. The `commands.*` entries below are therefore inert at apply time. The schema only requires the `commands` object itself (an open struct); the `install` / `remove` / `check` subkeys are not enforced — they are the conventional shape shown in the example and document what a future non-`apt` installer would consume.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `spec.pattern` | string | yes | Installer pattern. Currently only `"delegation"` is meaningful |
 | `spec.privileged` | bool | yes | Whether package operations require elevated privileges |
-| `spec.commands.install` | object | required by schema | `{command: string}` — inert; the APT installer hardcodes `apt-get install` and ignores this |
-| `spec.commands.remove` | object | required by schema | `{command: string}` — inert; the APT installer hardcodes `apt-get remove` and ignores this |
-| `spec.commands.check` | object | required by schema | `{command: string}` — inert; the APT installer probes via `dpkg-query` and ignores this |
+| `spec.commands.install` | object | no | `{command: string}` — inert; the APT installer hardcodes `apt-get install` and ignores this |
+| `spec.commands.remove` | object | no | `{command: string}` — inert; the APT installer hardcodes `apt-get remove` and ignores this |
+| `spec.commands.check` | object | no | `{command: string}` — inert; the APT installer probes via `dpkg-query` and ignores this |
 | `spec.commands.update` | string | no | Optional update command; inert for the APT installer (which runs `apt-get update` directly) |
 
-Because the only wired-in installer (`apt`) hardcodes its package operations, these `commands.*` declarations are inert for `apt` today. They are kept schema-required for forward compatibility; if a non-`apt` installer is added later, any Go template-variable conventions for these commands will be documented as part of that work.
+Because the only wired-in installer (`apt`) hardcodes its package operations, these `commands.*` declarations are inert for `apt` today. They are kept as the conventional shape for forward compatibility; if a non-`apt` installer is added later, any Go template-variable conventions for these commands will be documented as part of that work.
 
 ### SystemPackageRepository
 

--- a/docs/cue-schema.md
+++ b/docs/cue-schema.md
@@ -211,6 +211,7 @@ spec: {
 | `spec.source` | [DownloadSource](#downloadsource) | no | Explicit download source |
 | `spec.package` | [Package](#package) | no | Package identifier for registry or delegation |
 | `spec.binaryName` | string | no | Override binary name for both the placed binary and the symlink (e.g., `"kubectl-krew"` for krew). Affects `state.installPath` and `state.binPath`. Must match `^[a-zA-Z0-9][a-zA-Z0-9._-]*$` |
+| `spec.privileged` | bool | no | Default `false`. Opt into elevated placement for download/registry/`commands` tools: the symlink is placed in the system bin directory (default `/usr/local/bin`) via a `sudo` fallback instead of `~/.local/bin`. Ignored for installer/name-delegation tools; **rejected with `runtimeRef`**. Requires `tomei apply --system` (or `--system-only`); without it the tool is skipped. See [design.md §11 Privileged Tools](./design.md#11-privileged-tools). |
 
 \* Exactly one of `installerRef`, `runtimeRef`, or `commands` is required.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -328,7 +328,7 @@ SystemInstaller → SystemPackageRepository → SystemPackageSet
 
 ## 11. Privileged Tools
 
-Tools may set `spec.privileged: true` to opt into elevation semantics. The behavior depends on the install pattern; the new placement behavior introduced in this phase is documented below.
+Tools may set `spec.privileged: true` to opt into elevation semantics. The behavior depends on the install pattern, as documented below.
 
 Without `--system`, `tomei plan` keeps privileged tools in its output and marks them as `skip`. `tomei apply` filters them out of execution and logs a summary noting that privileged tools require a sudo cache for shell commands or for placing symlinks in the system bin directory.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -276,7 +276,7 @@ Completed:
 - CUE `@if()` boolean platform tags: `@if(darwin)`, `@if(arm64)`, `@if(headless)` for file-level branching
 - Disabled resource filtering: `enabled: false` resources excluded from ExpandSets and shown as "skip" in `tomei plan`
 - Aqua template variable `AssetWithoutExt` for `files[].src` path references
-- System package management: SystemInstaller validation (APT) via per-user state, sudo delegation, distro detection (Debian/Ubuntu family)
+- System package management (APT): SystemInstaller validation, SystemPackageRepository and SystemPackageSet install/remove, per-user state, sudo delegation, distro detection (Debian/Ubuntu family)
 - Privileged download/registry tools route through SystemBinDir
 
 ## 10. System Package Management
@@ -296,7 +296,7 @@ System resource state lives under `<dataDir>/system/state.json` (by default, `~/
 
 This is a deliberate trade-off for the tool's target use case (single-developer dev environment setup). It is **not** suitable for coordinated multi-user system administration:
 
-- **No cross-user coordination.** State files are independent. Once `SystemPackageSet` reconciliation is implemented (see Roadmap below), dropping a package from user A's manifest would cause tomei to run a system-wide removal (e.g., `apt-get remove vim`) — affecting user B who also relied on the package. Idempotent installs (`apt-get install`) are safe to overlap; removals are not.
+- **No cross-user coordination.** State files are independent. Because `SystemPackageSet` reconciliation runs system-wide package operations, dropping a package from user A's manifest causes tomei to run a system-wide removal (e.g., `apt-get remove vim`) — affecting user B who also relied on the package. Idempotent installs (`apt-get install`) are safe to overlap; removals are not.
 - **No drift detection.** Reconciliation compares the declared spec against tomei's own state file. Out-of-band changes (manual `apt install`, distro upgrades, packages installed by other tools) are invisible.
 
 For shared servers, use a configuration management tool (Ansible, Chef, Puppet) instead.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -460,6 +460,30 @@ spec: {
 
 Both `SystemPackage` and `SystemPackageSet` require `--system` at apply time. See [CUE Schema → SystemPackage](./cue-schema.md#systempackage) for field details.
 
+#### Privileged tools (`spec.privileged`)
+
+A download/registry tool can set `spec.privileged: true` to place its symlink in the system bin directory (default `/usr/local/bin`) instead of `~/.local/bin` — useful for binaries that must sit on a system-wide `PATH`. The binary itself still lives under the user-owned tools directory (`~/.local/share/tomei/tools/<name>/<version>/`); only the symlink is privileged, placed via `os.Symlink` with a `sudo -n ln -snf` fallback on a permission error.
+
+```cue
+_os:   string @tag(os)
+_arch: string @tag(arch)
+
+apiVersion: "tomei.terassyi.net/v1beta1"
+kind:       "Tool"
+metadata: name: "gh"
+spec: {
+    installerRef: "download"
+    privileged:   true
+    version:      "2.62.0"
+    source: {
+        url: "https://github.com/cli/cli/releases/download/v\(spec.version)/gh_\(spec.version)_\(_os)_\(_arch).tar.gz"
+        checksum: url: "https://github.com/cli/cli/releases/download/v\(spec.version)/gh_\(spec.version)_checksums.txt"
+    }
+}
+```
+
+Like system resources, privileged tools require `--system` (or `--system-only`); without it they are skipped. `privileged: true` is **rejected with `runtimeRef`** and **ignored** for installer/name-delegation tools (the installer owns placement). See [CUE Schema → Tool](./cue-schema.md#tool) and [design.md §11 Privileged Tools](./design.md#11-privileged-tools).
+
 Without `--system`, system resources and privileged tools are skipped at apply time:
 
 ```text

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -212,6 +212,7 @@ tomei apply <files or directories...> [flags]
 | `--timeout` | Per-download timeout (e.g., `5m`, `10m`, `1h`; default `5m`) |
 | `--quiet` | Suppress progress output |
 | `--no-color` | Disable colored output |
+| `--ignore-min-release-age` | Bypass the `minimumReleaseAge` gate and install regardless of upstream release age (aqua gating is best-effort: tag mismatches fail open) |
 | `--ignore-cosign` | Skip cosign signature verification for CUE module dependencies (global flag) |
 
 Before applying, `tomei apply` shows the execution plan and asks for confirmation (`y/N`). Use `--yes` to skip the prompt. If the current state already matches the manifests, no changes are made.
@@ -468,6 +469,18 @@ $ tomei apply .
 ```
 
 `tomei plan .` (without `--system`) shows the same resources marked `skip` in the graph and summary, without the count lines above.
+
+#### Privileged + system reapply (`--system-only`)
+
+`--system-only` is the inverse half of `--system`: it applies **only** privileged tools and system resources, forcing non-privileged resources (`Runtime`, non-privileged `Tool`, `Installer`, `InstallerRepository`) to skip. It is mutually exclusive with `--system`, but composes with `--yes`, `--sync`, and the `--update-*` flags. This is useful for CI provisioning and cron-driven privileged reapply, where the user-level environment is managed separately.
+
+```bash
+# CI / cron: reapply only privileged tools and system resources
+tomei apply --system-only --yes .
+# => N non-privileged resource(s) skipped (--system-only restricts apply to privileged tools and system resources).
+```
+
+`tomei plan --system-only .` honors the same scope, marking non-privileged resources as `skip` in the graph.
 
 Behavior notes:
 
@@ -741,7 +754,9 @@ tomei version [flags]
 
 | Flag | Description |
 |------|-------------|
-| `--system` | Enable system package management and privileged tool operations. Used with `apply` and `plan`. tomei itself runs as the invoking user; manifests use `sudo` explicitly for elevation, and tomei keeps the sudo timestamp refreshed so re-prompts are rare. Do not run `sudo tomei`. System state is stored per-user under `<dataDir>/system/` (by default `~/.local/share/tomei/system/`); in multi-user environments each user maintains an independent view, and out-of-band system changes are not detected. |
+| `--system` | Enable system package management and privileged tool operations. Used with `apply` and `plan`. Mutually exclusive with `--system-only`. tomei itself runs as the invoking user; manifests use `sudo` explicitly for elevation, and tomei keeps the sudo timestamp refreshed so re-prompts are rare. Do not run `sudo tomei`. System state is stored per-user under `<dataDir>/system/` (by default `~/.local/share/tomei/system/`); in multi-user environments each user maintains an independent view, and out-of-band system changes are not detected. |
+| `--system-only` | Apply (and plan) **only** privileged tools and system resources, forcing non-privileged resources to skip. Mutually exclusive with `--system`. Useful for CI provisioning and cron-driven privileged reapply. See [Privileged + system reapply](#privileged--system-reapply---system-only). |
+| `--log-level` | Log verbosity: `debug`, `info`, `warn`, `error` (default `info`). |
 
 ## Environment Variables
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -780,7 +780,7 @@ tomei version [flags]
 |------|-------------|
 | `--system` | Enable system package management and privileged tool operations. Used with `apply` and `plan`. Mutually exclusive with `--system-only`. tomei itself runs as the invoking user; manifests use `sudo` explicitly for elevation, and tomei keeps the sudo timestamp refreshed so re-prompts are rare. Do not run `sudo tomei`. System state is stored per-user under `<dataDir>/system/` (by default `~/.local/share/tomei/system/`); in multi-user environments each user maintains an independent view, and out-of-band system changes are not detected. |
 | `--system-only` | Apply (and plan) **only** privileged tools and system resources, forcing non-privileged resources to skip. Mutually exclusive with `--system`. Useful for CI provisioning and cron-driven privileged reapply. See [Privileged + system reapply](#privileged--system-reapply---system-only). |
-| `--log-level` | Log verbosity: `debug`, `info`, `warn`, `error` (default `info`). |
+| `--log-level` | Log verbosity: `debug`, `info`, `warn`, `error` (default `warn`). |
 
 ## Environment Variables
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -458,7 +458,7 @@ spec: {
 }
 ```
 
-Both `SystemPackage` and `SystemPackageSet` require `--system` at apply time. See [CUE Schema → SystemPackage](./cue-schema.md#systempackage) for field details.
+Both `SystemPackage` and `SystemPackageSet` require `--system` (or `--system-only`) at apply time. See [CUE Schema → SystemPackage](./cue-schema.md#systempackage) for field details.
 
 #### Privileged tools (`spec.privileged`)
 


### PR DESCRIPTION
Fill documentation gaps found in the pre-v0.2.0 audit. All behavior is
already shipped; this is docs-only.

- usage.md: add --ignore-min-release-age to the `tomei apply` flag table;
  add --system-only and --log-level to the Global Flags table (noting
  --system/--system-only mutual exclusion); add a "Privileged + system
  reapply (--system-only)" subsection with a worked CI/cron example whose
  output matches the engine's skip summary verbatim.
- README.md: add #RustupComponentInstaller / #RustupComponentToolSet to the
  rust preset row and a runnable rustup-component ToolSet example.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
