### PR TITLE
docs: correct uv release-age claim in minimumReleaseAge delegation note

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -341,9 +341,12 @@ asset name by OS/arch.)
 installed via `runtimeRef` are never gated, regardless of the runtime's `type`),
 does not make tomei check anything — it only renders the value as the
 `{{.MinimumReleaseAge}}` template variable (the literal duration string, e.g.
-`168h`) for your install commands. No mainstream installer (`cargo binstall`,
-`brew`, `go install`, `uv`) accepts a release-age flag, so honoring it requires a
-shell guard you write yourself:
+`168h`) for your install commands. Most delegation installers (`cargo binstall`,
+`brew`, `go install`) accept no release-age flag, so honoring the value requires a
+shell guard you write yourself. The exception is `uv`, which has `--exclude-newer`
+— but it takes an RFC3339 cutoff date, not the duration string this variable
+renders, so you would still have to convert `now − minimumReleaseAge` to a date
+yourself. Either way, tomei does not do it for you:
 
 ```cue
 binstall: {


### PR DESCRIPTION
The delegation note listed `uv` among installers with "no release-age
flag", but uv has `--exclude-newer`. It takes an RFC3339 cutoff date, not
the Go-duration string `{{.MinimumReleaseAge}}` renders, so the value still
can't be passed directly — but the previous wording was factually wrong.
Reframe: most delegation CLIs have no such flag; uv is the exception but
needs a converted cutoff date, and tomei never performs the check on
delegation paths regardless.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
