### PR TITLE
feat(installer): support gz archive type for bare gzipped single binaries (#272)

### DIFF
--- a/cuemodule/schema/schema.cue
+++ b/cuemodule/schema/schema.cue
@@ -26,7 +26,7 @@ package schema
 #DownloadSource: {
 	url:          #HTTPSURL
 	checksum?:    #Checksum
-	archiveType?: "tar.gz" | "tar.xz" | "zip" | "raw" | "pkg"
+	archiveType?: "tar.gz" | "tar.xz" | "zip" | "raw" | "pkg" | "gz"
 	asset?:       string
 }
 

--- a/internal/installer/extract/extractor.go
+++ b/internal/installer/extract/extractor.go
@@ -474,19 +474,19 @@ func (e *gzExtractor) Extract(r io.Reader, destDir string) error {
 		return fmt.Errorf("failed to create binary file: %w", err)
 	}
 
+	// io.Copy reads to EOF, so the gzip reader has already verified the CRC32/ISIZE
+	// trailer by the time Copy returns — a truncated/corrupt stream (one that slipped
+	// past the archive checksum) surfaces as an error here, not at gr.Close().
 	if _, err := io.Copy(f, gr); err != nil {
 		f.Close()
 		return fmt.Errorf("failed to write binary file: %w", err)
 	}
 
-	// Check Close explicitly (unlike the sibling rawExtractor): f.Close flushes
-	// buffered writes, and gr.Close verifies the gzip CRC32/ISIZE trailer — catching
-	// truncated/corrupt downloads that slipped past the archive checksum.
+	// Check f.Close explicitly (unlike the sibling rawExtractor) to surface flush
+	// errors. gr is closed once via the deferred call above; gr.Close adds no
+	// further validation beyond what io.Copy already performed.
 	if err := f.Close(); err != nil {
 		return fmt.Errorf("failed to close binary file: %w", err)
-	}
-	if err := gr.Close(); err != nil {
-		return fmt.Errorf("gzip stream validation failed (possibly truncated): %w", err)
 	}
 
 	slog.Debug("gzip binary extracted", "target", target)

--- a/internal/installer/extract/extractor.go
+++ b/internal/installer/extract/extractor.go
@@ -86,7 +86,8 @@ func NormalizeArchiveType(raw string) ArchiveType {
 // DetectArchiveType detects the archive type from a URL or filename.
 // Returns empty string if the type cannot be detected.
 func DetectArchiveType(urlOrFilename string) ArchiveType {
-	lower := filepath.Base(urlOrFilename)
+	// Lowercase so suffix matching is case-insensitive (e.g. tool.GZ, tool.ZIP).
+	lower := strings.ToLower(filepath.Base(urlOrFilename))
 
 	// Check for compound extensions first
 	if hasSuffix(lower, ".tar.gz") || hasSuffix(lower, ".tgz") {

--- a/internal/installer/extract/extractor.go
+++ b/internal/installer/extract/extractor.go
@@ -34,6 +34,11 @@ const (
 	// ArchiveTypePkg represents a macOS flat package (.pkg).
 	// Extracted using pkgutil --expand-full (available on macOS without sudo).
 	ArchiveTypePkg ArchiveType = "pkg"
+
+	// ArchiveTypeGz represents a bare gzipped single binary (.gz) — a single
+	// gzip-compressed file, NOT a tar.gz. Aqua's `format: gz` packages (e.g.
+	// tree-sitter/tree-sitter) use this. Decompresses to one executable file.
+	ArchiveTypeGz ArchiveType = "gz"
 )
 
 // Common alias names for archive types accepted by NormalizeArchiveType.
@@ -46,6 +51,15 @@ const (
 // (and other archives created on macOS). Tomei filters it out during extraction
 // and archive root detection.
 const MacOSMetadataDir = "__MACOSX"
+
+// IsSingleFileArchive reports whether archiveType extracts to a single binary
+// named after the destination directory (rather than a multi-file tree). The
+// raw and gz extractors both write one file named after destDir's base, so the
+// caller must extract into a tool-named subdirectory for the placer's findBinary
+// to locate it. Tar/zip/pkg archives carry their own paths and do not need this.
+func IsSingleFileArchive(archiveType ArchiveType) bool {
+	return archiveType == ArchiveTypeRaw || archiveType == ArchiveTypeGz
+}
 
 // NormalizeArchiveType normalizes an archive type string to a canonical ArchiveType constant.
 // It handles common aliases (e.g., "tgz" → ArchiveTypeTarGz, "txz" → ArchiveTypeTarXz).
@@ -62,6 +76,8 @@ func NormalizeArchiveType(raw string) ArchiveType {
 		return ArchiveTypeRaw
 	case string(ArchiveTypePkg):
 		return ArchiveTypePkg
+	case string(ArchiveTypeGz):
+		return ArchiveTypeGz
 	default:
 		return ArchiveType(raw)
 	}
@@ -84,6 +100,11 @@ func DetectArchiveType(urlOrFilename string) ArchiveType {
 	}
 	if hasSuffix(lower, ".pkg") {
 		return ArchiveTypePkg
+	}
+	// Bare gzip MUST be checked last: the compound .tar.gz / .tgz checks above
+	// return earlier, so this cannot shadow them.
+	if hasSuffix(lower, ".gz") {
+		return ArchiveTypeGz
 	}
 	return ""
 }
@@ -117,6 +138,8 @@ func NewExtractor(archiveType ArchiveType) (Extractor, error) {
 		return &rawExtractor{}, nil
 	case ArchiveTypePkg:
 		return &pkgExtractor{}, nil
+	case ArchiveTypeGz:
+		return &gzExtractor{}, nil
 	default:
 		return nil, fmt.Errorf("unsupported archive type: %s", archiveType)
 	}
@@ -128,6 +151,7 @@ var (
 	_ Extractor = (*zipExtractor)(nil)
 	_ Extractor = (*rawExtractor)(nil)
 	_ Extractor = (*pkgExtractor)(nil)
+	_ Extractor = (*gzExtractor)(nil)
 )
 
 // tarGzExtractor implements Extractor for tar.gz archives.
@@ -412,5 +436,59 @@ func (e *rawExtractor) Extract(r io.Reader, destDir string) error {
 	}
 
 	slog.Debug("raw binary extracted", "target", target)
+	return nil
+}
+
+// gzExtractor implements Extractor for bare gzipped single binaries (.gz) —
+// a single gzip-compressed file, NOT a tar.gz. Aqua's `format: gz` packages use this.
+type gzExtractor struct{}
+
+// Extract decompresses a single gzip stream to one binary file in destDir.
+//
+// The output is named after destDir's base name (the tool name), like rawExtractor,
+// so the placer's findBinary(BinaryName) can locate it. The gzip header's optional
+// FNAME field is intentionally ignored (it need not match the tool name and could
+// carry a path). Like rawExtractor it does not honor a registry files[].src mapping.
+//
+// gzip carries no Unix mode, so the binary is created executable (0755).
+func (e *gzExtractor) Extract(r io.Reader, destDir string) error {
+	slog.Debug("extracting gzip binary", "dest", destDir)
+
+	gr, err := gzip.NewReader(r)
+	if err != nil {
+		return fmt.Errorf("failed to create gzip reader: %w", err)
+	}
+	defer gr.Close()
+
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	// Use the directory name as the binary name.
+	binName := filepath.Base(destDir)
+	target := filepath.Join(destDir, binName)
+
+	// Create the binary file with executable permissions.
+	f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+	if err != nil {
+		return fmt.Errorf("failed to create binary file: %w", err)
+	}
+
+	if _, err := io.Copy(f, gr); err != nil {
+		f.Close()
+		return fmt.Errorf("failed to write binary file: %w", err)
+	}
+
+	// Check Close explicitly (unlike the sibling rawExtractor): f.Close flushes
+	// buffered writes, and gr.Close verifies the gzip CRC32/ISIZE trailer — catching
+	// truncated/corrupt downloads that slipped past the archive checksum.
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("failed to close binary file: %w", err)
+	}
+	if err := gr.Close(); err != nil {
+		return fmt.Errorf("gzip stream validation failed (possibly truncated): %w", err)
+	}
+
+	slog.Debug("gzip binary extracted", "target", target)
 	return nil
 }

--- a/internal/installer/extract/extractor_test.go
+++ b/internal/installer/extract/extractor_test.go
@@ -118,6 +118,21 @@ func TestDetectArchiveType(t *testing.T) {
 			expected: ArchiveTypeTarGz,
 		},
 		{
+			name:     "uppercase gz extension (case-insensitive)",
+			input:    "tree-sitter-linux-x64.GZ",
+			expected: ArchiveTypeGz,
+		},
+		{
+			name:     "mixed-case tar.gz (case-insensitive)",
+			input:    "tool.Tar.Gz",
+			expected: ArchiveTypeTarGz,
+		},
+		{
+			name:     "uppercase zip extension (case-insensitive)",
+			input:    "TOOL.ZIP",
+			expected: ArchiveTypeZip,
+		},
+		{
 			name:     "unknown extension",
 			input:    "https://example.com/tool.exe",
 			expected: "",
@@ -674,8 +689,9 @@ func TestExtractor_Gz_CorruptStream(t *testing.T) {
 	tmpDir := t.TempDir()
 	destDir := filepath.Join(tmpDir, "tool")
 
-	// Build a valid gzip stream, then truncate the trailing CRC32/ISIZE bytes
-	// so decompression detects corruption (via io.Copy and/or gr.Close).
+	// Build a valid gzip stream, then truncate the trailing CRC32/ISIZE bytes.
+	// The gzip reader verifies the trailer during the final Read, so decompression
+	// surfaces the corruption via io.Copy (not gr.Close).
 	var buf bytes.Buffer
 	gw := gzip.NewWriter(&buf)
 	_, err := gw.Write([]byte("some reasonably sized binary payload to compress"))

--- a/internal/installer/extract/extractor_test.go
+++ b/internal/installer/extract/extractor_test.go
@@ -31,6 +31,8 @@ func TestNormalizeArchiveType(t *testing.T) {
 		{name: "zip", input: "zip", want: ArchiveTypeZip},
 		{name: "raw", input: "raw", want: ArchiveTypeRaw},
 		{name: "pkg", input: "pkg", want: ArchiveTypePkg},
+		{name: "gz", input: "gz", want: ArchiveTypeGz},
+		{name: "GZ uppercase", input: "GZ", want: ArchiveTypeGz},
 		{name: "unknown", input: "unknown", want: ArchiveType("unknown")},
 		{name: "empty", input: "", want: ArchiveType("")},
 	}
@@ -96,6 +98,26 @@ func TestDetectArchiveType(t *testing.T) {
 			expected: ArchiveTypePkg,
 		},
 		{
+			name:     "gz extension (bare gzipped binary)",
+			input:    "https://github.com/tree-sitter/tree-sitter/releases/download/v0.26.9/tree-sitter-linux-x64.gz",
+			expected: ArchiveTypeGz,
+		},
+		{
+			name:     "simple filename gz",
+			input:    "tree-sitter-macos-arm64.gz",
+			expected: ArchiveTypeGz,
+		},
+		{
+			name:     "tar.gz not shadowed by gz",
+			input:    "tool-linux-amd64.tar.gz",
+			expected: ArchiveTypeTarGz,
+		},
+		{
+			name:     "tgz not shadowed by gz",
+			input:    "tool.tgz",
+			expected: ArchiveTypeTarGz,
+		},
+		{
 			name:     "unknown extension",
 			input:    "https://example.com/tool.exe",
 			expected: "",
@@ -152,6 +174,11 @@ func TestNewExtractor(t *testing.T) {
 		{
 			name:        "pkg extractor",
 			archiveType: ArchiveTypePkg,
+			wantErr:     false,
+		},
+		{
+			name:        "gz extractor",
+			archiveType: ArchiveTypeGz,
 			wantErr:     false,
 		},
 		{
@@ -582,6 +609,109 @@ func TestExtractor_Raw_CreatesParentDirectory(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestExtractor_Extract_Gz(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		destDirName string // final component of destDir becomes binary name
+		content     string
+	}{
+		{
+			name:        "extract gz binary",
+			destDirName: "tree-sitter",
+			content:     "tree-sitter binary content",
+		},
+		{
+			name:        "extract gz binary with different name",
+			destDirName: "mytool",
+			content:     "#!/bin/sh\necho hello",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tmpDir := t.TempDir()
+			destDir := filepath.Join(tmpDir, tt.destDirName)
+
+			extractor, err := NewExtractor(ArchiveTypeGz)
+			require.NoError(t, err)
+
+			err = extractor.Extract(createGzipStream(t, []byte(tt.content)), destDir)
+			require.NoError(t, err)
+
+			// The single decompressed file is named after the destDir basename,
+			// so the placer's findBinary(searchName) locates it.
+			binaryPath := filepath.Join(destDir, tt.destDirName)
+			got, err := os.ReadFile(binaryPath)
+			require.NoError(t, err)
+			assert.Equal(t, tt.content, string(got))
+
+			// gz carries no mode; the extractor assigns the executable bit.
+			info, err := os.Stat(binaryPath)
+			require.NoError(t, err)
+			assert.NotEqual(t, fs.FileMode(0), info.Mode()&0111, "expected executable permission")
+		})
+	}
+}
+
+func TestExtractor_Gz_InvalidStream(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	destDir := filepath.Join(tmpDir, "tool")
+
+	extractor, err := NewExtractor(ArchiveTypeGz)
+	require.NoError(t, err)
+
+	// Not a gzip stream: gzip.NewReader fails on the magic-byte header.
+	err = extractor.Extract(bytes.NewReader([]byte("this is not gzip data")), destDir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gzip reader")
+}
+
+func TestExtractor_Gz_CorruptStream(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	destDir := filepath.Join(tmpDir, "tool")
+
+	// Build a valid gzip stream, then truncate the trailing CRC32/ISIZE bytes
+	// so decompression detects corruption (via io.Copy and/or gr.Close).
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	_, err := gw.Write([]byte("some reasonably sized binary payload to compress"))
+	require.NoError(t, err)
+	require.NoError(t, gw.Close())
+
+	full := buf.Bytes()
+	truncated := full[:len(full)-4] // drop part of the gzip trailer
+
+	extractor, err := NewExtractor(ArchiveTypeGz)
+	require.NoError(t, err)
+
+	err = extractor.Extract(bytes.NewReader(truncated), destDir)
+	require.Error(t, err)
+	// A valid header but corrupt body is caught during decompression (io.Copy),
+	// distinct from TestExtractor_Gz_InvalidStream where the header read fails
+	// ("gzip reader").
+	assert.Contains(t, err.Error(), "failed to write binary file")
+}
+
+func TestExtractor_Gz_CreatesParentDirectory(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	destDir := filepath.Join(tmpDir, "nested", "path", "toolname")
+
+	extractor, err := NewExtractor(ArchiveTypeGz)
+	require.NoError(t, err)
+
+	err = extractor.Extract(createGzipStream(t, []byte("binary content")), destDir)
+	require.NoError(t, err)
+
+	binaryPath := filepath.Join(destDir, "toolname")
+	_, err = os.Stat(binaryPath)
+	require.NoError(t, err)
+}
+
 func TestExtractTar_DeferredLinks(t *testing.T) {
 	t.Parallel()
 
@@ -766,6 +896,20 @@ func createTarGzStreamWithExecutable(t *testing.T) io.Reader {
 	require.NoError(t, err)
 
 	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+
+	return &buf
+}
+
+// createGzipStream builds a bare gzip stream (a single gzip-compressed file, NOT a
+// tar.gz) wrapping the given content — the shape aqua's `format: gz` packages use.
+func createGzipStream(t *testing.T, content []byte) io.Reader {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	_, err := gw.Write(content)
+	require.NoError(t, err)
 	require.NoError(t, gw.Close())
 
 	return &buf

--- a/internal/installer/tool/installer.go
+++ b/internal/installer/tool/installer.go
@@ -345,9 +345,10 @@ func (i *Installer) installByDownload(ctx context.Context, res *resource.Tool, n
 		return nil, fmt.Errorf("failed to create extractor: %w", err)
 	}
 
-	// For raw binaries, use tool name as subdirectory so the binary gets the correct name
+	// For single-file binaries (raw, bare gz), use the tool name as the subdirectory
+	// so the extracted binary is named after the tool and findBinary can locate it.
 	extractDir := filepath.Join(tmpDir, "extracted")
-	if archiveType == extract.ArchiveTypeRaw {
+	if extract.IsSingleFileArchive(archiveType) {
 		extractDir = filepath.Join(tmpDir, "extracted", name)
 	}
 
@@ -362,7 +363,7 @@ func (i *Installer) installByDownload(ctx context.Context, res *resource.Tool, n
 	}
 
 	// Reset extractDir for placer to search from
-	if archiveType == extract.ArchiveTypeRaw {
+	if extract.IsSingleFileArchive(archiveType) {
 		extractDir = filepath.Join(tmpDir, "extracted")
 	}
 

--- a/internal/installer/tool/installer_test.go
+++ b/internal/installer/tool/installer_test.go
@@ -155,6 +155,61 @@ func TestToolInstaller_Install(t *testing.T) {
 	}
 }
 
+// TestToolInstaller_Install_GzFormat installs a bare gzipped single binary
+// (issue #272). It uses a REAL place.Placer so the installer's gz subdir
+// special-case (installByDownload, mirroring raw) is exercised end-to-end:
+// the decompressed file is named after the tool so findBinary locates it.
+// A mockPlacer would skip findBinary and hide a regression of that special-case.
+func TestToolInstaller_Install_GzFormat(t *testing.T) {
+	t.Parallel()
+	binaryContent := []byte("#!/bin/sh\necho tree-sitter")
+	gzContent := createGzipContent(t, binaryContent)
+	archiveHash := sha256Hash(gzContent)
+
+	tmpDir := t.TempDir()
+	toolsDir := filepath.Join(tmpDir, "tools")
+	userBinDir := filepath.Join(tmpDir, "bin")
+
+	dl := &mockDownloader{archiveData: gzContent}
+	installer := NewInstaller(dl, place.NewPlacer(toolsDir), userBinDir, "/system-bin")
+
+	tool := &resource.Tool{
+		BaseResource: resource.BaseResource{
+			Metadata: resource.Metadata{Name: "tree-sitter"},
+		},
+		ToolSpec: &resource.ToolSpec{
+			InstallerRef: "download",
+			Version:      "0.26.9",
+			Source: &resource.DownloadSource{
+				URL: "https://example.com/tree-sitter-linux-x64.gz",
+				Checksum: &resource.Checksum{
+					Value: "sha256:" + archiveHash,
+				},
+				ArchiveType: "gz",
+			},
+		},
+	}
+
+	state, err := installer.Install(context.Background(), tool, tool.Name())
+	require.NoError(t, err)
+	require.NotNil(t, state)
+
+	// The placed binary lives under tools/<name>/<version>/<name>: findBinary
+	// matched the decompressed file because the gz subdir special-case named it
+	// after the tool. Its content round-trips and the executable bit is set.
+	binPath := filepath.Join(toolsDir, "tree-sitter", "0.26.9", "tree-sitter")
+	got, err := os.ReadFile(binPath)
+	require.NoError(t, err)
+	assert.Equal(t, binaryContent, got)
+
+	info, err := os.Stat(binPath)
+	require.NoError(t, err)
+	assert.NotEqual(t, os.FileMode(0), info.Mode()&0o111, "placed gz binary must be executable")
+
+	// User (non-privileged) install: the symlink lands in userBinDir.
+	assert.Equal(t, filepath.Join(userBinDir, "tree-sitter"), state.BinPath)
+}
+
 // TestBuildResolvedTool_PreservesPrivileged pins SUB5 #228: the registry
 // install path (installFromRegistry) hands a re-shaped Tool to installByDownload,
 // and Privileged MUST flow through that re-shaping. Dropping it would route
@@ -676,6 +731,20 @@ func createTarGzContent(t *testing.T, binaryName string, content []byte) []byte 
 	require.NoError(t, err)
 
 	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+
+	return buf.Bytes()
+}
+
+// createGzipContent builds a bare gzip stream (a single gzip-compressed file, NOT a
+// tar.gz) wrapping content — the shape aqua's `format: gz` packages use.
+func createGzipContent(t *testing.T, content []byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	_, err := gw.Write(content)
+	require.NoError(t, err)
 	require.NoError(t, gw.Close())
 
 	return buf.Bytes()

--- a/internal/registry/aqua/resolver_test.go
+++ b/internal/registry/aqua/resolver_test.go
@@ -523,6 +523,37 @@ func TestResolver_Resolve_RawFormatAutoDetect(t *testing.T) {
 	assert.Equal(t, extract.ArchiveTypeRaw, result.Format, "should auto-detect raw format when asset has no archive extension")
 }
 
+func TestResolver_Resolve_GzFormat(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	ref := RegistryRef("v4.465.0")
+	pkg := "tree-sitter/tree-sitter"
+
+	// A bare gzipped single binary: format: gz (NOT tar.gz).
+	registryYAML := `packages:
+  - type: github_release
+    repo_owner: tree-sitter
+    repo_name: tree-sitter
+    asset: tree-sitter-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: gz
+    replacements:
+      amd64: x64
+      darwin: macos
+`
+	cacheFile := filepath.Join(cacheDir, ref.String(), "pkgs", pkg, "registry.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(cacheFile), 0o755))
+	require.NoError(t, os.WriteFile(cacheFile, []byte(registryYAML), 0o644))
+
+	resolver := NewResolver(cacheDir, nil)
+
+	result, err := resolver.ResolveWithOS(context.Background(), ref, pkg, "v0.26.9", "darwin", "arm64")
+
+	require.NoError(t, err)
+	assert.Equal(t, "https://github.com/tree-sitter/tree-sitter/releases/download/v0.26.9/tree-sitter-macos-arm64.gz", result.URL)
+	assert.Equal(t, extract.ArchiveTypeGz, result.Format)
+	assert.Empty(t, result.Errors)
+}
+
 func TestResolver_Resolve_FilesSrcRendering(t *testing.T) {
 	t.Parallel()
 	cacheDir := t.TempDir()


### PR DESCRIPTION
Aqua-registry packages distributed as a bare gzipped single binary
(`format: gz`, e.g. tree-sitter/tree-sitter) previously failed with
"unsupported archive type: gz". A `.gz` here is one gzip-compressed file,
not a tar.gz.

Add ArchiveTypeGz and a gzExtractor that decompresses the single stream to
one executable named after the tool (so the placer's findBinary locates it),
mirroring rawExtractor. Wire it through NormalizeArchiveType, DetectArchiveType
(checked last so it cannot shadow .tar.gz/.tgz), NewExtractor, and the CUE
archiveType disjunction. The tool installer's single-file subdir special-case
now covers gz via a new extract.IsSingleFileArchive predicate.

gzip carries no Unix mode, so the binary is created 0755; gr.Close() is checked
to surface CRC/ISIZE corruption. The gzip header FNAME is intentionally ignored.

Covered by unit + installer + resolver tests (no e2e, consistent with the
registry-resolution coverage strategy).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
