### PR TITLE
fix(installer): ensure placed tool binaries are executable (#273)

### DIFF
--- a/internal/installer/place/placer.go
+++ b/internal/installer/place/placer.go
@@ -179,6 +179,13 @@ func (p *filePlacer) Place(srcDir string, target Target) (*Result, error) {
 		return nil, fmt.Errorf("failed to copy binary: %w", err)
 	}
 
+	// A tool binary must be runnable. Some archives carry a non-executable mode
+	// (zip stores 0644; gz/raw carry none) which copyFile preserves, so ensure
+	// the executable bit here (#273). Fail loudly — a non-runnable install is useless.
+	if err := EnsureExecutable(destPath); err != nil {
+		return nil, fmt.Errorf("failed to make binary executable: %w", err)
+	}
+
 	slog.Debug("binary placed", "path", destPath)
 	return &Result{BinaryPath: destPath}, nil
 }
@@ -288,6 +295,24 @@ func findBinary(srcDir, binaryName string) (string, error) {
 	}
 
 	return found, nil
+}
+
+// EnsureExecutable sets the executable bit on path for all classes (owner/group/other),
+// preserving the existing read/write bits, when it is not already executable. It is
+// idempotent: a no-op when path already has any execute bit. A tool binary is meant to be
+// run, so this is safe regardless of the archive's stored mode (#273).
+func EnsureExecutable(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("ensure executable: %w", err)
+	}
+	if info.Mode()&0o111 != 0 {
+		return nil
+	}
+	if err := os.Chmod(path, info.Mode()|0o111); err != nil {
+		return fmt.Errorf("ensure executable: %w", err)
+	}
+	return nil
 }
 
 // copyFile copies a file preserving permissions.

--- a/internal/installer/place/placer_test.go
+++ b/internal/installer/place/placer_test.go
@@ -134,6 +134,21 @@ func TestPlacer_Place(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "place non-executable source binary (zip 0644) is made executable",
+			setup: func(t *testing.T, srcDir string) {
+				binPath := filepath.Join(srcDir, "tool")
+				// zip stores 0644; the placed tool binary must still be runnable (#273).
+				err := os.WriteFile(binPath, []byte("binary content"), 0o644)
+				require.NoError(t, err)
+			},
+			target: Target{
+				Name:       "mytool",
+				Version:    "1.0.0",
+				BinaryName: "tool",
+			},
+			wantErr: false,
+		},
+		{
 			name: "place binary from nested directory",
 			setup: func(t *testing.T, srcDir string) {
 				// Create nested structure like GitHub releases
@@ -266,6 +281,62 @@ func TestPlacer_Place(t *testing.T) {
 			assert.NotEqual(t, os.FileMode(0), info.Mode()&0111, "expected executable permission")
 		})
 	}
+}
+
+func TestEnsureExecutable(t *testing.T) {
+	t.Parallel()
+
+	t.Run("adds exec bit to non-executable file and preserves content", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "tool")
+		content := []byte("binary content")
+		require.NoError(t, os.WriteFile(path, content, 0o644))
+
+		require.NoError(t, EnsureExecutable(path))
+
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		assert.NotEqual(t, os.FileMode(0), info.Mode()&0o111, "expected executable permission")
+
+		got, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Equal(t, content, got, "content must be unchanged")
+	})
+
+	t.Run("preserves existing read/write bits (0640 -> 0751)", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "tool")
+		require.NoError(t, os.WriteFile(path, []byte("x"), 0o640))
+
+		require.NoError(t, EnsureExecutable(path))
+
+		// mode|0o111 adds exec for all classes while preserving r/w bits
+		// (0640 -> 0751), unlike a blunt chmod 0755. os.Chmod is not subject to umask.
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o751), info.Mode().Perm())
+	})
+
+	t.Run("idempotent no-op when already executable", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "tool")
+		require.NoError(t, os.WriteFile(path, []byte("x"), 0o755))
+
+		require.NoError(t, EnsureExecutable(path))
+
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o755), info.Mode().Perm(), "mode must be unchanged")
+	})
+
+	t.Run("returns error when path does not exist", func(t *testing.T) {
+		t.Parallel()
+		err := EnsureExecutable(filepath.Join(t.TempDir(), "missing"))
+		require.Error(t, err)
+	})
 }
 
 func TestPlacer_Symlink(t *testing.T) {

--- a/internal/installer/place/placer_test.go
+++ b/internal/installer/place/placer_test.go
@@ -309,6 +309,9 @@ func TestEnsureExecutable(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "tool")
 		require.NoError(t, os.WriteFile(path, []byte("x"), 0o640))
+		// Force the exact starting mode: os.WriteFile's mode is subject to umask
+		// (e.g. 0077 would yield 0600), os.Chmod is not.
+		require.NoError(t, os.Chmod(path, 0o640))
 
 		require.NoError(t, EnsureExecutable(path))
 
@@ -324,6 +327,8 @@ func TestEnsureExecutable(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "tool")
 		require.NoError(t, os.WriteFile(path, []byte("x"), 0o755))
+		// Force the exact starting mode: os.WriteFile's mode is subject to umask, os.Chmod is not.
+		require.NoError(t, os.Chmod(path, 0o755))
 
 		require.NoError(t, EnsureExecutable(path))
 

--- a/internal/installer/tool/installer.go
+++ b/internal/installer/tool/installer.go
@@ -283,6 +283,13 @@ func (i *Installer) installByDownload(ctx context.Context, res *resource.Tool, n
 	switch action {
 	case place.ValidateActionSkip:
 		slog.Debug("tool already installed, skipping", "name", name, "version", spec.Version)
+		// Heal binaries placed non-executable by an older tomei (#273): the skip path
+		// never calls Place, so a 0644 binary would stay non-runnable forever. Best-effort
+		// — the binary already validated, so a chmod failure (e.g. read-only tools dir)
+		// must not turn this previously-infallible branch into a hard failure.
+		if err := place.EnsureExecutable(i.placer.BinaryPath(target)); err != nil {
+			slog.Warn("failed to ensure tool binary is executable", "name", name, "error", err)
+		}
 		// Even if binary exists, ensure symlink points to correct version.
 		// SUB5 #228: privileged tools route through the system bin dir.
 		linkPath, binDirKind, err := i.createSymlink(ctx, res, target)

--- a/internal/installer/tool/installer_test.go
+++ b/internal/installer/tool/installer_test.go
@@ -646,6 +646,54 @@ func TestToolInstaller_Install_Skip(t *testing.T) {
 	assert.Equal(t, tool.ToolSpec.Version, state.Version)
 }
 
+// TestToolInstaller_Install_Skip_HealsNonExecutable pins issue #273: a binary placed
+// non-executable (0644) by an older tomei is re-applied with a matching hash, so Validate
+// returns ValidateActionSkip and Place is never called. The skip branch must still heal the
+// executable bit so the tool is runnable.
+func TestToolInstaller_Install_Skip_HealsNonExecutable(t *testing.T) {
+	t.Parallel()
+	binaryContent := []byte("#!/bin/sh\necho hello")
+
+	tmpDir := t.TempDir()
+	toolsDir := filepath.Join(tmpDir, "tools")
+	binDir := filepath.Join(tmpDir, "bin")
+
+	// Pre-install the binary as NON-executable (0644), as a zip-sourced install by an
+	// older tomei would have left it.
+	installDir := filepath.Join(toolsDir, "ripgrep", "14.1.1")
+	require.NoError(t, os.MkdirAll(installDir, 0o755))
+	binPath := filepath.Join(installDir, "ripgrep")
+	require.NoError(t, os.WriteFile(binPath, binaryContent, 0o644))
+
+	downloader := download.NewDownloader()
+	placer := place.NewPlacer(toolsDir)
+	inst := NewInstaller(downloader, placer, binDir, "/system-bin")
+
+	tool := &resource.Tool{
+		BaseResource: resource.BaseResource{
+			Metadata: resource.Metadata{Name: "ripgrep"},
+		},
+		ToolSpec: &resource.ToolSpec{
+			InstallerRef: "download",
+			Version:      "14.1.1",
+			Source: &resource.DownloadSource{
+				URL:         "https://example.com/ripgrep.tar.gz",
+				Checksum:    nil, // No checksum = existence check only → ValidateActionSkip
+				ArchiveType: "tar.gz",
+			},
+		},
+	}
+
+	state, err := inst.Install(context.Background(), tool, "ripgrep")
+	require.NoError(t, err)
+	require.NotNil(t, state)
+
+	// The skip branch healed the executable bit on the already-placed binary.
+	info, err := os.Stat(binPath)
+	require.NoError(t, err)
+	assert.NotEqual(t, os.FileMode(0), info.Mode()&0o111, "skip path must ensure the binary is executable")
+}
+
 func TestToolInstaller_InstallFromRegistry_NoResolver(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()


### PR DESCRIPTION
A tool binary is meant to be run, but tomei placed it with whatever mode the
source carried. Some archive shapes yield a non-executable binary: zip stores
entries 0644 (and zipExtractor preserves it), and gz/raw carry no Unix mode.
place.copyFile then preserved that mode, so the installed binary at
toolsDir/<name>/<version>/<binaryName> (and its symlink) was permission-denied
(e.g. tree-sitter).

Fix at the placer chokepoint, independent of archive format: add
place.EnsureExecutable (mode|0o111, preserving existing r/w bits, idempotent)
and call it after copyFile in Place (fatal — a non-runnable install is useless).
Also heal the ValidateActionSkip path in installByDownload: a binary placed 0644
by an older tomei is re-applied with a matching hash, so Place is never called;
EnsureExecutable there is best-effort (slog.Warn, no hard failure) since the
binary already validated. os.Chmod is not subject to umask, so the bit lands
reliably regardless of the extractor's OpenFile mode.

No change to extractors, runtime installer, the Placer interface, or the CUE
schema. Hash-based skip is unaffected (content-only hash).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
