### PR TITLE
test(plan): lock SHA-pinned tool plan action (#271)

### DIFF
--- a/cmd/tomei/plan.go
+++ b/cmd/tomei/plan.go
@@ -164,6 +164,27 @@ func runPlan(cmd *cobra.Command, args []string) error {
 	}
 }
 
+// toolAction computes the plan action for a Tool that already has a persisted
+// state entry, by comparing the spec's sha/version against state. Branch
+// ordering MUST match reconciler.ToolComparator
+// (internal/installer/reconciler/tool.go) — otherwise `tomei plan` and the
+// engine disagree on the reason surfaced when multiple signals fire at once.
+// In particular sha is checked first, so a sha-pinned tool already installed at
+// that sha (spec.sha == state.sha, both versions empty) reports ActionNone
+// rather than a perpetual upgrade (#271).
+func toolAction(specSHA, specVersion string, st *resource.ToolState) resource.ActionType {
+	switch {
+	case st.SHA != specSHA:
+		return resource.ActionUpgrade
+	case st.IsTainted():
+		return resource.ActionReinstall
+	case st.Version == specVersion:
+		return resource.ActionNone
+	default:
+		return resource.ActionUpgrade
+	}
+}
+
 func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig, scope ApplyScope) map[graph.NodeID]graph.ResourceInfo {
 	info := make(map[graph.NodeID]graph.ResourceInfo)
 
@@ -260,20 +281,7 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 				}
 			case resource.KindTool:
 				if tool, ok := userState.Tools[res.Name()]; ok && tool != nil {
-					// Branch ordering MUST match reconciler.ToolComparator
-					// (internal/installer/reconciler/tool.go) — otherwise
-					// `tomei plan` and the engine disagree on the reason
-					// surfaced when multiple signals fire at once.
-					switch {
-					case tool.SHA != resInfo.SHA:
-						resInfo.Action = resource.ActionUpgrade
-					case tool.IsTainted():
-						resInfo.Action = resource.ActionReinstall
-					case tool.Version == resInfo.Version:
-						resInfo.Action = resource.ActionNone
-					default:
-						resInfo.Action = resource.ActionUpgrade
-					}
+					resInfo.Action = toolAction(resInfo.SHA, resInfo.Version, tool)
 				}
 			case resource.KindInstaller:
 				// Installers don't have versions in state typically

--- a/cmd/tomei/plan_test.go
+++ b/cmd/tomei/plan_test.go
@@ -559,3 +559,69 @@ func TestRenderSectionedTree(t *testing.T) {
 		assert.Contains(t, out, "Tool/gone-priv (1.0.0) [- remove]")
 	})
 }
+
+// TestToolAction pins the plan-layer action decision, whose branch ordering
+// must match reconciler.ToolComparator. The "sha pin already installed" case
+// is the #271 regression guard: spec.sha == state.sha (both versions empty)
+// must yield ActionNone, not a perpetual upgrade.
+func TestToolAction(t *testing.T) {
+	t.Parallel()
+
+	const (
+		shaA = "0123456789abcdef0123456789abcdef01234567"
+		shaB = "fedcba9876543210fedcba9876543210fedcba98"
+	)
+
+	tests := []struct {
+		name        string
+		specSHA     string
+		specVersion string
+		state       *resource.ToolState
+		want        resource.ActionType
+	}{
+		{
+			name:    "sha pin already installed at that sha -> none (#271)",
+			specSHA: shaA,
+			state:   &resource.ToolState{SHA: shaA, Version: "", VersionKind: resource.VersionExact},
+			want:    resource.ActionNone,
+		},
+		{
+			name:    "sha rotated -> upgrade",
+			specSHA: shaB,
+			state:   &resource.ToolState{SHA: shaA, Version: ""},
+			want:    resource.ActionUpgrade,
+		},
+		{
+			name:    "tainted -> reinstall",
+			specSHA: shaA,
+			state:   &resource.ToolState{SHA: shaA, Version: "", TaintReason: resource.TaintReason("runtime upgraded")},
+			want:    resource.ActionReinstall,
+		},
+		{
+			name:        "version match, no sha/taint -> none",
+			specVersion: "1.2.3",
+			state:       &resource.ToolState{Version: "1.2.3"},
+			want:        resource.ActionNone,
+		},
+		{
+			name:        "version differs -> upgrade",
+			specVersion: "1.2.4",
+			state:       &resource.ToolState{Version: "1.2.3"},
+			want:        resource.ActionUpgrade,
+		},
+		{
+			// sha takes precedence over a would-be taint reinstall.
+			name:    "sha change wins over taint",
+			specSHA: shaB,
+			state:   &resource.ToolState{SHA: shaA, TaintReason: resource.TaintReason("x")},
+			want:    resource.ActionUpgrade,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, toolAction(tt.specSHA, tt.specVersion, tt.state))
+		})
+	}
+}


### PR DESCRIPTION
#271 reported SHA-pinned go tools showing [~ upgrade] on every plan/apply.
Investigation found this already fixed by #250 (state.sha persistence + SHA-first
comparison, shipped in v0.2.0): a tool already installed at its pinned sha plans
as ActionNone. Verified end-to-end via `tomei plan` against a converged sha state
(no upgrade) and a pre-#250-shaped state (one-time upgrade, then converges).

This adds the missing plan-layer regression test. The Tool action switch in
buildResourceInfo (a near-duplicate of reconciler.ToolComparator, with a comment
requiring branch-order parity) had no test. Extract it into a pure
toolAction(specSHA, specVersion, *ToolState) ActionType helper — behavior-preserving
(caller keeps its `ok && tool != nil` guard and the ActionInstall default for the
no-state case) — and add TestToolAction covering sha-pin match -> None (the #271
guard), sha rotated -> Upgrade, tainted -> Reinstall, version match/differ, and
sha-precedence-over-taint.

The comparator and SHA JSON round-trip are already covered
(reconciler_test.go, tool_test.go); not duplicated.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
