### PR TITLE
fix(plan): stop perpetual [~ upgrade] for version-less tools (#270)

### DIFF
--- a/cmd/tomei/plan.go
+++ b/cmd/tomei/plan.go
@@ -165,23 +165,48 @@ func runPlan(cmd *cobra.Command, args []string) error {
 }
 
 // toolAction computes the plan action for a Tool that already has a persisted
-// state entry, by comparing the spec's sha/version against state. Branch
-// ordering MUST match reconciler.ToolComparator
-// (internal/installer/reconciler/tool.go) — otherwise `tomei plan` and the
-// engine disagree on the reason surfaced when multiple signals fire at once.
-// In particular sha is checked first, so a sha-pinned tool already installed at
-// that sha (spec.sha == state.sha, both versions empty) reports ActionNone
-// rather than a perpetual upgrade (#271).
+// state entry, by comparing the spec's sha/version against state.
+//
+// sha is checked first, so a sha-pinned tool already installed at that sha
+// (spec.sha == state.sha, both versions empty) reports ActionNone (#271). The
+// version comparison uses resource.SpecVersionDiffers (VersionKind-aware), the
+// same predicate the reconciler uses, so a version-less tool whose resolveVersion
+// populated state.Version (e.g. #Homebrew) is not perpetually [~ upgrade] (#270).
+//
+// Ordering vs reconciler.ToolComparator: sha is checked first in both. The
+// taint/version order intentionally differs (here taint precedes version) — a
+// pre-existing choice. Note that plan surfaces a tainted resource as
+// ActionReinstall whereas the reconciler maps any change to ActionUpgrade; that
+// plan/apply label difference is pre-existing and out of scope here.
 func toolAction(specSHA, specVersion string, st *resource.ToolState) resource.ActionType {
 	switch {
 	case st.SHA != specSHA:
 		return resource.ActionUpgrade
 	case st.IsTainted():
 		return resource.ActionReinstall
-	case st.Version == specVersion:
-		return resource.ActionNone
-	default:
+	case resource.SpecVersionDiffers(specVersion, st.VersionKind, st.Version, st.SpecVersion):
 		return resource.ActionUpgrade
+	default:
+		return resource.ActionNone
+	}
+}
+
+// runtimeAction computes the plan action for a Runtime that already has a
+// persisted state entry. Branch order (taint -> version) is preserved from the
+// original inline branch; runtimes have no sha. The version comparison uses the
+// shared VersionKind-aware resource.SpecVersionDiffers so a version-less runtime
+// whose resolveVersion populated state.Version is not perpetually [~ upgrade]
+// (#270). As with toolAction, this preserves the existing taint-as-Reinstall
+// labeling, which differs from reconciler.RuntimeComparator (version-first,
+// mapping any change to ActionUpgrade) — pre-existing and out of scope here.
+func runtimeAction(specVersion string, st *resource.RuntimeState) resource.ActionType {
+	switch {
+	case st.IsTainted():
+		return resource.ActionReinstall
+	case resource.SpecVersionDiffers(specVersion, st.VersionKind, st.Version, st.SpecVersion):
+		return resource.ActionUpgrade
+	default:
+		return resource.ActionNone
 	}
 }
 
@@ -271,13 +296,7 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 			switch res.Kind() {
 			case resource.KindRuntime:
 				if rt, ok := userState.Runtimes[res.Name()]; ok && rt != nil {
-					if rt.IsTainted() {
-						resInfo.Action = resource.ActionReinstall
-					} else if rt.Version == resInfo.Version {
-						resInfo.Action = resource.ActionNone
-					} else {
-						resInfo.Action = resource.ActionUpgrade
-					}
+					resInfo.Action = runtimeAction(resInfo.Version, rt)
 				}
 			case resource.KindTool:
 				if tool, ok := userState.Tools[res.Name()]; ok && tool != nil {

--- a/cmd/tomei/plan_test.go
+++ b/cmd/tomei/plan_test.go
@@ -616,12 +616,105 @@ func TestToolAction(t *testing.T) {
 			state:   &resource.ToolState{SHA: shaA, TaintReason: resource.TaintReason("x")},
 			want:    resource.ActionUpgrade,
 		},
+		{
+			// #270: version-less commands tool (e.g. #Homebrew) whose resolveVersion
+			// populated state.Version. Empty spec + VersionLatest must NOT upgrade.
+			name:        "version-less latest with resolved state -> none (#270)",
+			specVersion: "",
+			state:       &resource.ToolState{Version: "5.1.15", VersionKind: resource.VersionLatest},
+			want:        resource.ActionNone,
+		},
+		{
+			name:        "alias unchanged -> none",
+			specVersion: "stable",
+			state:       &resource.ToolState{Version: "1.2.3", VersionKind: resource.VersionAlias, SpecVersion: "stable"},
+			want:        resource.ActionNone,
+		},
+		{
+			name:        "alias changed -> upgrade",
+			specVersion: "lts",
+			state:       &resource.ToolState{Version: "1.2.3", VersionKind: resource.VersionAlias, SpecVersion: "stable"},
+			want:        resource.ActionUpgrade,
+		},
+		{
+			// Pins the plan-layer branch order: taint is checked before version,
+			// so a tool that is both tainted AND version-changed reports Reinstall.
+			name:        "tainted and version differs -> reinstall (taint wins)",
+			specVersion: "2.0.0",
+			state:       &resource.ToolState{Version: "1.0.0", VersionKind: resource.VersionExact, TaintReason: resource.TaintReason("x")},
+			want:        resource.ActionReinstall,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tt.want, toolAction(tt.specSHA, tt.specVersion, tt.state))
+		})
+	}
+}
+
+// TestRuntimeAction pins the plan-layer runtime action decision. Like toolAction
+// it must be VersionKind-aware so a version-less runtime (resolveVersion populates
+// state.Version) is not perpetually [~ upgrade] (#270). Branch order is taint ->
+// version (preserved from the original inline branch); runtimes have no SHA.
+func TestRuntimeAction(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		specVersion string
+		state       *resource.RuntimeState
+		want        resource.ActionType
+	}{
+		{
+			name:        "exact match -> none",
+			specVersion: "1.25.5",
+			state:       &resource.RuntimeState{Version: "1.25.5"},
+			want:        resource.ActionNone,
+		},
+		{
+			name:        "exact mismatch -> upgrade",
+			specVersion: "1.25.6",
+			state:       &resource.RuntimeState{Version: "1.25.5"},
+			want:        resource.ActionUpgrade,
+		},
+		{
+			name:        "tainted -> reinstall",
+			specVersion: "1.25.5",
+			state:       &resource.RuntimeState{Version: "1.25.5", TaintReason: resource.TaintReason("dep upgraded")},
+			want:        resource.ActionReinstall,
+		},
+		{
+			name:        "version-less latest with resolved state -> none (#270)",
+			specVersion: "",
+			state:       &resource.RuntimeState{Version: "1.89.0", VersionKind: resource.VersionLatest},
+			want:        resource.ActionNone,
+		},
+		{
+			name:        "alias unchanged -> none",
+			specVersion: "stable",
+			state:       &resource.RuntimeState{Version: "1.89.0", VersionKind: resource.VersionAlias, SpecVersion: "stable"},
+			want:        resource.ActionNone,
+		},
+		{
+			name:        "alias changed -> upgrade",
+			specVersion: "nightly",
+			state:       &resource.RuntimeState{Version: "1.89.0", VersionKind: resource.VersionAlias, SpecVersion: "stable"},
+			want:        resource.ActionUpgrade,
+		},
+		{
+			// Pins the branch order: taint precedes version.
+			name:        "tainted and version differs -> reinstall (taint wins)",
+			specVersion: "1.25.6",
+			state:       &resource.RuntimeState{Version: "1.25.5", VersionKind: resource.VersionExact, TaintReason: resource.TaintReason("x")},
+			want:        resource.ActionReinstall,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, runtimeAction(tt.specVersion, tt.state))
 		})
 	}
 }

--- a/cuemodule/presets/brew/brew.cue
+++ b/cuemodule/presets/brew/brew.cue
@@ -24,6 +24,11 @@ _brew:       _brewPrefix + "/bin/brew"
 			install: [
 				"NONINTERACTIVE=1 /bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"",
 			]
+			// update runs only on the --update-tools path (a version-less tool is
+			// otherwise satisfied and skipped). `brew update` refreshes Homebrew
+			// itself + formula metadata — the manager's "upgrade" — without
+			// re-running install.sh. Runs as the invoking user (brew refuses root).
+			update: [_brew + " update"]
 			check: [_brew + " --version"]
 			remove: ["NONINTERACTIVE=1 /bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)\""]
 			resolveVersion: [_brew + " --version 2>/dev/null | head -1 | grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+' || echo ''"]

--- a/internal/installer/reconciler/tool.go
+++ b/internal/installer/reconciler/tool.go
@@ -4,23 +4,12 @@ import (
 	"github.com/terassyi/tomei/internal/resource"
 )
 
-// specVersionChanged determines whether the spec's version specification
-// has changed compared to what is recorded in state, based on the VersionKind.
-//
-// Rules:
-//   - VersionLatest: only changed if spec switches to a non-empty version
-//     (actual latest updates are driven by --sync taint, not reconciler)
-//   - VersionAlias: changed if spec version differs from the stored alias (state.SpecVersion)
-//   - VersionExact: changed if spec version differs from the installed version (state.Version)
+// specVersionChanged is a thin alias for resource.SpecVersionDiffers, kept so the
+// tool/runtime comparators (and their tests) read naturally. The version-change
+// rules live in resource.SpecVersionDiffers — the single source of truth shared
+// with `tomei plan` so plan and apply never disagree.
 func specVersionChanged(specVersion string, stateVersionKind resource.VersionKind, stateVersion, stateSpecVersion string) bool {
-	switch stateVersionKind {
-	case resource.VersionLatest:
-		return !resource.IsLatestVersion(specVersion)
-	case resource.VersionAlias:
-		return specVersion != stateSpecVersion
-	default: // VersionExact
-		return specVersion != stateVersion
-	}
+	return resource.SpecVersionDiffers(specVersion, stateVersionKind, stateVersion, stateSpecVersion)
 }
 
 // ToolComparator returns a comparator for Tool resources.

--- a/internal/installer/reconciler/tool.go
+++ b/internal/installer/reconciler/tool.go
@@ -7,7 +7,9 @@ import (
 // specVersionChanged is a thin alias for resource.SpecVersionDiffers, kept so the
 // tool/runtime comparators (and their tests) read naturally. The version-change
 // rules live in resource.SpecVersionDiffers — the single source of truth shared
-// with `tomei plan` so plan and apply never disagree.
+// with `tomei plan` so the two agree on *version drift* specifically. (Plan and
+// apply can still differ on other axes, e.g. plan labels a tainted resource
+// ActionReinstall while the reconciler maps any change to ActionUpgrade.)
 func specVersionChanged(specVersion string, stateVersionKind resource.VersionKind, stateVersion, stateSpecVersion string) bool {
 	return resource.SpecVersionDiffers(specVersion, stateVersionKind, stateVersion, stateSpecVersion)
 }

--- a/internal/resource/types.go
+++ b/internal/resource/types.go
@@ -223,6 +223,30 @@ func IsLatestVersion(version string) bool {
 	return version == "" || version == string(VersionLatest)
 }
 
+// SpecVersionDiffers reports whether a spec's version specification differs from
+// what is recorded in state, honoring VersionKind. It is the single source of
+// truth for the reconciler comparators and `tomei plan`; both MUST agree,
+// otherwise plan and apply disagree (see #270/#271).
+//
+// Rules:
+//   - VersionLatest: changed only if the spec switches to a non-empty/non-"latest"
+//     version. A version-less tool whose resolveVersion populated stateVersion
+//     therefore does NOT differ (no perpetual upgrade).
+//   - VersionAlias: changed if the spec alias differs from the stored alias
+//     (stateSpecVersion), since stateVersion holds the resolved value.
+//   - VersionExact (and the zero value): changed if the spec version differs from
+//     the installed version (stateVersion).
+func SpecVersionDiffers(specVersion string, vk VersionKind, stateVersion, stateSpecVersion string) bool {
+	switch vk {
+	case VersionLatest:
+		return !IsLatestVersion(specVersion)
+	case VersionAlias:
+		return specVersion != stateSpecVersion
+	default: // VersionExact (and zero value "")
+		return specVersion != stateVersion
+	}
+}
+
 // ClassifyVersion determines the VersionKind for a given spec version string.
 // Empty string or "latest" → VersionLatest, otherwise VersionExact.
 // VersionAlias is only assigned by runtime installers that use ResolveVersion.

--- a/internal/resource/types_test.go
+++ b/internal/resource/types_test.go
@@ -399,6 +399,40 @@ func TestIsLatestVersion(t *testing.T) {
 	}
 }
 
+func TestSpecVersionDiffers(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name             string
+		specVersion      string
+		vk               VersionKind
+		stateVersion     string
+		stateSpecVersion string
+		want             bool
+	}{
+		// VersionExact (and zero-value kind)
+		{"exact match", "1.2.3", VersionExact, "1.2.3", "1.2.3", false},
+		{"exact mismatch", "1.2.4", VersionExact, "1.2.3", "1.2.3", true},
+		{"zero kind match", "1.2.3", VersionKind(""), "1.2.3", "", false},
+		{"both empty exact", "", VersionExact, "", "", false},
+		// VersionLatest — the #270 case: empty spec, resolved state.Version, must NOT differ
+		{"latest version-less with resolved state", "", VersionLatest, "5.1.15", "", false},
+		{"latest literal with resolved state", "latest", VersionLatest, "5.1.15", "", false},
+		{"latest switched to explicit", "1.2.3", VersionLatest, "5.1.15", "", true},
+		// VersionAlias — compares spec against the stored alias
+		{"alias unchanged", "stable", VersionAlias, "1.2.3", "stable", false},
+		{"alias changed", "lts", VersionAlias, "1.2.3", "stable", true},
+		{"alias vs empty stored alias differs", "stable", VersionAlias, "1.2.3", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := SpecVersionDiffers(tt.specVersion, tt.vk, tt.stateVersion, tt.stateSpecVersion)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestClassifyVersion(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
A version-less commands-pattern tool (#Homebrew: no spec.version, resolveVersion
returns e.g. "5.1.15") showed `Tool/homebrew [~ upgrade]` on every plan. Root
cause: the version comparison was duplicated and had drifted — `tomei apply`
(reconciler) was VersionKind-aware and correctly skipped, but `tomei plan` used a
raw `state.Version == spec.Version` compare, so a resolved state.Version never
matched the empty spec.Version → perpetual upgrade.

Fix: make the comparison a single source of truth and use it in both layers.
- Add resource.SpecVersionDiffers (VersionKind-aware); reconciler.specVersionChanged
  becomes a thin delegating alias (no reconciler-test churn).
- plan.go: toolAction's version branch now calls SpecVersionDiffers; extract a
  symmetric runtimeAction (the Runtime branch had the same raw-compare bug) so
  version-less tools AND runtimes report ActionNone when satisfied.
- preset/brew: give #Homebrew an `update` ("brew update") command so the
  --update-tools path refreshes Homebrew instead of re-running install.sh. Runs as
  the invoking user; only fires under --update-tools (plain apply skips).

Behavior is otherwise unchanged: sha pins (#271), exact-version and alias tools,
and the pre-existing taint-as-Reinstall plan labeling are preserved. compareTools
(state-vs-state diff), InstallerRepository and SystemPackage are out of scope
(no version comparison). Tests: TestSpecVersionDiffers; TestToolAction/
TestRuntimeAction gain version-less (#270), alias, and taint-ordering guards.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
