### PR TITLE
fix(installer): prepend delegation installer's own binDir to command PATH (#269)

### DIFF
--- a/internal/installer/engine/engine.go
+++ b/internal/installer/engine/engine.go
@@ -460,16 +460,9 @@ func (e *Engine) Apply(ctx context.Context, resources []resource.Resource) error
 			if err := inst.InstallerSpec.Validate(); err != nil {
 				return fmt.Errorf("invalid installer %q: %w", inst.Name(), err)
 			}
-			e.toolInstaller.RegisterInstaller(inst.Name(), &tool.InstallerInfo{
-				Type:              inst.InstallerSpec.Type,
-				ToolRef:           inst.InstallerSpec.ToolRef,
-				Commands:          inst.InstallerSpec.Commands,
-				MinimumReleaseAge: inst.InstallerSpec.MinimumReleaseAge,
-			})
-			// Persist installer state (including ToolRef and BinDir) for removal lookup and env
-			if st.Installers == nil {
-				st.Installers = make(map[string]*resource.InstallerState)
-			}
+			// Expand the installer's own binDir up front: it is both passed to the
+			// tool installer (so delegation commands get it on PATH, #269) and
+			// persisted in InstallerState below.
 			var expandedBinDir string
 			if inst.InstallerSpec.BinDir != "" {
 				var err error
@@ -477,6 +470,17 @@ func (e *Engine) Apply(ctx context.Context, resources []resource.Resource) error
 				if err != nil {
 					return fmt.Errorf("failed to expand binDir for installer %q: %w", inst.Name(), err)
 				}
+			}
+			e.toolInstaller.RegisterInstaller(inst.Name(), &tool.InstallerInfo{
+				Type:              inst.InstallerSpec.Type,
+				ToolRef:           inst.InstallerSpec.ToolRef,
+				BinDir:            expandedBinDir,
+				Commands:          inst.InstallerSpec.Commands,
+				MinimumReleaseAge: inst.InstallerSpec.MinimumReleaseAge,
+			})
+			// Persist installer state (including ToolRef and BinDir) for removal lookup and env
+			if st.Installers == nil {
+				st.Installers = make(map[string]*resource.InstallerState)
 			}
 			// Preserve existing state fields (e.g., Version) that are not set here
 			existing := st.Installers[inst.Name()]

--- a/internal/installer/tool/installer.go
+++ b/internal/installer/tool/installer.go
@@ -39,8 +39,13 @@ type RuntimeInfo struct {
 
 // InstallerInfo contains the information needed to install tools via installer delegation.
 type InstallerInfo struct {
-	Type     resource.InstallType // "download" or "delegation"
-	ToolRef  string               // Reference to tool (optional, e.g., cargo-binstall)
+	Type    resource.InstallType // "download" or "delegation"
+	ToolRef string               // Reference to tool (optional, e.g., cargo-binstall)
+	// BinDir is the installer's own bin directory (expanded), e.g. /opt/homebrew/bin
+	// for #BrewInstaller. Prepended to PATH when running the installer's delegation
+	// commands so a bare command (e.g. `brew install`) resolves even when Homebrew
+	// was bootstrapped in the same run (#269). Empty when the spec omits binDir.
+	BinDir   string
 	Commands *resource.CommandsSpec
 	// MinimumReleaseAge is the Go duration string from the Installer spec, exposed
 	// to delegation install commands as {{.MinimumReleaseAge}}. Empty when unset.
@@ -122,19 +127,31 @@ func (i *Installer) SetToolBinPaths(paths map[string]string) {
 	i.toolBinPaths = paths
 }
 
-// buildEnvWithToolPath builds an environment map with the tool's bin directory prepended to PATH.
-// This ensures installer delegation commands (e.g., helm pull) can find their toolRef binary.
-func (i *Installer) buildEnvWithToolPath(installerName string) map[string]string {
-	if i.toolBinPaths == nil {
+// buildEnvWithToolPath builds an environment map whose PATH lets an installer's
+// delegation commands find their binary. PATH is composed, highest precedence
+// first, of: the installer's own binDir (installerBinDir; e.g. /opt/homebrew/bin
+// for #BrewInstaller — the production location of the delegated CLI, #269), then
+// the installer's toolRef tool bin dir (toolBinPaths[installerName]; e.g. for
+// cargo-binstall installed via cargo), then the inherited $PATH. The installer's
+// own binDir wins because it is the authoritative location for its CLI; the
+// toolRef dir is a fallback. Empty components are skipped; returns nil (PATH left
+// inherited) when neither is available.
+func (i *Installer) buildEnvWithToolPath(installerName, installerBinDir string) map[string]string {
+	var parts []string
+	if installerBinDir != "" {
+		parts = append(parts, installerBinDir)
+	}
+	if i.toolBinPaths != nil {
+		if binDir := i.toolBinPaths[installerName]; binDir != "" {
+			parts = append(parts, binDir)
+		}
+	}
+	if len(parts) == 0 {
 		return nil
 	}
-	binDir, ok := i.toolBinPaths[installerName]
-	if !ok || binDir == "" {
-		return nil
-	}
-	currentPath := os.Getenv("PATH")
+	parts = append(parts, os.Getenv("PATH"))
 	return map[string]string{
-		"PATH": binDir + string(os.PathListSeparator) + currentPath,
+		"PATH": strings.Join(parts, string(os.PathListSeparator)),
 	}
 }
 
@@ -889,8 +906,9 @@ func (i *Installer) installByInstaller(ctx context.Context, res *resource.Tool, 
 		MinimumReleaseAge: info.MinimumReleaseAge,
 	}
 
-	// Build environment with PATH including the installer's toolRef binary directory
-	env := i.buildEnvWithToolPath(spec.InstallerRef)
+	// Build environment with PATH including the installer's own binDir (#269) and
+	// its toolRef binary directory.
+	env := i.buildEnvWithToolPath(spec.InstallerRef, info.BinDir)
 
 	// Execute install command with output streaming
 	if err := i.executeCommand(ctx, info.Commands.Install, vars, env); err != nil {

--- a/internal/installer/tool/installer.go
+++ b/internal/installer/tool/installer.go
@@ -149,7 +149,11 @@ func (i *Installer) buildEnvWithToolPath(installerName, installerBinDir string) 
 	if len(parts) == 0 {
 		return nil
 	}
-	parts = append(parts, os.Getenv("PATH"))
+	// Only append the inherited PATH when non-empty: a trailing separator
+	// (e.g. "/opt/homebrew/bin:") makes shells treat the cwd as on PATH.
+	if current := os.Getenv("PATH"); current != "" {
+		parts = append(parts, current)
+	}
 	return map[string]string{
 		"PATH": strings.Join(parts, string(os.PathListSeparator)),
 	}

--- a/internal/installer/tool/installer_test.go
+++ b/internal/installer/tool/installer_test.go
@@ -1203,7 +1203,8 @@ func TestToolInstaller_ProgressCallback_Priority(t *testing.T) {
 type mockCommandRunner struct {
 	executedCmds [][]string
 	executedVars []command.Vars
-	methods      []string // "Execute", "ExecuteWithEnv", "ExecuteWithOutput", "Check"
+	executedEnv  []map[string]string // env map per delegation command (nil for Execute)
+	methods      []string            // "Execute", "ExecuteWithEnv", "ExecuteWithOutput", "Check"
 	checkedCmds  [][]string
 	checkResult  bool
 	executeErr   error
@@ -1213,27 +1214,31 @@ func (m *mockCommandRunner) Execute(_ context.Context, cmds []string, vars comma
 	m.methods = append(m.methods, "Execute")
 	m.executedCmds = append(m.executedCmds, cmds)
 	m.executedVars = append(m.executedVars, vars)
+	m.executedEnv = append(m.executedEnv, nil)
 	return m.executeErr
 }
 
-func (m *mockCommandRunner) ExecuteWithEnv(_ context.Context, cmds []string, vars command.Vars, _ map[string]string) error {
+func (m *mockCommandRunner) ExecuteWithEnv(_ context.Context, cmds []string, vars command.Vars, env map[string]string) error {
 	m.methods = append(m.methods, "ExecuteWithEnv")
 	m.executedCmds = append(m.executedCmds, cmds)
 	m.executedVars = append(m.executedVars, vars)
+	m.executedEnv = append(m.executedEnv, env)
 	return m.executeErr
 }
 
-func (m *mockCommandRunner) ExecuteWithOutput(_ context.Context, cmds []string, vars command.Vars, _ map[string]string, _ command.OutputCallback) error {
+func (m *mockCommandRunner) ExecuteWithOutput(_ context.Context, cmds []string, vars command.Vars, env map[string]string, _ command.OutputCallback) error {
 	m.methods = append(m.methods, "ExecuteWithOutput")
 	m.executedCmds = append(m.executedCmds, cmds)
 	m.executedVars = append(m.executedVars, vars)
+	m.executedEnv = append(m.executedEnv, env)
 	return m.executeErr
 }
 
-func (m *mockCommandRunner) Check(_ context.Context, cmds []string, vars command.Vars, _ map[string]string) bool {
+func (m *mockCommandRunner) Check(_ context.Context, cmds []string, vars command.Vars, env map[string]string) bool {
 	m.methods = append(m.methods, "Check")
 	m.checkedCmds = append(m.checkedCmds, cmds)
 	m.executedVars = append(m.executedVars, vars)
+	m.executedEnv = append(m.executedEnv, env)
 	return m.checkResult
 }
 
@@ -1725,4 +1730,75 @@ func TestExtractBinaryMapping(t *testing.T) {
 			assert.Equal(t, tt.wantSrcBinaryName, cfg.SrcBinaryName)
 		})
 	}
+}
+
+// TestInstallByInstaller_PrependsBinDirToPath pins #269: a delegation installer's
+// own binDir is prepended to the PATH used to run its commands, so a bare command
+// (e.g. `brew install`) resolves even when the binary isn't otherwise on PATH.
+func TestInstallByInstaller_PrependsBinDirToPath(t *testing.T) {
+	t.Parallel()
+	sep := string(os.PathListSeparator)
+
+	newTool := func() *resource.Tool {
+		return &resource.Tool{
+			BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "mytool"}},
+			ToolSpec: &resource.ToolSpec{
+				InstallerRef: "inst",
+				Version:      "1.0.0",
+				Package:      &resource.Package{Name: "mytool"},
+			},
+		}
+	}
+	registerWithBinDir := func(inst *Installer) {
+		inst.RegisterInstaller("inst", &InstallerInfo{
+			Type:     resource.InstallTypeDelegation,
+			BinDir:   "/opt/homebrew/bin",
+			Commands: &resource.CommandsSpec{Install: []string{"faketool install {{.Package}}"}},
+		})
+	}
+
+	t.Run("binDir prepended to PATH", func(t *testing.T) {
+		t.Parallel()
+		runner := &mockCommandRunner{checkResult: true}
+		inst := NewInstallerWithRunner(download.NewDownloader(), &mockPlacer{}, "/bin", "/system-bin", runner)
+		registerWithBinDir(inst)
+
+		_, err := inst.Install(context.Background(), newTool(), "mytool")
+		require.NoError(t, err)
+		require.Len(t, runner.executedEnv, 1)
+		path := runner.executedEnv[0]["PATH"]
+		assert.True(t, strings.HasPrefix(path, "/opt/homebrew/bin"+sep),
+			"installer binDir must be prepended; got %q", path)
+	})
+
+	t.Run("binDir precedes toolRef binDir", func(t *testing.T) {
+		t.Parallel()
+		runner := &mockCommandRunner{checkResult: true}
+		inst := NewInstallerWithRunner(download.NewDownloader(), &mockPlacer{}, "/bin", "/system-bin", runner)
+		registerWithBinDir(inst)
+		inst.SetToolBinPaths(map[string]string{"inst": "/tool/bin"})
+
+		_, err := inst.Install(context.Background(), newTool(), "mytool")
+		require.NoError(t, err)
+		require.Len(t, runner.executedEnv, 1)
+		path := runner.executedEnv[0]["PATH"]
+		assert.True(t, strings.HasPrefix(path, "/opt/homebrew/bin"+sep+"/tool/bin"+sep),
+			"order must be installer binDir, then toolRef binDir, then inherited; got %q", path)
+	})
+
+	t.Run("no binDir and no toolRef -> no PATH override", func(t *testing.T) {
+		t.Parallel()
+		runner := &mockCommandRunner{checkResult: true}
+		inst := NewInstallerWithRunner(download.NewDownloader(), &mockPlacer{}, "/bin", "/system-bin", runner)
+		inst.RegisterInstaller("inst", &InstallerInfo{
+			Type:     resource.InstallTypeDelegation,
+			Commands: &resource.CommandsSpec{Install: []string{"faketool install {{.Package}}"}},
+		})
+
+		_, err := inst.Install(context.Background(), newTool(), "mytool")
+		require.NoError(t, err)
+		require.Len(t, runner.executedEnv, 1)
+		_, hasPath := runner.executedEnv[0]["PATH"]
+		assert.False(t, hasPath, "no binDir/toolRef should leave PATH unset (inherited): %v", runner.executedEnv[0])
+	})
 }

--- a/internal/installer/tool/installer_test.go
+++ b/internal/installer/tool/installer_test.go
@@ -1766,9 +1766,11 @@ func TestInstallByInstaller_PrependsBinDirToPath(t *testing.T) {
 		_, err := inst.Install(context.Background(), newTool(), "mytool")
 		require.NoError(t, err)
 		require.Len(t, runner.executedEnv, 1)
-		path := runner.executedEnv[0]["PATH"]
-		assert.True(t, strings.HasPrefix(path, "/opt/homebrew/bin"+sep),
-			"installer binDir must be prepended; got %q", path)
+		// Assert on the first component (not a trailing separator): an empty
+		// inherited $PATH legitimately yields exactly "/opt/homebrew/bin".
+		parts := strings.Split(runner.executedEnv[0]["PATH"], sep)
+		assert.Equal(t, "/opt/homebrew/bin", parts[0],
+			"installer binDir must be the first PATH component; got %q", runner.executedEnv[0]["PATH"])
 	})
 
 	t.Run("binDir precedes toolRef binDir", func(t *testing.T) {
@@ -1781,9 +1783,10 @@ func TestInstallByInstaller_PrependsBinDirToPath(t *testing.T) {
 		_, err := inst.Install(context.Background(), newTool(), "mytool")
 		require.NoError(t, err)
 		require.Len(t, runner.executedEnv, 1)
-		path := runner.executedEnv[0]["PATH"]
-		assert.True(t, strings.HasPrefix(path, "/opt/homebrew/bin"+sep+"/tool/bin"+sep),
-			"order must be installer binDir, then toolRef binDir, then inherited; got %q", path)
+		parts := strings.Split(runner.executedEnv[0]["PATH"], sep)
+		require.GreaterOrEqual(t, len(parts), 2)
+		assert.Equal(t, "/opt/homebrew/bin", parts[0], "installer binDir must come first")
+		assert.Equal(t, "/tool/bin", parts[1], "toolRef binDir must come second")
 	})
 
 	t.Run("no binDir and no toolRef -> no PATH override", func(t *testing.T) {

--- a/tests/tool_installer_test.go
+++ b/tests/tool_installer_test.go
@@ -391,3 +391,45 @@ func toolSha256Hash(data []byte) string {
 	h := sha256.Sum256(data)
 	return hex.EncodeToString(h[:])
 }
+
+// TestToolInstaller_InstallerDelegation_BinDirResolvesStub reproduces #269: a
+// delegation installer's command uses a bare binary name that is only resolvable
+// via the installer's own binDir on PATH. Before the fix this failed with exit
+// 127 ("command not found"); the installer's binDir must be prepended to PATH.
+func TestToolInstaller_InstallerDelegation_BinDirResolvesStub(t *testing.T) {
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, "installerbin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	marker := filepath.Join(tmpDir, "installed.marker")
+
+	// Stub executable resolvable only via PATH (bare name in the command).
+	stub := "#!/bin/sh\ntouch " + marker + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "faketool"), []byte(stub), 0o755))
+
+	dl := download.NewDownloader()
+	placer := place.NewPlacer(filepath.Join(tmpDir, "tools"))
+	installer := toolpkg.NewInstaller(dl, placer, filepath.Join(tmpDir, "bin"), filepath.Join(tmpDir, "system-bin"))
+
+	// Delegation installer whose binDir holds the stub; bare command relies on PATH.
+	installer.RegisterInstaller("fake", &toolpkg.InstallerInfo{
+		Type:   resource.InstallTypeDelegation,
+		BinDir: binDir,
+		Commands: &resource.CommandsSpec{
+			Install: []string{"faketool install {{.Package}}"},
+		},
+	})
+
+	tool := &resource.Tool{
+		BaseResource: resource.BaseResource{Metadata: resource.Metadata{Name: "ffmpeg"}},
+		ToolSpec: &resource.ToolSpec{
+			InstallerRef: "fake",
+			Version:      "1.0.0",
+			Package:      &resource.Package{Name: "ffmpeg"},
+		},
+	}
+
+	_, err := installer.Install(context.Background(), tool, "ffmpeg")
+	require.NoError(t, err, "install must not fail with exit 127 when the stub is on PATH via the installer binDir")
+	_, statErr := os.Stat(marker)
+	require.NoError(t, statErr, "stub binary should have run (marker created), proving binDir was on PATH")
+}

--- a/tests/tool_installer_test.go
+++ b/tests/tool_installer_test.go
@@ -402,8 +402,11 @@ func TestToolInstaller_InstallerDelegation_BinDirResolvesStub(t *testing.T) {
 	require.NoError(t, os.MkdirAll(binDir, 0o755))
 	marker := filepath.Join(tmpDir, "installed.marker")
 
-	// Stub executable resolvable only via PATH (bare name in the command).
-	stub := "#!/bin/sh\ntouch " + marker + "\n"
+	// Stub executable resolvable only via PATH (bare name in the command). The
+	// stub creates the marker with a shell builtin (`: >`) rather than external
+	// `touch`, so the test depends only on the installer binDir being on PATH,
+	// not on coreutils being present in a minimal/empty PATH.
+	stub := "#!/bin/sh\n: > " + marker + "\n"
 	require.NoError(t, os.WriteFile(filepath.Join(binDir, "faketool"), []byte(stub), 0o755))
 
 	dl := download.NewDownloader()


### PR DESCRIPTION
`#BrewInstaller` runs bare `brew install` and declares binDir: /opt/homebrew/bin
("set for tomei env PATH inclusion"), but tomei never put the installer's own
binDir on PATH when running its commands — only the toolRef tool's bin dir. brew's
toolRef (#Homebrew, a commands tool) has no state BinPath, so PATH stayed empty and
formula installs failed with exit 127 ("brew: command not found") when Homebrew was
bootstrapped in the same apply. (`installByRuntime` already prepends the runtime's
own BinDir; installer delegation had no analog.)

Fix: carry the installer's expanded binDir into InstallerInfo (wired in
RegisterInstaller, reusing the expansion already done for InstallerState) and make
buildEnvWithToolPath compose PATH as: installer binDir -> toolRef tool bin dir ->
inherited $PATH (empty parts skipped; nil when none, leaving PATH inherited). This
is timing-robust (binDir is static from the spec) and honors the preset's documented
binDir-for-PATH contract, so no preset change is needed. The executor merges env
onto os.Environ, so passing a PATH-only map preserves HOME etc.

Scope: install path only. Removal of installer-delegated tools does not run the
installer's remove command today (no-op cleanup, no exit 127) — a separate
pre-existing gap, out of scope. Only brew declares an installer binDir; gated on
BinDir != "" so no other installer's behavior changes. Tests: unit asserts binDir
is prepended (and ordered before toolRef); integration reproduces #269 with a stub
binary resolved only via the installer binDir on PATH.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
