### PR TITLE
chore(cuemod): bump tomei.terassyi.net default version to v0.2.1

### DIFF
--- a/demo/manifests/cue.mod/module.cue
+++ b/demo/manifests/cue.mod/module.cue
@@ -1,5 +1,5 @@
 module: "manifests.local@v0"
 language: version: "v0.9.0"
 deps: {
-	"tomei.terassyi.net@v0": v: "v0.2.0"
+	"tomei.terassyi.net@v0": v: "v0.2.1"
 }

--- a/docs/cosign.md
+++ b/docs/cosign.md
@@ -10,7 +10,7 @@ When `tomei apply`, `tomei plan`, or `tomei validate` loads CUE manifests that i
 
 1. Reads `cue.mod/module.cue` to extract module dependencies
 2. Filters for first-party modules (`tomei.terassyi.net` prefix)
-3. Resolves each dependency to its OCI reference (e.g. `ghcr.io/terassyi/tomei.terassyi.net:v0.2.0`)
+3. Resolves each dependency to its OCI reference (e.g. `ghcr.io/terassyi/tomei.terassyi.net:v0.2.1`)
 4. Fetches and verifies the cosign signature for each OCI artifact
 5. Proceeds with CUE evaluation only if verification passes
 

--- a/docs/cue-ecosystem.md
+++ b/docs/cue-ecosystem.md
@@ -139,7 +139,7 @@ Update tomei module dependencies to the latest version:
 
 ```bash
 $ tomei cue update
-tomei.terassyi.net@v0: v0.1.10 -> v0.2.0
+tomei.terassyi.net@v0: v0.2.0 -> v0.2.1
 
 Updated cue.mod/module.cue
 

--- a/docs/cue-schema.md
+++ b/docs/cue-schema.md
@@ -854,7 +854,7 @@ Use `tomei cue init` to create the module structure, or manually create `cue.mod
 module: "manifests.local@v0"
 language: version: "v0.9.0"
 deps: {
-    "tomei.terassyi.net@v0": v: "v0.2.0"
+    "tomei.terassyi.net@v0": v: "v0.2.1"
 }
 ```
 

--- a/docs/module-publishing.md
+++ b/docs/module-publishing.md
@@ -19,7 +19,7 @@ While in `@v0`, breaking changes are permitted.
 
 ```cue
 deps: {
-    "tomei.terassyi.net@v0": v: "v0.2.0"
+    "tomei.terassyi.net@v0": v: "v0.2.1"
 }
 ```
 

--- a/examples/real-world/cue.mod/module.cue
+++ b/examples/real-world/cue.mod/module.cue
@@ -4,6 +4,6 @@ language: {
 }
 deps: {
 	"tomei.terassyi.net@v0": {
-		v: "v0.2.0"
+		v: "v0.2.1"
 	}
 }

--- a/internal/cuemod/init.go
+++ b/internal/cuemod/init.go
@@ -28,7 +28,7 @@ var platformTmpl string
 
 const (
 	DefaultModuleName = "manifests.local@v0"
-	DefaultModuleVer  = "v0.2.0"
+	DefaultModuleVer  = "v0.2.1"
 )
 
 // ModuleParams holds the parameters for module.cue template rendering.

--- a/internal/cuemod/init_test.go
+++ b/internal/cuemod/init_test.go
@@ -28,7 +28,7 @@ func TestGenerateModuleCUE_TableDriven(t *testing.T) {
 			wantContains: []string{
 				`module: "manifests.local@v0"`,
 				`language: version: "v0.9.0"`,
-				`"tomei.terassyi.net@v0": v: "v0.2.0"`,
+				`"tomei.terassyi.net@v0": v: "v0.2.1"`,
 			},
 		},
 		{


### PR DESCRIPTION
Align DefaultModuleVer, demo/real-world example manifests, and docs with the
newly published cuemodule/v0.2.1 so `tomei cue init` pins the latest schema
(gz archive type, brew #Homebrew update command) out of the box.

Mirrors #267 (the v0.2.0 bump). cuemodule/v0.2.1 is already tagged and published
(publish-module succeeded), so @v0.2.1 resolves. Must land before the v0.2.1
binary tag so the released binary pins the matching module version.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
