### PR TITLE
fix(installer): place gz/raw single binaries with aqua files[].src mapping (#281)

### DIFF
--- a/internal/installer/extract/extractor.go
+++ b/internal/installer/extract/extractor.go
@@ -55,8 +55,10 @@ const MacOSMetadataDir = "__MACOSX"
 // IsSingleFileArchive reports whether archiveType extracts to a single binary
 // named after the destination directory (rather than a multi-file tree). The
 // raw and gz extractors both write one file named after destDir's base, so the
-// caller must extract into a tool-named subdirectory for the placer's findBinary
-// to locate it. Tar/zip/pkg archives carry their own paths and do not need this.
+// caller must extract into a subdirectory named after the placer's search name
+// (place.Target.SearchName) for the placer's findBinary to locate it — this is
+// what lets aqua's files[].src mapping work (#281). Tar/zip/pkg archives carry
+// their own paths and do not need this.
 func IsSingleFileArchive(archiveType ArchiveType) bool {
 	return archiveType == ArchiveTypeRaw || archiveType == ArchiveTypeGz
 }
@@ -412,7 +414,9 @@ func isInsideDir(baseDir, target string) bool {
 type rawExtractor struct{}
 
 // Extract copies a raw binary file to the destination directory.
-// The binary is named after the base name of destDir (the tool name).
+// The binary is named after the base name of destDir. The caller sets destDir's
+// base to the placer's search name (place.Target.SearchName), so findBinary can
+// locate it even when aqua's files[].src differs from the tool name (#281).
 func (e *rawExtractor) Extract(r io.Reader, destDir string) error {
 	slog.Debug("extracting raw binary", "dest", destDir)
 
@@ -446,10 +450,11 @@ type gzExtractor struct{}
 
 // Extract decompresses a single gzip stream to one binary file in destDir.
 //
-// The output is named after destDir's base name (the tool name), like rawExtractor,
-// so the placer's findBinary(BinaryName) can locate it. The gzip header's optional
-// FNAME field is intentionally ignored (it need not match the tool name and could
-// carry a path). Like rawExtractor it does not honor a registry files[].src mapping.
+// The output is named after destDir's base name, like rawExtractor, so the
+// placer's findBinary can locate it. The caller sets destDir's base to the
+// placer's search name (place.Target.SearchName), so a registry files[].src
+// mapping IS honored (#281). The gzip header's optional FNAME field is
+// intentionally ignored (it need not match the search name and could carry a path).
 //
 // gzip carries no Unix mode, so the binary is created executable (0755).
 func (e *gzExtractor) Extract(r io.Reader, destDir string) error {

--- a/internal/installer/place/placer.go
+++ b/internal/installer/place/placer.go
@@ -20,6 +20,18 @@ type Target struct {
 	SrcBinaryName string // Binary name to search in archive (e.g., krew-linux_arm64); empty = BinaryName
 }
 
+// SearchName returns the binary name to search for in extracted archives.
+// SrcBinaryName (the archive-specific asset name, e.g. tree-sitter-linux-arm64)
+// takes precedence over BinaryName when set. This is the single source of truth
+// for the search name, shared by Place and the download installer's single-file
+// extraction so the extracted file name and the search name cannot diverge.
+func (t Target) SearchName() string {
+	if t.SrcBinaryName != "" {
+		return t.SrcBinaryName
+	}
+	return t.BinaryName
+}
+
 // Result contains information about the placed tool.
 type Result struct {
 	BinaryPath string // Path to the placed binary
@@ -153,10 +165,7 @@ func (p *filePlacer) calculateHash(path string) (string, error) {
 
 // Place finds and places a binary from srcDir to the tools directory.
 func (p *filePlacer) Place(srcDir string, target Target) (*Result, error) {
-	searchName := target.BinaryName
-	if target.SrcBinaryName != "" {
-		searchName = target.SrcBinaryName
-	}
+	searchName := target.SearchName()
 
 	destDir := filepath.Join(p.toolsDir, target.Name, target.Version)
 	slog.Debug("placing binary", "src", srcDir, "dest", destDir, "binary", target.BinaryName, "search", searchName)

--- a/internal/installer/place/placer_test.go
+++ b/internal/installer/place/placer_test.go
@@ -183,6 +183,25 @@ func TestPlacer_Place(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			// #281: gz/raw single-file install extracts into a subdirectory named
+			// after SearchName(); the extracted file carries that same name. The
+			// placer must search SrcBinaryName, find it, and place it as BinaryName.
+			name: "place single-file gz/raw with files[].src subdir (tree-sitter pattern)",
+			setup: func(t *testing.T, srcDir string) {
+				dir := filepath.Join(srcDir, "tree-sitter-linux-arm64")
+				require.NoError(t, os.MkdirAll(dir, 0755))
+				err := os.WriteFile(filepath.Join(dir, "tree-sitter-linux-arm64"), []byte("binary content"), 0755)
+				require.NoError(t, err)
+			},
+			target: Target{
+				Name:          "tree-sitter",
+				Version:       "0.26.9",
+				BinaryName:    "tree-sitter",
+				SrcBinaryName: "tree-sitter-linux-arm64",
+			},
+			wantErr: false,
+		},
+		{
 			name: "place binary found by WalkDir in subdirectory (helm pattern)",
 			setup: func(t *testing.T, srcDir string) {
 				// Archive layout: linux-arm64/helm — installer has already extracted path.Base("linux-arm64/helm") = "helm"
@@ -279,6 +298,38 @@ func TestPlacer_Place(t *testing.T) {
 			info, err := os.Stat(result.BinaryPath)
 			require.NoError(t, err)
 			assert.NotEqual(t, os.FileMode(0), info.Mode()&0111, "expected executable permission")
+		})
+	}
+}
+
+func TestTarget_SearchName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		target Target
+		want   string
+	}{
+		{
+			name:   "SrcBinaryName set takes precedence",
+			target: Target{BinaryName: "tree-sitter", SrcBinaryName: "tree-sitter-linux-arm64"},
+			want:   "tree-sitter-linux-arm64",
+		},
+		{
+			name:   "empty SrcBinaryName falls back to BinaryName",
+			target: Target{BinaryName: "rg", SrcBinaryName: ""},
+			want:   "rg",
+		},
+		{
+			name:   "both empty returns empty",
+			target: Target{},
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.target.SearchName())
 		})
 	}
 }

--- a/internal/installer/tool/installer.go
+++ b/internal/installer/tool/installer.go
@@ -202,12 +202,13 @@ func (i *Installer) executeCommand(ctx context.Context, cmds []string, vars comm
 // binaryNameRegexp matches the CUE schema constraint: ^[a-zA-Z0-9][a-zA-Z0-9._-]*$
 var binaryNameRegexp = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 
-// validateBinaryName checks that binaryName is safe for use in file paths.
-// Enforces the same regex as the CUE schema (^[a-zA-Z0-9][a-zA-Z0-9._-]*$)
-// as defense-in-depth for inputs that bypass CUE validation (e.g., JSON/YAML).
-func validateBinaryName(name string) error {
+// validateName checks that a path-bound name (kind labels which one, e.g.
+// "binaryName" or "srcBinaryName") is safe for use in file paths. Enforces the
+// same regex as the CUE schema (^[a-zA-Z0-9][a-zA-Z0-9._-]*$) as defense-in-depth
+// for inputs that bypass CUE validation (e.g., JSON/YAML or untrusted registry data).
+func validateName(kind, name string) error {
 	if !binaryNameRegexp.MatchString(name) {
-		return fmt.Errorf("invalid binaryName %q: must match ^[a-zA-Z0-9][a-zA-Z0-9._-]*$", name)
+		return fmt.Errorf("invalid %s %q: must match ^[a-zA-Z0-9][a-zA-Z0-9._-]*$", kind, name)
 	}
 	return nil
 }
@@ -218,7 +219,7 @@ func (i *Installer) Install(ctx context.Context, res *resource.Tool, name string
 
 	// Validate binaryName to prevent path traversal (defense-in-depth; CUE schema also enforces this)
 	if spec.BinaryName != "" {
-		if err := validateBinaryName(spec.BinaryName); err != nil {
+		if err := validateName("binaryName", spec.BinaryName); err != nil {
 			return nil, err
 		}
 	}
@@ -272,8 +273,16 @@ func (i *Installer) installByDownload(ctx context.Context, res *resource.Tool, n
 	}
 
 	// Validate effective binary name (after registry mapping and spec override)
-	if err := validateBinaryName(cfg.BinaryName); err != nil {
+	if err := validateName("binaryName", cfg.BinaryName); err != nil {
 		return nil, err
+	}
+	// SrcBinaryName (from untrusted registry files[].src) is now used as the
+	// single-file extraction subdirectory name via Target.SearchName(), so it
+	// must also be path-safe. path.Base does not neutralize ".." (#281).
+	if cfg.SrcBinaryName != "" {
+		if err := validateName("srcBinaryName", cfg.SrcBinaryName); err != nil {
+			return nil, err
+		}
 	}
 
 	// Validate spec
@@ -373,11 +382,14 @@ func (i *Installer) installByDownload(ctx context.Context, res *resource.Tool, n
 		return nil, fmt.Errorf("failed to create extractor: %w", err)
 	}
 
-	// For single-file binaries (raw, bare gz), use the tool name as the subdirectory
-	// so the extracted binary is named after the tool and findBinary can locate it.
+	// For single-file binaries (raw, bare gz), name the subdirectory after the
+	// placer's search name. The gz/raw extractor names the extracted file after
+	// the subdirectory's base name, so this makes the extracted file name match
+	// what place.Place searches for — including aqua's files[].src case where
+	// SrcBinaryName differs from the tool name (e.g. tree-sitter-linux-arm64). See #281.
 	extractDir := filepath.Join(tmpDir, "extracted")
 	if extract.IsSingleFileArchive(archiveType) {
-		extractDir = filepath.Join(tmpDir, "extracted", name)
+		extractDir = filepath.Join(tmpDir, "extracted", target.SearchName())
 	}
 
 	archiveFile, err := os.Open(archivePath)

--- a/internal/installer/tool/installer_test.go
+++ b/internal/installer/tool/installer_test.go
@@ -210,6 +210,136 @@ func TestToolInstaller_Install_GzFormat(t *testing.T) {
 	assert.Equal(t, filepath.Join(userBinDir, "tree-sitter"), state.BinPath)
 }
 
+// TestToolInstaller_Install_GzFormat_FilesSrcMapping pins #281: a gz single-file
+// package whose aqua registry maps files[].name != files[].src (the tree-sitter
+// shape) must install. The decompressed file is named after SearchName()
+// (SrcBinaryName = tree-sitter-<os>-<arch>), and place.Place must locate it by
+// that search name and place it as BinaryName (tree-sitter). Before the fix the
+// gz subdir was named after the resource, so findBinary searched the src name and
+// failed with "binary not found".
+func TestToolInstaller_Install_GzFormat_FilesSrcMapping(t *testing.T) {
+	t.Parallel()
+	binaryContent := []byte("#!/bin/sh\necho tree-sitter")
+	gzContent := createGzipContent(t, binaryContent)
+
+	tmpDir := t.TempDir()
+	toolsDir := filepath.Join(tmpDir, "tools")
+	userBinDir := filepath.Join(tmpDir, "bin")
+	cacheDir := t.TempDir()
+	ref := aqua.RegistryRef("v4.465.0")
+	pkg := "tree-sitter/tree-sitter"
+
+	registryYAML := `packages:
+  - type: github_release
+    repo_owner: tree-sitter
+    repo_name: tree-sitter
+    asset: tree-sitter-{{.OS}}-{{.Arch}}.gz
+    format: gz
+    files:
+      - name: tree-sitter
+        src: tree-sitter-{{.OS}}-{{.Arch}}
+`
+	cacheFile := filepath.Join(cacheDir, ref.String(), "pkgs", pkg, "registry.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(cacheFile), 0o755))
+	require.NoError(t, os.WriteFile(cacheFile, []byte(registryYAML), 0o644))
+
+	dl := &mockDownloader{archiveData: gzContent}
+	inst := NewInstaller(dl, place.NewPlacer(toolsDir), userBinDir, "/system-bin")
+	inst.SetResolver(aqua.NewResolver(cacheDir, nil), ref)
+
+	tool := &resource.Tool{
+		BaseResource: resource.BaseResource{
+			Metadata: resource.Metadata{Name: "tree-sitter"},
+		},
+		ToolSpec: &resource.ToolSpec{
+			InstallerRef: "aqua",
+			Version:      "v0.26.9",
+			Package: &resource.Package{
+				Owner: "tree-sitter",
+				Repo:  "tree-sitter",
+			},
+		},
+	}
+
+	state, err := inst.Install(context.Background(), tool, tool.Name())
+	require.NoError(t, err)
+	require.NotNil(t, state)
+
+	// Placed as BinaryName (tree-sitter) despite the src being tree-sitter-<os>-<arch>.
+	binPath := filepath.Join(toolsDir, "tree-sitter", "v0.26.9", "tree-sitter")
+	got, err := os.ReadFile(binPath)
+	require.NoError(t, err)
+	assert.Equal(t, binaryContent, got)
+
+	info, err := os.Stat(binPath)
+	require.NoError(t, err)
+	assert.NotEqual(t, os.FileMode(0), info.Mode()&0o111, "placed gz binary must be executable")
+}
+
+// TestToolInstaller_Install_GzFormat_SpecBinaryNameOverride pins the interaction
+// between a user spec.BinaryName override and a registry files[].src mapping for a
+// gz single-file package (the #281 path). The registry sets SrcBinaryName, so the
+// override branch (installByDownload: spec.BinaryName != "") keeps the registry's
+// SrcBinaryName for archive search via SearchName() and places the binary under the
+// spec-overridden name. This exercises the override branch the FilesSrcMapping test
+// does not reach.
+func TestToolInstaller_Install_GzFormat_SpecBinaryNameOverride(t *testing.T) {
+	t.Parallel()
+	binaryContent := []byte("#!/bin/sh\necho custom")
+	gzContent := createGzipContent(t, binaryContent)
+
+	tmpDir := t.TempDir()
+	toolsDir := filepath.Join(tmpDir, "tools")
+	userBinDir := filepath.Join(tmpDir, "bin")
+	cacheDir := t.TempDir()
+	ref := aqua.RegistryRef("v4.465.0")
+	pkg := "mytool/mytool"
+
+	registryYAML := `packages:
+  - type: github_release
+    repo_owner: mytool
+    repo_name: mytool
+    asset: mytool-{{.OS}}-{{.Arch}}.gz
+    format: gz
+    files:
+      - name: mytool
+        src: mytool-{{.OS}}-{{.Arch}}
+`
+	cacheFile := filepath.Join(cacheDir, ref.String(), "pkgs", pkg, "registry.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(cacheFile), 0o755))
+	require.NoError(t, os.WriteFile(cacheFile, []byte(registryYAML), 0o644))
+
+	dl := &mockDownloader{archiveData: gzContent}
+	inst := NewInstaller(dl, place.NewPlacer(toolsDir), userBinDir, "/system-bin")
+	inst.SetResolver(aqua.NewResolver(cacheDir, nil), ref)
+
+	tool := &resource.Tool{
+		BaseResource: resource.BaseResource{
+			Metadata: resource.Metadata{Name: "mytool"},
+		},
+		ToolSpec: &resource.ToolSpec{
+			InstallerRef: "aqua",
+			Version:      "v1.0.0",
+			Package:      &resource.Package{Owner: "mytool", Repo: "mytool"},
+			BinaryName:   "custom", // spec override differs from registry files[].name
+		},
+	}
+
+	state, err := inst.Install(context.Background(), tool, tool.Name())
+	require.NoError(t, err)
+	require.NotNil(t, state)
+
+	// Found via registry's SrcBinaryName (mytool-<os>-<arch>), placed as the override name.
+	binPath := filepath.Join(toolsDir, "mytool", "v1.0.0", "custom")
+	got, err := os.ReadFile(binPath)
+	require.NoError(t, err)
+	assert.Equal(t, binaryContent, got)
+
+	info, err := os.Stat(binPath)
+	require.NoError(t, err)
+	assert.NotEqual(t, os.FileMode(0), info.Mode()&0o111, "placed gz binary must be executable")
+}
+
 // TestBuildResolvedTool_PreservesPrivileged pins SUB5 #228: the registry
 // install path (installFromRegistry) hands a re-shaped Tool to installByDownload,
 // and Privileged MUST flow through that re-shaping. Dropping it would route
@@ -1730,6 +1860,51 @@ func TestExtractBinaryMapping(t *testing.T) {
 			assert.Equal(t, tt.wantSrcBinaryName, cfg.SrcBinaryName)
 		})
 	}
+}
+
+// TestToolInstaller_Install_RejectsUnsafeSrcBinaryName pins the #281 defense-in-depth:
+// SrcBinaryName (from untrusted registry files[].src) is now used as a path component
+// via Target.SearchName(), and path.Base does not neutralize "..". A registry mapping
+// whose src basename is path-unsafe must be rejected before any download/extraction.
+func TestToolInstaller_Install_RejectsUnsafeSrcBinaryName(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	cacheDir := t.TempDir()
+	ref := aqua.RegistryRef("v4.465.0")
+	pkg := "evil/evil"
+
+	// src renders to ".."; path.Base("..") == ".." → must be rejected.
+	registryYAML := `packages:
+  - type: github_release
+    repo_owner: evil
+    repo_name: evil
+    asset: evil-{{.OS}}-{{.Arch}}.gz
+    format: gz
+    files:
+      - name: evil
+        src: ".."
+`
+	cacheFile := filepath.Join(cacheDir, ref.String(), "pkgs", pkg, "registry.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(cacheFile), 0o755))
+	require.NoError(t, os.WriteFile(cacheFile, []byte(registryYAML), 0o644))
+
+	inst := NewInstaller(&mockDownloader{}, place.NewPlacer(filepath.Join(tmpDir, "tools")), filepath.Join(tmpDir, "bin"), "/system-bin")
+	inst.SetResolver(aqua.NewResolver(cacheDir, nil), ref)
+
+	tool := &resource.Tool{
+		BaseResource: resource.BaseResource{
+			Metadata: resource.Metadata{Name: "evil"},
+		},
+		ToolSpec: &resource.ToolSpec{
+			InstallerRef: "aqua",
+			Version:      "v1.0.0",
+			Package:      &resource.Package{Owner: "evil", Repo: "evil"},
+		},
+	}
+
+	_, err := inst.Install(context.Background(), tool, tool.Name())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "srcBinaryName")
 }
 
 // TestInstallByInstaller_PrependsBinDirToPath pins #269: a delegation installer's


### PR DESCRIPTION
gz/raw single-binary tools whose aqua registry maps files[].src (e.g.
tree-sitter: src=tree-sitter-{{.OS}}-{{.Arch}}) failed to install with
"binary not found: <src>". The single-file extraction subdir was named
after the resource, so the gz/raw extractor named the file after the
resource while place.Place searched for SrcBinaryName — a mismatch.

Unify the search name in place.Target.SearchName() (SrcBinaryName, else
BinaryName) and name the single-file extraction subdir after it, so the
extracted file name and the placer's search name cannot diverge. Validate
SrcBinaryName (untrusted registry data, now a path component) with the
same regex as binaryName, since path.Base does not neutralize "..".

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
