### PR TITLE
feat(installer): dearmor apt repository keys in-process to drop the gnupg runtime dependency (#283)

### DIFF
--- a/e2e/containers/ubuntu/Dockerfile
+++ b/e2e/containers/ubuntu/Dockerfile
@@ -1,6 +1,10 @@
 FROM ubuntu:24.04
 
-# Install minimal dependencies
+# Install minimal dependencies.
+# gnupg is NOT a tomei runtime dependency — SystemPackageRepository apply
+# dearmors signing keys in-process (#283). It is kept here solely as the test
+# oracle for the keyring-validation spec (`gpg --list-keys`) in
+# e2e/system_package_test.go.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -157,8 +157,9 @@ func systemPackageTests() {
 	//
 	// The apply / removal / idempotency arms of the spec are exercised
 	// against the host in the sibling Ordered Context "Apply --system
-	// installs SystemPackageRepository (#218)" below (gnupg now ships in
-	// the e2e runner image; see e2e/containers/ubuntu/Dockerfile).
+	// installs SystemPackageRepository (#218)" below (gnupg ships in the
+	// e2e runner image only as the keyring-validation oracle now that apply
+	// dearmors in-process, #283; see e2e/containers/ubuntu/Dockerfile).
 	Context("SystemPackageRepository (#197)", func() {
 		It("validates the manifest", func() {
 			out, err := testExec.Exec("tomei", "validate", cfgPath)
@@ -520,7 +521,8 @@ func systemPackageTests() {
 	// that exercise the SystemPackageSet apply path WITHOUT pgdgRepo.
 	// SystemPackageRepository apply now lives in the sibling
 	// "Apply --system installs SystemPackageRepository (#218)" Context
-	// below (gnupg is now installed in the runner image; see
+	// below (gnupg is in the runner image only as the keyring-validation
+	// oracle now that apply dearmors in-process, #283; see
 	// e2e/containers/ubuntu/Dockerfile). Keeping the SystemPackageSet
 	// apply heredocs PGDG-free lets that Context exercise the package-
 	// install path in isolation, without reaching apt.postgresql.org
@@ -1777,26 +1779,27 @@ EOF`, dir, repoBlock)
 		BeforeAll(func() {
 			skipIfNotLinux()
 
-			// gpg is required by apt.PackageRepositoryInstaller (gpg
-			// --dearmor) AND by the keyring assertion in spec 1.
-			// skipIfNotLinux only probes apt-get / dpkg-query, so a
-			// native opt-in run on a minimal Debian/Ubuntu host without
-			// gnupg would fail mid-apply with a confusing error instead
-			// of skipping with a clear prerequisite message.
+			// gpg is NO LONGER required by apt.PackageRepositoryInstaller:
+			// the key is dearmored in-process now (#283), so apply works on
+			// minimal images without gnupg. gpg is still needed here purely
+			// as the TEST ORACLE that validates the decoded keyring via
+			// `gpg --list-keys` (the "lists ... public key" spec below) —
+			// the strongest proof that the in-process decode byte-matches
+			// `gpg --dearmor`.
 			//
-			// In TOMEI_E2E_CONTAINER mode the Dockerfile is supposed to
-			// install gnupg (see e2e/containers/ubuntu/Dockerfile). A
-			// regression that drops the gnupg apt-get line must FAIL
-			// CI rather than turn this whole Context into a silent
-			// skip, so the missing-gpg branch only Skips for native
-			// opt-in runs and Expects in container mode.
+			// In TOMEI_E2E_CONTAINER mode the Dockerfile installs gnupg for
+			// that oracle (see e2e/containers/ubuntu/Dockerfile). A
+			// regression that drops the gnupg apt-get line must FAIL CI
+			// rather than turn the keyring-validation coverage into a silent
+			// skip, so the missing-gpg branch only Skips for native opt-in
+			// runs and Expects in container mode.
 			_, gpgErr := testExec.ExecBash("command -v gpg >/dev/null 2>&1")
 			if gpgErr != nil {
 				if os.Getenv("TOMEI_E2E_CONTAINER") != "" {
 					Expect(gpgErr).NotTo(HaveOccurred(),
-						"gpg missing in TOMEI_E2E_CONTAINER mode: the runner image is supposed to install gnupg via e2e/containers/ubuntu/Dockerfile — a regression there silently turned repository apply coverage into a skip")
+						"gpg missing in TOMEI_E2E_CONTAINER mode: the runner image installs gnupg via e2e/containers/ubuntu/Dockerfile as the keyring-validation oracle — a regression there silently turned that coverage into a skip")
 				}
-				Skip("gpg not found on PATH: SystemPackageRepository apply requires gnupg (install `gnupg` or use the container e2e runner)")
+				Skip("gpg not found on PATH: the keyring-validation oracle requires gnupg (apply itself no longer needs it, #283); install `gnupg` or use the container e2e runner")
 			}
 
 			// NOPASSWD probe — same rationale as the #200 BeforeAll.
@@ -1965,14 +1968,17 @@ EOF`, dir, repoBlock)
 					// to /dev/null so a real gpg failure (corrupt keyring,
 					// missing agent socket) surfaces in test logs instead of
 					// being silenced — pipefail propagates the non-zero exit.
-					// Isolate gpg from the host's GNUPGHOME / gpg.conf:
-					// `--homedir` to a fresh /tmp directory, `--no-options`
-					// so a developer's gpg.conf can't change command
-					// semantics, and `--batch` to prevent any pinentry/
-					// agent prompt. Mirrors the dearmor isolation done by
-					// the installer in internal/installer/apt/repository.go.
-					// trap-cleanup removes the homedir on success or
-					// failure so a leaked /tmp/gpghome-* does not pile up.
+					// Isolate this validation-oracle gpg from the host's
+					// GNUPGHOME / gpg.conf: `--homedir` to a fresh /tmp
+					// directory, `--no-options` so a developer's gpg.conf
+					// can't change command semantics, and `--batch` to
+					// prevent any pinentry/agent prompt. (The installer no
+					// longer runs gpg at all — it dearmors in-process,
+					// #283; this gpg invocation is purely the test oracle
+					// proving the in-process-decoded keyring is a valid,
+					// parseable OpenPGP keyring.) trap-cleanup removes the
+					// homedir on success or failure so a leaked
+					// /tmp/gpghome-* does not pile up.
 					gpgOut, err := testExec.ExecBash(
 						"set -o pipefail; H=$(mktemp -d -t tomei-e2e-gpg-XXXXXX); trap 'rm -rf -- \"$H\"' EXIT; gpg --homedir \"$H\" --no-options --batch --no-default-keyring --keyring " + pgdgKeyringPath + " --with-colons --list-keys 2>&1")
 					Expect(err).NotTo(HaveOccurred(),

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.0
 require (
 	cuelang.org/go v0.16.1
 	github.com/Masterminds/semver/v3 v3.5.0
+	github.com/ProtonMail/go-crypto v1.1.6
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/fatih/color v1.19.0
@@ -32,7 +33,6 @@ require (
 	cuelabs.dev/go/oci/ociregistry v0.0.0-20251212221603-3adeb8663819 // indirect
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/ProtonMail/go-crypto v1.1.6 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect

--- a/internal/installer/apt/repository.go
+++ b/internal/installer/apt/repository.go
@@ -315,16 +315,37 @@ func decodeAllArmorBlocks(data []byte, w io.Writer) (int64, error) {
 			return total, fmt.Errorf("copy decoded key: %w", copyErr)
 		}
 		// Advance past this block's END line so the next iteration can find any
-		// subsequent concatenated block. The base64 alphabet has no '-', so the
-		// END marker cannot occur inside a block body.
+		// subsequent concatenated block. Anchor the match to a line start: the
+		// END marker is, per the armor grammar, a whole line, and a marker-like
+		// substring could otherwise appear inside an armor header value (e.g.
+		// `Comment: ...-----END PGP PUBLIC KEY BLOCK-----...`) and mis-advance.
 		endMarker := []byte("-----END " + block.Type + "-----")
-		idx := bytes.Index(rest, endMarker)
+		idx := indexAtLineStart(rest, endMarker)
 		if idx < 0 {
 			// A successful Decode implies a terminated block; defensive.
 			return total, nil
 		}
 		rest = rest[idx+len(endMarker):]
 	}
+}
+
+// indexAtLineStart returns the offset of the first occurrence of marker that
+// begins a line (at offset 0 or immediately after '\n' or '\r'), or -1 if none.
+// Anchoring to a line start prevents a marker-like substring inside an armor
+// header value from being mistaken for the block's terminating END line.
+func indexAtLineStart(data, marker []byte) int {
+	for off := 0; off <= len(data)-len(marker); {
+		i := bytes.Index(data[off:], marker)
+		if i < 0 {
+			return -1
+		}
+		abs := off + i
+		if abs == 0 || data[abs-1] == '\n' || data[abs-1] == '\r' {
+			return abs
+		}
+		off = abs + 1
+	}
+	return -1
 }
 
 // buildSourcesListLine renders a single APT one-line sources.list entry

--- a/internal/installer/apt/repository.go
+++ b/internal/installer/apt/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"maps"
 	"os"
@@ -15,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
 	"github.com/terassyi/tomei/internal/installer/command"
 	"github.com/terassyi/tomei/internal/installer/download"
 	"github.com/terassyi/tomei/internal/installer/executor"
@@ -62,12 +64,11 @@ var repoNameRE = regexp.MustCompile(`^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$`)
 var failedToFetchRE = regexp.MustCompile(`(?m)^W: Failed to fetch (\S+)`)
 
 // defaultRepoInstallTimeout caps the cumulative cost of an Install's
-// post-validation work (key download + verify + dearmor + sudo install
-// of the keyring and sources.list + apt-get update). Surfaced as a var
+// post-validation work (key download + verify + in-process dearmor + sudo
+// install of the keyring and sources.list + apt-get update). Surfaced as a var
 // (not const) so tests and a future cross-installer timeout knob can
-// override it. 10 minutes is roomy enough for slow dearmor on
-// constrained hardware plus a worst-case apt-get update against a
-// healthy-but-distant mirror, while still bounding a hang against a
+// override it. 10 minutes is roomy enough for a worst-case apt-get update
+// against a healthy-but-distant mirror, while still bounding a hang against a
 // dead mirror.
 var defaultRepoInstallTimeout = 10 * time.Minute
 
@@ -137,10 +138,11 @@ func (s destinationSnapshot) dataFor(path string) []byte {
 // executor.Installer[*resource.SystemPackageRepository, *resource.SystemPackageRepositoryState]
 // and is obtained from Client.PackageRepositoryInstaller.
 //
-// Host requirements: Linux, GNU coreutils `install`, passwordless `sudo -n`,
-// and `gpg` (gnupg) in PATH. See Install for the full caller contract,
-// trust model, and concurrency notes; the struct itself is just a handle
-// that bundles the runner with a download.Downloader for the key fetch.
+// Host requirements: Linux, GNU coreutils `install`, and passwordless
+// `sudo -n`. The signing key is dearmored in-process (no gnupg dependency,
+// #283). See Install for the full caller contract, trust model, and
+// concurrency notes; the struct itself is just a handle that bundles the
+// runner with a download.Downloader for the key fetch.
 type PackageRepositoryInstaller struct {
 	client     *Client
 	downloader download.Downloader
@@ -226,6 +228,49 @@ func sourcesListPath(name string) string {
 	return filepath.Join(sourcesListDir, name+".list")
 }
 
+// dearmorKey reads an ASCII-armored OpenPGP key from armoredPath, decodes it to
+// raw binary OpenPGP packets, and writes the result to dstPath (0600; the later
+// `sudo install` re-chmods to 0644). It returns the number of bytes written.
+//
+// This is the in-process equivalent of `gpg --dearmor` for the single-key
+// apt-signing contract, and is what lets tomei configure third-party
+// repositories on minimal images without gnupg in PATH (#283). armor.Decode
+// reads only the FIRST armor block (gpg --dearmor concatenates all blocks),
+// which suffices for the single-key contract. ProtonMail/go-crypto does NOT
+// validate the armor CRC24 checksum — integrity is guaranteed upstream by
+// keyHash (sha256 of the armored bytes, verified before this call) and by
+// apt's own Release-signature check at update time.
+func dearmorKey(armoredPath, dstPath string) (int64, error) {
+	in, err := os.Open(armoredPath)
+	if err != nil {
+		return 0, fmt.Errorf("open armored key: %w", err)
+	}
+	defer in.Close()
+
+	// A non-armored input yields io.EOF here ("no armored data found").
+	block, err := armor.Decode(in)
+	if err != nil {
+		return 0, fmt.Errorf("decode armor: %w", err)
+	}
+
+	out, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return 0, fmt.Errorf("create keyring: %w", err)
+	}
+	// base64 / structural corruption surfaces while reading block.Body, NOT at
+	// armor.Decode — checking copyErr is load-bearing: dropping it would write a
+	// truncated/corrupt keyring and let apt fail opaquely later.
+	n, copyErr := io.Copy(out, block.Body)
+	closeErr := out.Close()
+	if copyErr != nil {
+		return n, fmt.Errorf("copy decoded key: %w", copyErr)
+	}
+	if closeErr != nil {
+		return n, fmt.Errorf("close keyring: %w", closeErr)
+	}
+	return n, nil
+}
+
 // buildSourcesListLine renders a single APT one-line sources.list entry
 // for the given repository. The returned string includes a trailing
 // newline so it can be written verbatim into /etc/apt/sources.list.d/.
@@ -297,25 +342,22 @@ func buildSourcesListLine(name string, src *resource.AptSource) (string, error) 
 // via spec.Validate() called at the top of this function, and
 // download.Downloader's own validateDownloadURL all enforce the same
 // rule, with a localhost http:// escape hatch for integration tests),
-// verify its SHA256 against spec.Apt.KeyHash, convert to the binary
-// keyring format with `gpg --dearmor`, place it under
-// /usr/share/keyrings/, write a one-line sources.list entry under
-// /etc/apt/sources.list.d/, and refresh the APT index.
+// verify its SHA256 against spec.Apt.KeyHash, decode the ASCII-armored
+// key to binary OpenPGP packet form in-process (no gnupg dependency,
+// #283), place it under /usr/share/keyrings/, write a one-line
+// sources.list entry under /etc/apt/sources.list.d/, and refresh the APT index.
 //
-// Shell commands executed (the first three via ExecuteCapture; the
+// Shell commands executed (the first two via ExecuteCapture; the
 // apt-get update step via ExecuteWithOutput with a per-line callback
 // that scans both stdout and stderr for partial-fetch warnings):
 //
-//   - gpg --no-default-keyring --no-options --homedir '<tmp>' --batch --yes --output '<tmp>/<name>.gpg' --dearmor '<tmp>/<name>.armored'
 //   - sudo -n install -D -m 0644 -o root -g root -- '<tmp>/<name>.gpg' '/usr/share/keyrings/<name>.gpg'
 //   - sudo -n install -D -m 0644 -o root -g root -- '<tmp>/<name>.list' '/etc/apt/sources.list.d/<name>.list'
 //   - sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get update
 //
 // The `-D` flag on `install` ensures the destination directory exists
 // (Ubuntu 20.04 minimal images may ship without /usr/share/keyrings/).
-// The dearmor step uses an ephemeral `--homedir` so user-level
-// `~/.gnupg/gpg.conf` cannot redirect logs or output; `LC_ALL=C
-// LANGUAGE=C` on apt-get update ensures the `W: Failed to fetch`
+// `LC_ALL=C LANGUAGE=C` on apt-get update ensures the `W: Failed to fetch`
 // partial-fetch detector matches against the canonical English warning
 // regardless of the host's locale. The update step's stdout and stderr
 // are read concurrently (no shell `2>&1` redirection) and only the
@@ -333,7 +375,7 @@ func buildSourcesListLine(name string, src *resource.AptSource) (string, error) 
 //     options / URL / suite / components / disallowed Options key).
 //     Callers wanting the name in a uniform position should use
 //     errors.Is / errors.As on sentinel errors rather than the prefix.
-//   - download / verify / dearmor failure: (nil, wrapped error). No
+//   - download / verify / decode failure: (nil, wrapped error). No
 //     files placed.
 //   - sudo install failure for the keyring: (nil, wrapped error). No
 //     files placed.
@@ -404,7 +446,7 @@ func (p *PackageRepositoryInstaller) Install(ctx context.Context, res *resource.
 	// Cap the cumulative cost of the post-validation steps so a slow or
 	// dead mirror (DNS hang, half-routed CDN) cannot block tomei apply
 	// indefinitely. ctx.WithTimeout ensures the spawned subprocesses
-	// (gpg / sudo install / apt-get update) receive SIGTERM via
+	// (sudo install / apt-get update) receive SIGTERM via
 	// command.Executor's CommandContext path on deadline expiry, which
 	// is the only way to release the dpkg-frontend lock cleanly;
 	// wall-clock kill would leave orphan apt holding the lock.
@@ -446,23 +488,18 @@ func (p *PackageRepositoryInstaller) Install(ctx context.Context, res *resource.
 		return nil, fmt.Errorf("apt: repository %q: verify key: %w", name, err)
 	}
 
+	// Decode the armored key to binary keyring form in-process (no gnupg
+	// dependency, #283). keyHash was already verified above, so the armored
+	// bytes are trusted at this point.
 	dearmoredPath := filepath.Join(tmpDir, name+".gpg")
-	dearmorCmd := fmt.Sprintf(
-		"gpg --no-default-keyring --no-options --homedir %s --batch --yes --output %s --dearmor %s",
-		shellQuote(tmpDir), shellQuote(dearmoredPath), shellQuote(armoredPath))
-	if _, err := p.client.runner.ExecuteCapture(ctx, []string{dearmorCmd}, command.Vars{}, nil); err != nil {
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return nil, fmt.Errorf("apt: repository %q: dearmor key: %w", name, ctxErr)
-		}
+	n, err := dearmorKey(armoredPath, dearmoredPath)
+	if err != nil {
 		return nil, fmt.Errorf("apt: repository %q: dearmor key: %w", name, err)
 	}
-	// Defense-in-depth: gpg returning success while producing a 0-byte
-	// keyring would otherwise sail through to apt-get update which would
-	// then fail opaquely with "the repository is not signed". The lenient
-	// err==nil guard avoids a hard failure when the test mock runner
-	// hasn't written a file (the integration test exercises the strict
-	// path against a real gpg binary).
-	if info, statErr := os.Stat(dearmoredPath); statErr == nil && info.Size() == 0 {
+	// Defense-in-depth: a well-formed but empty armor envelope decodes to a
+	// 0-byte keyring, which would otherwise sail through to apt-get update and
+	// fail opaquely with "the repository is not signed".
+	if n == 0 {
 		return nil, fmt.Errorf("apt: repository %q: dearmor produced empty keyring", name)
 	}
 

--- a/internal/installer/apt/repository.go
+++ b/internal/installer/apt/repository.go
@@ -297,10 +297,10 @@ func decodeAllArmorBlocks(data []byte, w io.Writer) (int64, error) {
 		block, err := armor.Decode(bytes.NewReader(rest))
 		if errors.Is(err, io.EOF) {
 			// No (further) armor block. If we never found one, the input is
-			// not armored — surface that as a hard error; otherwise we are
-			// simply past the last block.
+			// not armored — surface that as a clear hard error; otherwise we
+			// are simply past the last block.
 			if blocks == 0 {
-				return total, fmt.Errorf("decode armor: %w", err)
+				return total, fmt.Errorf("no ASCII-armored OpenPGP block found in key")
 			}
 			return total, nil
 		}

--- a/internal/installer/apt/repository.go
+++ b/internal/installer/apt/repository.go
@@ -229,6 +229,12 @@ func sourcesListPath(name string) string {
 	return filepath.Join(sourcesListDir, name+".list")
 }
 
+// maxArmoredKeyBytes bounds how much of a downloaded key file dearmorKey reads
+// into memory. Real apt signing keys are a few kilobytes (tens of KB even when a
+// file concatenates several rotated keys); 4 MiB is a generous defense-in-depth
+// ceiling against a misconfigured KeyURL, not a functional limit.
+const maxArmoredKeyBytes = 4 << 20
+
 // dearmorKey reads an ASCII-armored OpenPGP key from armoredPath, decodes it to
 // raw binary OpenPGP packets, and writes the result to dstPath (0600; the later
 // `sudo install` re-chmods to 0644). It returns the number of bytes written.
@@ -243,13 +249,26 @@ func sourcesListPath(name string) string {
 // keyHash (sha256 of the armored bytes, verified before this call) and by
 // apt's own Release-signature check at update time.
 //
-// The whole (hash-pinned, small) file is read into memory: armor.Decode wraps
-// its input in a throwaway bufio that swallows read-ahead, so it cannot be
-// called repeatedly on one stream without losing bytes between blocks.
+// The whole file is read into memory (capped at maxArmoredKeyBytes): armor.Decode
+// wraps its input in a throwaway bufio that swallows read-ahead, so it cannot be
+// called repeatedly on one stream without losing bytes between blocks. The cap
+// keeps a misconfigured KeyURL pointing at a huge file from OOMing the process —
+// the download layer does not bound response size, and real apt signing keys are
+// kilobytes even when a file concatenates several rotated keys.
 func dearmorKey(armoredPath, dstPath string) (int64, error) {
-	data, err := os.ReadFile(armoredPath)
+	in, err := os.Open(armoredPath)
 	if err != nil {
 		return 0, fmt.Errorf("open armored key: %w", err)
+	}
+	defer in.Close()
+	// Read one byte past the cap so an over-limit file is detected rather than
+	// silently truncated mid-decode.
+	data, err := io.ReadAll(io.LimitReader(in, maxArmoredKeyBytes+1))
+	if err != nil {
+		return 0, fmt.Errorf("read armored key: %w", err)
+	}
+	if int64(len(data)) > maxArmoredKeyBytes {
+		return 0, fmt.Errorf("armored key exceeds %d bytes", int64(maxArmoredKeyBytes))
 	}
 
 	out, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)

--- a/internal/installer/apt/repository.go
+++ b/internal/installer/apt/repository.go
@@ -1,6 +1,7 @@
 package apt
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -232,43 +233,79 @@ func sourcesListPath(name string) string {
 // raw binary OpenPGP packets, and writes the result to dstPath (0600; the later
 // `sudo install` re-chmods to 0644). It returns the number of bytes written.
 //
-// This is the in-process equivalent of `gpg --dearmor` for the single-key
-// apt-signing contract, and is what lets tomei configure third-party
-// repositories on minimal images without gnupg in PATH (#283). armor.Decode
-// reads only the FIRST armor block (gpg --dearmor concatenates all blocks),
-// which suffices for the single-key contract. ProtonMail/go-crypto does NOT
+// This is the in-process equivalent of `gpg --dearmor`, and is what lets tomei
+// configure third-party repositories on minimal images without gnupg in PATH
+// (#283). Like `gpg --dearmor`, it decodes EVERY concatenated armor block and
+// appends their packets — a repo may publish multiple public keys in one key
+// file during key rotation, and apt must hold all of them to verify a Release
+// signed by either the old or the new key. ProtonMail/go-crypto does NOT
 // validate the armor CRC24 checksum — integrity is guaranteed upstream by
 // keyHash (sha256 of the armored bytes, verified before this call) and by
 // apt's own Release-signature check at update time.
+//
+// The whole (hash-pinned, small) file is read into memory: armor.Decode wraps
+// its input in a throwaway bufio that swallows read-ahead, so it cannot be
+// called repeatedly on one stream without losing bytes between blocks.
 func dearmorKey(armoredPath, dstPath string) (int64, error) {
-	in, err := os.Open(armoredPath)
+	data, err := os.ReadFile(armoredPath)
 	if err != nil {
 		return 0, fmt.Errorf("open armored key: %w", err)
-	}
-	defer in.Close()
-
-	// A non-armored input yields io.EOF here ("no armored data found").
-	block, err := armor.Decode(in)
-	if err != nil {
-		return 0, fmt.Errorf("decode armor: %w", err)
 	}
 
 	out, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return 0, fmt.Errorf("create keyring: %w", err)
 	}
-	// base64 / structural corruption surfaces while reading block.Body, NOT at
-	// armor.Decode — checking copyErr is load-bearing: dropping it would write a
-	// truncated/corrupt keyring and let apt fail opaquely later.
-	n, copyErr := io.Copy(out, block.Body)
+	n, decodeErr := decodeAllArmorBlocks(data, out)
 	closeErr := out.Close()
-	if copyErr != nil {
-		return n, fmt.Errorf("copy decoded key: %w", copyErr)
+	if decodeErr != nil {
+		return n, decodeErr
 	}
 	if closeErr != nil {
 		return n, fmt.Errorf("close keyring: %w", closeErr)
 	}
 	return n, nil
+}
+
+// decodeAllArmorBlocks decodes every concatenated ASCII-armor block in data and
+// writes each block's raw binary OpenPGP packets to w, returning the total bytes
+// written. It errors if data contains no armor block at all (not armored input).
+func decodeAllArmorBlocks(data []byte, w io.Writer) (int64, error) {
+	var total int64
+	rest := data
+	for blocks := 0; ; blocks++ {
+		block, err := armor.Decode(bytes.NewReader(rest))
+		if errors.Is(err, io.EOF) {
+			// No (further) armor block. If we never found one, the input is
+			// not armored — surface that as a hard error; otherwise we are
+			// simply past the last block.
+			if blocks == 0 {
+				return total, fmt.Errorf("decode armor: %w", err)
+			}
+			return total, nil
+		}
+		if err != nil {
+			return total, fmt.Errorf("decode armor: %w", err)
+		}
+		// base64 / structural corruption surfaces while reading block.Body, NOT
+		// at armor.Decode — checking copyErr is load-bearing: dropping it would
+		// write a truncated/corrupt keyring and let apt fail opaquely later.
+		n, copyErr := io.Copy(w, block.Body)
+		total += n
+		if copyErr != nil {
+			return total, fmt.Errorf("copy decoded key: %w", copyErr)
+		}
+		// Advance past this block's END line so the next iteration can find any
+		// subsequent concatenated block. The base64 alphabet has no '-', so the
+		// END marker cannot occur inside a block body.
+		endMarker := []byte("-----END " + block.Type + "-----")
+		idx := bytes.Index(rest, endMarker)
+		if idx < 0 {
+			// A successful Decode implies a terminated block; defensive.
+			return total, nil
+		}
+		rest = rest[idx+len(endMarker):]
+	}
 }
 
 // buildSourcesListLine renders a single APT one-line sources.list entry

--- a/internal/installer/apt/repository.go
+++ b/internal/installer/apt/repository.go
@@ -139,7 +139,8 @@ func (s destinationSnapshot) dataFor(path string) []byte {
 // executor.Installer[*resource.SystemPackageRepository, *resource.SystemPackageRepositoryState]
 // and is obtained from Client.PackageRepositoryInstaller.
 //
-// Host requirements: Linux, GNU coreutils `install`, and passwordless
+// Host requirements: Linux, `apt-get` (for `apt-get update`), GNU coreutils
+// `install` and `rm` (the latter for the rollback path), and passwordless
 // `sudo -n`. The signing key is dearmored in-process (no gnupg dependency,
 // #283). See Install for the full caller contract, trust model, and
 // concurrency notes; the struct itself is just a handle that bundles the

--- a/internal/installer/apt/repository_test.go
+++ b/internal/installer/apt/repository_test.go
@@ -418,6 +418,27 @@ func TestDearmorKey(t *testing.T) {
 		assert.Contains(t, err.Error(), "open armored key")
 	})
 
+	t.Run("a marker inside an armor header does not truncate the scan", func(t *testing.T) {
+		t.Parallel()
+		// Inject an armor header whose value contains the END-marker substring
+		// (mid-line), then concatenate a second real block. Both blocks must
+		// still decode — the line-anchored scan must ignore the in-header text.
+		single := armoredKeyFixture(t)
+		beginLine := []byte("-----BEGIN PGP PUBLIC KEY BLOCK-----\n")
+		require.True(t, bytes.HasPrefix(single, beginLine), "fixture must start with the BEGIN line")
+		poisoned := bytes.Replace(single, beginLine,
+			append(append([]byte{}, beginLine...), []byte("Comment: x-----END PGP PUBLIC KEY BLOCK-----x\n")...), 1)
+		twoBlocks := append(append([]byte{}, poisoned...), single...)
+
+		dstOne := filepath.Join(t.TempDir(), "one.gpg")
+		n1, err := dearmorKey(write(t, single), dstOne)
+		require.NoError(t, err)
+		dst := filepath.Join(t.TempDir(), "two.gpg")
+		n, err := dearmorKey(write(t, twoBlocks), dst)
+		require.NoError(t, err)
+		assert.Equal(t, 2*n1, n, "both blocks must decode despite the marker-like header value")
+	})
+
 	t.Run("oversized input is rejected before decode", func(t *testing.T) {
 		t.Parallel()
 		// A misconfigured KeyURL serving a huge file must fail fast rather than
@@ -427,6 +448,33 @@ func TestDearmorKey(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "exceeds")
 	})
+}
+
+func TestIndexAtLineStart(t *testing.T) {
+	t.Parallel()
+	marker := []byte("-----END PGP PUBLIC KEY BLOCK-----")
+	tests := []struct {
+		name string
+		data string
+		want int
+	}{
+		{name: "at offset zero", data: "-----END PGP PUBLIC KEY BLOCK-----\n", want: 0},
+		{name: "after newline", data: "abc\n-----END PGP PUBLIC KEY BLOCK-----\n", want: 4},
+		{name: "after carriage return", data: "abc\r-----END PGP PUBLIC KEY BLOCK-----", want: 4},
+		{name: "mid-line occurrence is ignored", data: "Comment: x-----END PGP PUBLIC KEY BLOCK-----x\n", want: -1},
+		{
+			name: "skips mid-line, finds line-start",
+			data: "Comment: x-----END PGP PUBLIC KEY BLOCK-----\n-----END PGP PUBLIC KEY BLOCK-----",
+			want: 45,
+		},
+		{name: "absent", data: "no marker here", want: -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, indexAtLineStart([]byte(tt.data), marker))
+		})
+	}
 }
 
 // --- Install: error paths ---

--- a/internal/installer/apt/repository_test.go
+++ b/internal/installer/apt/repository_test.go
@@ -383,7 +383,7 @@ func TestDearmorKey(t *testing.T) {
 		dst := filepath.Join(t.TempDir(), "out.gpg")
 		_, err := dearmorKey(src, dst)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "decode armor")
+		assert.Contains(t, err.Error(), "no ASCII-armored OpenPGP block found")
 	})
 
 	t.Run("well-formed but empty armor yields zero bytes", func(t *testing.T) {

--- a/internal/installer/apt/repository_test.go
+++ b/internal/installer/apt/repository_test.go
@@ -71,6 +71,17 @@ func dockerSpec(name string) *resource.SystemPackageRepository {
 	}
 }
 
+// armoredKeyFixture returns a real single-block ASCII-armored OpenPGP public
+// key. Install now dearmors in-process (#283), so tests that proceed past the
+// dearmor step must feed valid armored bytes (mockDownloader writes downloadBody
+// verbatim to the temp path that dearmorKey then decodes).
+func armoredKeyFixture(t *testing.T) []byte {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("testdata", "tomei-integration-test.asc"))
+	require.NoError(t, err)
+	return b
+}
+
 // --- buildSourcesListLine ---
 
 func TestBuildSourcesListLine(t *testing.T) {
@@ -276,7 +287,7 @@ func TestMain(m *testing.M) {
 func TestPackageRepositoryInstaller_Install_Success(t *testing.T) {
 	t.Parallel()
 	runner := &mockCommandRunner{}
-	dl := &mockDownloader{downloadBody: []byte("armored key body")}
+	dl := &mockDownloader{downloadBody: armoredKeyFixture(t)}
 
 	state, err := New(runner).PackageRepositoryInstaller(dl).Install(context.Background(), dockerSpec("docker"), "docker")
 	require.NoError(t, err)
@@ -287,29 +298,22 @@ func TestPackageRepositoryInstaller_Install_Success(t *testing.T) {
 	assert.Equal(t, "https://download.docker.com/linux/ubuntu/gpg", dl.downloadURLs[0])
 	require.Len(t, dl.verifyPaths, 1)
 
-	// Shell call sequence: 4 calls (dearmor, install keyring, install
-	// sources, apt-get update). Each call has exactly one cmd string.
-	require.Len(t, runner.captureCallCmds, 4)
+	// Shell call sequence: 3 calls (install keyring, install sources, apt-get
+	// update). The dearmor step is now in-process (#283), not a shell command.
+	// Each call has exactly one cmd string.
+	require.Len(t, runner.captureCallCmds, 3)
 	for i, cmds := range runner.captureCallCmds {
 		require.Len(t, cmds, 1, "call %d", i)
 	}
 
 	// Sub-string anchors on each cmd (full strings vary by tmpDir path).
-	// Dearmor invocation uses --no-options + ephemeral --homedir to
-	// neutralize any user ~/.gnupg/gpg.conf side-effects, and explicit
-	// --output to avoid relying on shell redirection.
-	assert.Contains(t, runner.captureCallCmds[0][0], "gpg ")
-	assert.Contains(t, runner.captureCallCmds[0][0], "--no-default-keyring")
-	assert.Contains(t, runner.captureCallCmds[0][0], "--no-options")
-	assert.Contains(t, runner.captureCallCmds[0][0], "--homedir")
-	assert.Contains(t, runner.captureCallCmds[0][0], "--dearmor")
+	assert.Contains(t, runner.captureCallCmds[0][0], "sudo -n install -D -m 0644 -o root -g root --")
+	assert.Contains(t, runner.captureCallCmds[0][0], keyringPath("docker"))
 	assert.Contains(t, runner.captureCallCmds[1][0], "sudo -n install -D -m 0644 -o root -g root --")
-	assert.Contains(t, runner.captureCallCmds[1][0], keyringPath("docker"))
-	assert.Contains(t, runner.captureCallCmds[2][0], "sudo -n install -D -m 0644 -o root -g root --")
-	assert.Contains(t, runner.captureCallCmds[2][0], sourcesListPath("docker"))
+	assert.Contains(t, runner.captureCallCmds[1][0], sourcesListPath("docker"))
 	assert.Equal(t,
 		"sudo -n env DEBIAN_FRONTEND=noninteractive LC_ALL=C LANGUAGE=C apt-get update",
-		runner.captureCallCmds[3][0])
+		runner.captureCallCmds[2][0])
 
 	// State contract: keyring first, then sources.list.
 	assert.Equal(t, resource.InstallerRefApt, state.InstallerRef)
@@ -317,6 +321,75 @@ func TestPackageRepositoryInstaller_Install_Success(t *testing.T) {
 		keyringPath("docker"),
 		sourcesListPath("docker"),
 	}, state.InstalledFiles)
+}
+
+// TestDearmorKey pins the in-process dearmor (#283): it must decode a real
+// armored key to non-empty binary OpenPGP packets, and surface errors instead
+// of writing a partial/empty keyring.
+func TestDearmorKey(t *testing.T) {
+	t.Parallel()
+
+	write := func(t *testing.T, data []byte) string {
+		t.Helper()
+		p := filepath.Join(t.TempDir(), "in.asc")
+		require.NoError(t, os.WriteFile(p, data, 0o600))
+		return p
+	}
+
+	t.Run("decodes armored key to binary packets", func(t *testing.T) {
+		t.Parallel()
+		src := write(t, armoredKeyFixture(t))
+		dst := filepath.Join(t.TempDir(), "out.gpg")
+		n, err := dearmorKey(src, dst)
+		require.NoError(t, err)
+		assert.Positive(t, n)
+		out, err := os.ReadFile(dst)
+		require.NoError(t, err)
+		assert.Len(t, out, int(n))
+		// Binary OpenPGP packets, not the ASCII armor envelope.
+		assert.NotContains(t, string(out), "-----BEGIN PGP")
+	})
+
+	t.Run("non-armored input is a hard error", func(t *testing.T) {
+		t.Parallel()
+		src := write(t, []byte("this is not an armored key"))
+		dst := filepath.Join(t.TempDir(), "out.gpg")
+		_, err := dearmorKey(src, dst)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decode armor")
+	})
+
+	t.Run("well-formed but empty armor yields zero bytes", func(t *testing.T) {
+		t.Parallel()
+		// A structurally valid armor block with no packet body. dearmorKey
+		// returns n==0 (no error); the Install caller maps n==0 to the
+		// "dearmor produced empty keyring" guard.
+		empty := "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\n=twTO\n-----END PGP PUBLIC KEY BLOCK-----\n"
+		src := write(t, []byte(empty))
+		dst := filepath.Join(t.TempDir(), "out.gpg")
+		n, err := dearmorKey(src, dst)
+		require.NoError(t, err)
+		assert.Zero(t, n)
+	})
+
+	t.Run("corrupt base64 body errors at copy time", func(t *testing.T) {
+		t.Parallel()
+		// Valid armor header but garbage base64 in the body: armor.Decode
+		// succeeds, the failure surfaces while reading block.Body.
+		corrupt := "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\n!!!!notbase64!!!!\n-----END PGP PUBLIC KEY BLOCK-----\n"
+		src := write(t, []byte(corrupt))
+		dst := filepath.Join(t.TempDir(), "out.gpg")
+		_, err := dearmorKey(src, dst)
+		require.Error(t, err)
+	})
+
+	t.Run("missing source file errors", func(t *testing.T) {
+		t.Parallel()
+		dst := filepath.Join(t.TempDir(), "out.gpg")
+		_, err := dearmorKey(filepath.Join(t.TempDir(), "nope.asc"), dst)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "open armored key")
+	})
 }
 
 // --- Install: error paths ---
@@ -366,46 +439,70 @@ func TestPackageRepositoryInstaller_Install_VerifyFailure(t *testing.T) {
 
 func TestPackageRepositoryInstaller_Install_DearmorFailure(t *testing.T) {
 	t.Parallel()
-	runner := &mockCommandRunner{captureErrs: []error{errors.New("gpg failed")}}
-	dl := &mockDownloader{downloadBody: []byte("body")}
+	runner := &mockCommandRunner{}
+	// Non-armored bytes make the in-process armor.Decode fail (#283) before
+	// any shell command runs — no gnupg, no runner call.
+	dl := &mockDownloader{downloadBody: []byte("not an armored key")}
 	_, err := New(runner).PackageRepositoryInstaller(dl).Install(context.Background(), dockerSpec("docker"), "docker")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `apt: repository "docker": dearmor key`)
-	// Only dearmor was attempted (no keyring install yet).
-	require.Len(t, runner.captureCallCmds, 1)
+	// Decode fails before any host mutation: zero shell commands attempted.
+	assert.Empty(t, runner.captureCallCmds)
 }
 
 func TestPackageRepositoryInstaller_Install_KeyringInstallFailure_RollsBackKeyring(t *testing.T) {
 	t.Parallel()
-	// call 0 (dearmor) succeeds; call 1 (install keyring) fails; call 2
-	// must be the rollback `sudo rm -f --` of the keyring — `install`
-	// can leave a partially-created destination on error, so the rm is
-	// load-bearing for the "no host state regression on failure"
-	// contract.
-	runner := &mockCommandRunner{captureErrs: []error{nil, errors.New("sudo denied"), nil}}
-	dl := &mockDownloader{downloadBody: []byte("body")}
+	// call 0 (install keyring) fails; call 1 must be the rollback
+	// `sudo rm -f --` of the keyring — `install` can leave a
+	// partially-created destination on error, so the rm is load-bearing
+	// for the "no host state regression on failure" contract. (Dearmor is
+	// now in-process, #283, so it no longer occupies call 0.)
+	runner := &mockCommandRunner{captureErrs: []error{errors.New("sudo denied"), nil}}
+	dl := &mockDownloader{downloadBody: armoredKeyFixture(t)}
 	_, err := New(runner).PackageRepositoryInstaller(dl).Install(context.Background(), dockerSpec("docker"), "docker")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `apt: repository "docker": install keyring`)
-	require.Len(t, runner.captureCallCmds, 3)
-	assert.Contains(t, runner.captureCallCmds[2][0], "sudo -n rm -f --")
-	assert.Contains(t, runner.captureCallCmds[2][0], keyringPath("docker"))
+	require.Len(t, runner.captureCallCmds, 2)
+	assert.Contains(t, runner.captureCallCmds[1][0], "sudo -n rm -f --")
+	assert.Contains(t, runner.captureCallCmds[1][0], keyringPath("docker"))
 }
 
 func TestPackageRepositoryInstaller_Install_SourcesInstallFailure_RollsBackBoth(t *testing.T) {
 	t.Parallel()
-	// call 0 dearmor ok, call 1 install keyring ok, call 2 install sources
-	// fails. Rollback must remove BOTH sourcesDst (the install command may
-	// have partially placed it before failing) AND keyringDst, in that
-	// order (sources first so a brief window doesn't leave a sources.list
-	// pointing at a missing keyring). Calls 3 and 4 are the rm operations.
+	// call 0 install keyring ok, call 1 install sources fails. Rollback must
+	// remove BOTH sourcesDst (the install command may have partially placed it
+	// before failing) AND keyringDst, in that order (sources first so a brief
+	// window doesn't leave a sources.list pointing at a missing keyring). Calls
+	// 2 and 3 are the rm operations. (Dearmor is in-process now, #283.)
 	runner := &mockCommandRunner{
-		captureErrs: []error{nil, nil, errors.New("sudo denied"), nil, nil},
+		captureErrs: []error{nil, errors.New("sudo denied"), nil, nil},
 	}
-	dl := &mockDownloader{downloadBody: []byte("body")}
+	dl := &mockDownloader{downloadBody: armoredKeyFixture(t)}
 	_, err := New(runner).PackageRepositoryInstaller(dl).Install(context.Background(), dockerSpec("docker"), "docker")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `apt: repository "docker": install sources`)
+	require.Len(t, runner.captureCallCmds, 4)
+	assert.Contains(t, runner.captureCallCmds[2][0], "sudo -n rm -f --")
+	assert.Contains(t, runner.captureCallCmds[2][0], sourcesListPath("docker"))
+	assert.Contains(t, runner.captureCallCmds[3][0], "sudo -n rm -f --")
+	assert.Contains(t, runner.captureCallCmds[3][0], keyringPath("docker"))
+}
+
+func TestPackageRepositoryInstaller_Install_UpdateFailure_RollsBackBoth(t *testing.T) {
+	t.Parallel()
+	// install keyring ok, install sources ok, update fails hard (non-zero
+	// exit) → rollback both placed files. The follow-up update is
+	// intentionally skipped on hard failure because the cache is already in an
+	// indeterminate state and re-running won't help. (Dearmor is in-process
+	// now, #283, so it no longer occupies call 0.)
+	runner := &mockCommandRunner{
+		captureErrs: []error{nil, nil, errors.New("update broke")},
+	}
+	dl := &mockDownloader{downloadBody: armoredKeyFixture(t)}
+	_, err := New(runner).PackageRepositoryInstaller(dl).Install(context.Background(), dockerSpec("docker"), "docker")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `apt: repository "docker": update`)
+	// 3 (success path) + 2 rollback rm = 5 calls.
 	require.Len(t, runner.captureCallCmds, 5)
 	assert.Contains(t, runner.captureCallCmds[3][0], "sudo -n rm -f --")
 	assert.Contains(t, runner.captureCallCmds[3][0], sourcesListPath("docker"))
@@ -413,49 +510,30 @@ func TestPackageRepositoryInstaller_Install_SourcesInstallFailure_RollsBackBoth(
 	assert.Contains(t, runner.captureCallCmds[4][0], keyringPath("docker"))
 }
 
-func TestPackageRepositoryInstaller_Install_UpdateFailure_RollsBackBoth(t *testing.T) {
-	t.Parallel()
-	// dearmor ok, install keyring ok, install sources ok, update fails
-	// hard (non-zero exit) → rollback both placed files. The follow-up
-	// update is intentionally skipped on hard failure because the cache
-	// is already in an indeterminate state and re-running won't help.
-	runner := &mockCommandRunner{
-		captureErrs: []error{nil, nil, nil, errors.New("update broke")},
-	}
-	dl := &mockDownloader{downloadBody: []byte("body")}
-	_, err := New(runner).PackageRepositoryInstaller(dl).Install(context.Background(), dockerSpec("docker"), "docker")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), `apt: repository "docker": update`)
-	// 4 (success path) + 2 rollback rm = 6 calls.
-	require.Len(t, runner.captureCallCmds, 6)
-	assert.Contains(t, runner.captureCallCmds[4][0], "sudo -n rm -f --")
-	assert.Contains(t, runner.captureCallCmds[4][0], sourcesListPath("docker"))
-	assert.Contains(t, runner.captureCallCmds[5][0], "sudo -n rm -f --")
-	assert.Contains(t, runner.captureCallCmds[5][0], keyringPath("docker"))
-}
-
 func TestPackageRepositoryInstaller_Install_PartialFetchFailure_RollsBackBoth(t *testing.T) {
 	t.Parallel()
-	// All four success-path calls succeed; the apt-get update output
+	// All three success-path calls succeed; the apt-get update output
 	// contains a `W: Failed to fetch` line targeting the configured URL,
-	// triggering rollback even though exit code was zero.
+	// triggering rollback even though exit code was zero. (Dearmor is
+	// in-process now, #283, so update is call 2 not call 3.)
 	failedOutput := `Hit:1 https://archive.ubuntu.com/ubuntu jammy InRelease
 W: Failed to fetch https://download.docker.com/linux/ubuntu/dists/jammy/InRelease  404 Not Found
 Reading package lists... Done
 `
 	runner := &mockCommandRunner{
-		captureOutputs: []string{"", "", "", failedOutput},
+		captureOutputs: []string{"", "", failedOutput},
 	}
-	dl := &mockDownloader{downloadBody: []byte("body")}
+	dl := &mockDownloader{downloadBody: armoredKeyFixture(t)}
 	_, err := New(runner).PackageRepositoryInstaller(dl).Install(context.Background(), dockerSpec("docker"), "docker")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `apt: repository "docker": failed to fetch`)
 	assert.Contains(t, err.Error(), "https://download.docker.com/linux/ubuntu/dists/jammy/InRelease")
-	require.Len(t, runner.captureCallCmds, 7)
+	// 3 (success path) + 2 rollback rm + 1 follow-up update = 6 calls.
+	require.Len(t, runner.captureCallCmds, 6)
+	assert.Contains(t, runner.captureCallCmds[3][0], "sudo -n rm -f --")
+	assert.Contains(t, runner.captureCallCmds[3][0], sourcesListPath("docker"))
 	assert.Contains(t, runner.captureCallCmds[4][0], "sudo -n rm -f --")
-	assert.Contains(t, runner.captureCallCmds[4][0], sourcesListPath("docker"))
-	assert.Contains(t, runner.captureCallCmds[5][0], "sudo -n rm -f --")
-	assert.Contains(t, runner.captureCallCmds[5][0], keyringPath("docker"))
+	assert.Contains(t, runner.captureCallCmds[4][0], keyringPath("docker"))
 }
 
 func TestPackageRepositoryInstaller_Install_PartialFetchFailure_UnrelatedURLIgnored(t *testing.T) {
@@ -466,14 +544,14 @@ func TestPackageRepositoryInstaller_Install_PartialFetchFailure_UnrelatedURLIgno
 Reading package lists... Done
 `
 	runner := &mockCommandRunner{
-		captureOutputs: []string{"", "", "", output},
+		captureOutputs: []string{"", "", output},
 	}
-	dl := &mockDownloader{downloadBody: []byte("body")}
+	dl := &mockDownloader{downloadBody: armoredKeyFixture(t)}
 	state, err := New(runner).PackageRepositoryInstaller(dl).Install(context.Background(), dockerSpec("docker"), "docker")
 	require.NoError(t, err)
 	require.NotNil(t, state)
-	// Exactly the 4 success-path commands, no rollback.
-	require.Len(t, runner.captureCallCmds, 4)
+	// Exactly the 3 success-path commands, no rollback (dearmor is in-process, #283).
+	require.Len(t, runner.captureCallCmds, 3)
 }
 
 // TestFailedToFetchURLs_PrefixBoundary pins the path-boundary rule:
@@ -509,7 +587,6 @@ func TestPackageRepositoryInstaller_Install_UpdateFailure_RollbackRmAlsoFails_Do
 	t.Parallel()
 	runner := &mockCommandRunner{
 		captureErrs: []error{
-			nil,                        // dearmor
 			nil,                        // install keyring
 			nil,                        // install sources
 			errors.New("update broke"), // update fails
@@ -517,7 +594,7 @@ func TestPackageRepositoryInstaller_Install_UpdateFailure_RollbackRmAlsoFails_Do
 			errors.New("sudo denied"),  // rollback rm keyring fails
 		},
 	}
-	dl := &mockDownloader{downloadBody: []byte("body")}
+	dl := &mockDownloader{downloadBody: armoredKeyFixture(t)}
 	_, err := New(runner).PackageRepositoryInstaller(dl).Install(context.Background(), dockerSpec("docker"), "docker")
 	require.Error(t, err)
 	// The original update failure remains the surfaced cause.
@@ -732,20 +809,20 @@ func TestPackageRepositoryInstaller_Install_PartialFetchFailure_RestoresPreexist
 
 	failedOutput := `W: Failed to fetch https://download.docker.com/linux/ubuntu/dists/jammy/InRelease  404 Not Found`
 	runner := &mockCommandRunner{
-		captureOutputs: []string{"", "", "", failedOutput},
+		captureOutputs: []string{"", "", failedOutput},
 	}
-	dl := &mockDownloader{downloadBody: []byte("body")}
+	dl := &mockDownloader{downloadBody: armoredKeyFixture(t)}
 	_, err := New(runner).PackageRepositoryInstaller(dl).Install(context.Background(), dockerSpec("docker"), "docker")
 	require.Error(t, err)
-	// Rollback path: calls 4 and 5 are the per-destination restores
-	// (sudo install -D back to root:root 0644 from a tmp file). Call 6
-	// is the follow-up apt-get update. Crucially, NO `rm -f` is issued
-	// because the destinations preexisted.
-	require.GreaterOrEqual(t, len(runner.captureCallCmds), 6)
+	// Rollback path (dearmor is in-process now, #283, so indices shift down by
+	// one): calls 3 and 4 are the per-destination restores (sudo install -D
+	// back to root:root 0644 from a tmp file). Call 5 is the follow-up apt-get
+	// update. Crucially, NO `rm -f` is issued because the destinations preexisted.
+	require.GreaterOrEqual(t, len(runner.captureCallCmds), 5)
+	assert.Contains(t, runner.captureCallCmds[3][0], "sudo -n install -D")
+	assert.Contains(t, runner.captureCallCmds[3][0], sourcesListPath("docker"))
 	assert.Contains(t, runner.captureCallCmds[4][0], "sudo -n install -D")
-	assert.Contains(t, runner.captureCallCmds[4][0], sourcesListPath("docker"))
-	assert.Contains(t, runner.captureCallCmds[5][0], "sudo -n install -D")
-	assert.Contains(t, runner.captureCallCmds[5][0], keyringPath("docker"))
+	assert.Contains(t, runner.captureCallCmds[4][0], keyringPath("docker"))
 	for _, cmds := range runner.captureCallCmds {
 		assert.NotContains(t, cmds[0], "sudo -n rm -f --",
 			"rollback must restore preexisting files, never rm them")

--- a/internal/installer/apt/repository_test.go
+++ b/internal/installer/apt/repository_test.go
@@ -350,6 +350,32 @@ func TestDearmorKey(t *testing.T) {
 		assert.NotContains(t, string(out), "-----BEGIN PGP")
 	})
 
+	t.Run("decodes all concatenated armor blocks", func(t *testing.T) {
+		t.Parallel()
+		// gpg --dearmor concatenates the packets of every armor block; a key
+		// file with two concatenated blocks (e.g. during key rotation) must
+		// decode to both keys, not just the first.
+		single := armoredKeyFixture(t)
+		two := append(append([]byte{}, single...), single...)
+
+		dstOne := filepath.Join(t.TempDir(), "one.gpg")
+		n1, err := dearmorKey(write(t, single), dstOne)
+		require.NoError(t, err)
+		require.Positive(t, n1)
+
+		dstTwo := filepath.Join(t.TempDir(), "two.gpg")
+		n2, err := dearmorKey(write(t, two), dstTwo)
+		require.NoError(t, err)
+
+		assert.Equal(t, 2*n1, n2, "two concatenated blocks must decode to double the bytes")
+		one, err := os.ReadFile(dstOne)
+		require.NoError(t, err)
+		got, err := os.ReadFile(dstTwo)
+		require.NoError(t, err)
+		assert.Equal(t, append(append([]byte{}, one...), one...), got,
+			"two-block output must equal the single block's packets repeated")
+	})
+
 	t.Run("non-armored input is a hard error", func(t *testing.T) {
 		t.Parallel()
 		src := write(t, []byte("this is not an armored key"))

--- a/internal/installer/apt/repository_test.go
+++ b/internal/installer/apt/repository_test.go
@@ -1,6 +1,7 @@
 package apt
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"os"
@@ -415,6 +416,16 @@ func TestDearmorKey(t *testing.T) {
 		_, err := dearmorKey(filepath.Join(t.TempDir(), "nope.asc"), dst)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "open armored key")
+	})
+
+	t.Run("oversized input is rejected before decode", func(t *testing.T) {
+		t.Parallel()
+		// A misconfigured KeyURL serving a huge file must fail fast rather than
+		// OOM the process (the download layer does not bound response size).
+		huge := bytes.Repeat([]byte("A"), maxArmoredKeyBytes+1)
+		_, err := dearmorKey(write(t, huge), filepath.Join(t.TempDir(), "out.gpg"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds")
 	})
 }
 

--- a/internal/installer/apt/testdata/README.md
+++ b/internal/installer/apt/testdata/README.md
@@ -4,11 +4,13 @@
 
 A throwaway ASCII-armored GPG public key used by
 `tests/apt_repository_integration_test.go` as the fixture key served from
-`httptest.NewServer`. The matching private key is intentionally discarded;
-this file is only ever consumed as a public key payload for
-`gpg --dearmor` and `apt-get update` signature lookup — the integration
-test does not rely on signature verification succeeding (it exercises the
-rollback path when `apt-get update` cannot fetch a real `InRelease`).
+`httptest.NewServer`. It is also read directly by the `internal/installer/apt`
+unit tests to exercise the in-process dearmor (#283). The matching private key
+is intentionally discarded; this file is only ever consumed as a public key
+payload for the in-process armor decode (`dearmorKey` in repository.go) and
+`apt-get update` signature lookup — the integration test does not rely on
+signature verification succeeding (it exercises the rollback path when
+`apt-get update` cannot fetch a real `InRelease`).
 
 ### Regeneration
 
@@ -43,6 +45,9 @@ After regenerating, update the `keyHashSHA256` constant in
 
 ### Why a real key (rather than random bytes)?
 
-`gpg --dearmor` rejects input that is not a valid ASCII-armored OpenPGP
-packet stream. The integration test exercises the real `gpg --dearmor`
-subprocess, so the fixture must be a real (if throwaway) public key.
+The in-process armor decoder (`armor.Decode`, used by `dearmorKey` in
+repository.go) rejects input that is not a valid ASCII-armored OpenPGP packet
+stream, and the e2e keyring-validation oracle (`gpg --list-keys`) requires a
+parseable public key. Both the unit tests and the integration test feed this
+fixture through the real decode path, so it must be a real (if throwaway)
+public key.

--- a/tests/apt_repository_integration_test.go
+++ b/tests/apt_repository_integration_test.go
@@ -32,7 +32,7 @@ const keyHashSHA256 = "sha256:c136badca3a932d7d4ae3a48068370d203ae3fb876dec76fa8
 
 // TestPackageRepositoryInstaller_RealSystem_RollbackOnUpdateFailure
 // exercises Install end-to-end against the real local filesystem, real
-// sudo, real gpg --dearmor, and real apt-get update — but with a
+// sudo, in-process dearmor (#283), and real apt-get update — but with a
 // localhost httptest server standing in for the third-party APT
 // repository. The server returns the test fixture key for /key.asc and
 // 404 for every other path, so apt-get update emits
@@ -46,8 +46,8 @@ const keyHashSHA256 = "sha256:c136badca3a932d7d4ae3a48068370d203ae3fb876dec76fa8
 //   - download.NewDownloader actually fetches the armored key over
 //     HTTP from the httptest server (the validator allows
 //     http://127.0.0.1 / localhost for tests).
-//   - The committed fixture key dearmors successfully through the real
-//     /usr/bin/gpg binary.
+//   - The committed fixture key dearmors successfully through the
+//     in-process armor decoder (no gnupg dependency, #283).
 //   - `sudo -n install -D -m 0644 -o root -g root --` actually creates
 //     /usr/share/keyrings/<name>.gpg and /etc/apt/sources.list.d/<name>.list
 //     as root:root with 0644 permissions.
@@ -62,8 +62,8 @@ const keyHashSHA256 = "sha256:c136badca3a932d7d4ae3a48068370d203ae3fb876dec76fa8
 // APT repository). Successful Install / Remove ordering is covered by
 // the unit tests in internal/installer/apt/repository_test.go.
 //
-// Requires Linux + gpg + apt-get + sudo + passwordless sudo. Skips on
-// any other configuration.
+// Requires Linux + apt-get + sudo + passwordless sudo. No longer requires
+// gpg (dearmor is in-process now, #283). Skips on any other configuration.
 func TestPackageRepositoryInstaller_RealSystem_RollbackOnUpdateFailure(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("apt repository integration test requires Linux")
@@ -74,7 +74,7 @@ func TestPackageRepositoryInstaller_RealSystem_RollbackOnUpdateFailure(t *testin
 	// on any system that ships apt-get, but the explicit check makes a
 	// minimal/stripped image skip cleanly instead of failing with an
 	// unexpected error shape mid-run.
-	for _, bin := range []string{"apt-get", "dpkg", "sudo", "gpg", "install", "rm"} {
+	for _, bin := range []string{"apt-get", "dpkg", "sudo", "install", "rm"} {
 		if _, err := exec.LookPath(bin); err != nil {
 			t.Skipf("%s not found in PATH", bin)
 		}

--- a/tests/apt_repository_integration_test.go
+++ b/tests/apt_repository_integration_test.go
@@ -62,8 +62,9 @@ const keyHashSHA256 = "sha256:c136badca3a932d7d4ae3a48068370d203ae3fb876dec76fa8
 // APT repository). Successful Install / Remove ordering is covered by
 // the unit tests in internal/installer/apt/repository_test.go.
 //
-// Requires Linux + apt-get + sudo + passwordless sudo. No longer requires
-// gpg (dearmor is in-process now, #283). Skips on any other configuration.
+// Requires Linux + apt-get + dpkg + install + rm + sudo + passwordless sudo.
+// No longer requires gpg (dearmor is in-process now, #283). Skips on any
+// other configuration.
 func TestPackageRepositoryInstaller_RealSystem_RollbackOnUpdateFailure(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("apt repository integration test requires Linux")


### PR DESCRIPTION
The apt SystemPackageRepository backend shelled out to `gpg --dearmor` to
convert the armored signing key into binary keyring form. Because system
apply runs installers -> repos -> packages, gnupg could not be supplied by a
SystemPackageSet (packages phase), so configuring any third-party repository
failed on minimal images (e.g. ubuntu:26.04) where gnupg is absent — making
gnupg a mandatory out-of-band prerequisite.

Replace the exec with an in-process ASCII-armor decode via
github.com/ProtonMail/go-crypto/openpgp/armor. `--dearmor` is a pure format
transform (armor -> binary OpenPGP packets) with no signature, keyring, or
network work, so the in-process decode is equivalent. Integrity is unchanged:
keyHash (sha256 of the armored bytes) is verified before decode, and apt
checks the Release signature at update time. SrcBinaryName-style path safety
is not relevant here; the decoded bytes go to a 0600 temp file that the
existing `sudo install -m 0644` places unchanged.

This also removes the gpg PATH dependency and shell-injection surface for
this step. gnupg remains in the e2e runner image solely as the
keyring-validation test oracle (`gpg --list-keys`).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
