### PR TITLE
fix(plan): surface SystemPackage as its authored kind, not SystemPackageSet (#285)

### DIFF
--- a/cmd/tomei/plan.go
+++ b/cmd/tomei/plan.go
@@ -325,9 +325,10 @@ func buildResourceInfo(resources []resource.Resource, updCfg engine.UpdateConfig
 			if resource.IsSystemKind(res.Kind()) {
 				nodeID := graph.NewNodeID(res.Kind(), res.Name())
 				info[nodeID] = graph.ResourceInfo{
-					Kind:   res.Kind(),
-					Name:   res.Name(),
-					Action: resource.ActionSkip,
+					Kind:        res.Kind(),
+					DisplayKind: resource.DisplayKindOf(res), // surface authored SystemPackage (#285)
+					Name:        res.Name(),
+					Action:      resource.ActionSkip,
 				}
 			}
 		}
@@ -489,6 +490,10 @@ func resolvePlan(resources []resource.Resource, updateCfg engine.UpdateConfig, s
 	if err != nil {
 		return nil, err
 	}
+
+	// Surface each node's authored kind (e.g. sugar SystemPackage) in layer/JSON
+	// labels without touching the dispatch Kind or NodeID. Display-only (#285).
+	graph.SetNodeDisplayKinds(layers, engine.BuildResourceMap(engine.AppendBuiltinInstallers(resources)))
 
 	var filteredLayers []graph.Layer
 	for _, layer := range layers {
@@ -704,9 +709,10 @@ func markAllSystemAsInstall(info map[graph.NodeID]graph.ResourceInfo, resources 
 		if resource.IsSystemKind(res.Kind()) {
 			nodeID := graph.NewNodeID(res.Kind(), res.Name())
 			info[nodeID] = graph.ResourceInfo{
-				Kind:   res.Kind(),
-				Name:   res.Name(),
-				Action: resource.ActionInstall,
+				Kind:        res.Kind(),
+				DisplayKind: resource.DisplayKindOf(res), // surface authored SystemPackage (#285)
+				Name:        res.Name(),
+				Action:      resource.ActionInstall,
 			}
 		}
 	}
@@ -730,11 +736,17 @@ func convertActions[R resource.Resource, S resource.State](
 	actions []reconciler.Action[R, S],
 ) {
 	for _, action := range actions {
+		// NodeID/Kind stay on the dispatch kind; DisplayKind surfaces a sugar
+		// resource's authored kind (e.g. SystemPackage). action.Resource is the
+		// zero value for Remove, where DisplayKindOf falls back to the dispatch
+		// kind — so removals display as SystemPackageSet (state has no authored
+		// kind to recover). (#285)
 		nodeID := graph.NewNodeID(kind, action.Name)
 		info[nodeID] = graph.ResourceInfo{
-			Kind:   kind,
-			Name:   action.Name,
-			Action: action.Type,
+			Kind:        kind,
+			DisplayKind: resource.DisplayKindOf(action.Resource),
+			Name:        action.Name,
+			Action:      action.Type,
 		}
 	}
 }

--- a/cmd/tomei/validate.go
+++ b/cmd/tomei/validate.go
@@ -74,11 +74,14 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	cmd.Println("Resources:")
 	validationFailed := false
 	for _, res := range resources {
+		// Surface the authored kind (e.g. sugar SystemPackage) rather than the
+		// post-expansion dispatch kind (#285).
+		label := style.Path.Sprintf("%s/%s", resource.DisplayKindOf(res), res.Name())
 		if err := res.Spec().Validate(); err != nil {
-			cmd.Printf("  %s %s - %v\n", style.FailMark, style.Path.Sprintf("%s/%s", res.Kind(), res.Name()), err)
+			cmd.Printf("  %s %s - %v\n", style.FailMark, label, err)
 			validationFailed = true
 		} else {
-			cmd.Printf("  %s %s\n", style.SuccessMark, style.Path.Sprintf("%s/%s", res.Kind(), res.Name()))
+			cmd.Printf("  %s %s\n", style.SuccessMark, label)
 		}
 	}
 	cmd.Println()

--- a/e2e/system_package_test.go
+++ b/e2e/system_package_test.go
@@ -118,12 +118,12 @@ func systemPackageTests() {
 		out, err := testExec.Exec("tomei", "validate", cfgPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(out).To(ContainSubstring("SystemInstaller/apt"))
-		Expect(out).To(ContainSubstring("SystemPackageSet/tree"))
+		// #285: a resource authored `kind: SystemPackage` surfaces with its
+		// authored kind (SystemPackage/<name>), even though it is internally
+		// expanded to a single-element SystemPackageSet for dispatch. A
+		// directly-authored set still surfaces as SystemPackageSet.
+		Expect(out).To(ContainSubstring("SystemPackage/tree"))
 		Expect(out).To(ContainSubstring("SystemPackageSet/cli-tools"))
-		// Desugar contract: pre-expand SystemPackage names must not surface
-		// in user-visible output. ExpandSets rewrites SystemPackage into
-		// SystemPackageSet before any kind/name printing.
-		Expect(out).NotTo(ContainSubstring("SystemPackage/tree"))
 		Expect(out).To(ContainSubstring("Validation successful"))
 	})
 
@@ -132,7 +132,7 @@ func systemPackageTests() {
 		// regardless of installer wiring. Action label is not asserted.
 		out, err := testExec.Exec("tomei", "plan", cfgPath)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(out).To(ContainSubstring("SystemPackageSet/tree"))
+		Expect(out).To(ContainSubstring("SystemPackage/tree")) // authored kind surfaces (#285)
 		Expect(out).To(ContainSubstring("SystemPackageSet/cli-tools"))
 	})
 
@@ -144,7 +144,7 @@ func systemPackageTests() {
 		out, err := testExec.Exec("tomei", "plan", "--system", cfgPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(out).To(ContainSubstring("SystemInstaller/apt"))
-		Expect(out).To(ContainSubstring("SystemPackageSet/tree"))
+		Expect(out).To(ContainSubstring("SystemPackage/tree")) // authored kind surfaces (#285)
 		Expect(out).To(ContainSubstring("SystemPackageSet/cli-tools"))
 	})
 
@@ -1438,7 +1438,7 @@ EOF`, dir, repoBlock)
 				out, err := ExecApply(testExec, "--system", installCfgPath)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).To(ContainSubstring("SystemPackageSet/cli-tools"))
-				Expect(out).To(ContainSubstring("SystemPackageSet/tree"))
+				Expect(out).To(ContainSubstring("SystemPackage/tree")) // sugar surfaces authored kind (#285)
 				assertInstalled("cowsay")
 				assertInstalled("sl")
 				assertInstalled("tree")

--- a/internal/graph/dag.go
+++ b/internal/graph/dag.go
@@ -24,8 +24,35 @@ func (id NodeID) String() string {
 // Node represents a resource in the dependency graph.
 type Node struct {
 	ID   NodeID        // Kind/Name format (e.g., "Runtime/go", "Tool/ripgrep")
-	Kind resource.Kind // Resource kind
+	Kind resource.Kind // Dispatch kind (drives ID and execution dispatch)
 	Name string        // Resource name
+	// DisplayKind is the kind to SURFACE in user-facing output (plan tree/JSON,
+	// apply layer labels) when it differs from the dispatch Kind — e.g. a
+	// SystemPackage authored as sugar dispatches as SystemPackageSet but should
+	// display as SystemPackage. Empty means "use Kind". (#285)
+	DisplayKind resource.Kind
+}
+
+// DisplayKindOrKind returns DisplayKind when set, else the dispatch Kind.
+func (n Node) DisplayKindOrKind() resource.Kind {
+	if n.DisplayKind != "" {
+		return n.DisplayKind
+	}
+	return n.Kind
+}
+
+// SetNodeDisplayKinds populates each layer node's display-only DisplayKind from
+// its resource in resourceMap (keyed by NodeID string), so sugar resources like
+// SystemPackage surface their authored kind in labels without changing the
+// dispatch Kind/NodeID. Shared by the plan and apply paths. (#285)
+func SetNodeDisplayKinds(layers []Layer, resourceMap map[string]resource.Resource) {
+	for _, layer := range layers {
+		for _, node := range layer.Nodes {
+			if res, ok := resourceMap[node.ID.String()]; ok {
+				node.DisplayKind = resource.DisplayKindOf(res)
+			}
+		}
+	}
 }
 
 // Layer represents a group of nodes that can be executed in parallel.

--- a/internal/graph/export.go
+++ b/internal/graph/export.go
@@ -78,7 +78,10 @@ func (e *Exporter) BuildOutput() PlanOutput {
 		deps[edge.From] = append(deps[edge.From], string(edge.To))
 	}
 
-	// Build resources and layers
+	// Build resources and layers. emitted is keyed by the dispatch NodeID (not
+	// the surfaced Kind) so the skip-collection dedup below is unaffected by the
+	// display-kind surfacing for sugar resources. (#285)
+	emitted := make(map[NodeID]bool)
 	for i, layer := range e.layers {
 		planLayer := PlanLayer{
 			Index:     i + 1,
@@ -90,7 +93,7 @@ func (e *Exporter) BuildOutput() PlanOutput {
 			info := e.resourceInfo[nodeID]
 
 			planResource := PlanResource{
-				Kind:         node.Kind,
+				Kind:         node.DisplayKindOrKind(),
 				Name:         node.Name,
 				Version:      info.Version,
 				SHA:          info.SHA,
@@ -100,6 +103,7 @@ func (e *Exporter) BuildOutput() PlanOutput {
 			}
 			output.Resources = append(output.Resources, planResource)
 			planLayer.Resources = append(planLayer.Resources, string(nodeID))
+			emitted[nodeID] = true
 		}
 
 		output.Layers = append(output.Layers, planLayer)
@@ -107,15 +111,11 @@ func (e *Exporter) BuildOutput() PlanOutput {
 
 	// Collect ActionSkip resources that are not part of any layer.
 	// Build sorted slice first for deterministic JSON/YAML output.
-	emitted := make(map[NodeID]bool)
-	for _, res := range output.Resources {
-		emitted[NewNodeID(res.Kind, res.Name)] = true
-	}
 	var skipResources []PlanResource
 	for nodeID, info := range e.resourceInfo {
 		if info.Action == resource.ActionSkip && !emitted[nodeID] {
 			skipResources = append(skipResources, PlanResource{
-				Kind:    info.Kind,
+				Kind:    info.DisplayKindOrKind(),
 				Name:    info.Name,
 				Version: info.Version,
 				SHA:     info.SHA,

--- a/internal/graph/export_test.go
+++ b/internal/graph/export_test.go
@@ -8,6 +8,41 @@ import (
 	"github.com/terassyi/tomei/internal/resource"
 )
 
+// TestBuildOutput_DisplayKind pins #285: a sugar SystemPackage (dispatch kind
+// SystemPackageSet, DisplayKind SystemPackage) surfaces as SystemPackage in the
+// plan JSON .kind for both layer and skip entries, while the NodeID/dispatch
+// stay on SystemPackageSet. A directly-authored set (no DisplayKind) is unchanged.
+func TestBuildOutput_DisplayKind(t *testing.T) {
+	t.Parallel()
+
+	spsNode := NewNodeID(resource.KindSystemPackageSet, "gcloud")
+	setNode := NewNodeID(resource.KindSystemPackageSet, "dev")
+	skipNode := NewNodeID(resource.KindSystemPackageSet, "media")
+	layers := []Layer{
+		{Nodes: []*Node{
+			{ID: spsNode, Kind: resource.KindSystemPackageSet, Name: "gcloud", DisplayKind: resource.KindSystemPackage},
+			{ID: setNode, Kind: resource.KindSystemPackageSet, Name: "dev"}, // no DisplayKind -> stays a set
+		}},
+	}
+	resourceInfo := map[NodeID]ResourceInfo{
+		spsNode:  {Kind: resource.KindSystemPackageSet, DisplayKind: resource.KindSystemPackage, Name: "gcloud", Action: resource.ActionInstall},
+		setNode:  {Kind: resource.KindSystemPackageSet, Name: "dev", Action: resource.ActionInstall},
+		skipNode: {Kind: resource.KindSystemPackageSet, DisplayKind: resource.KindSystemPackage, Name: "media", Action: resource.ActionSkip},
+	}
+
+	output := NewExporter(layers, resourceInfo, nil).BuildOutput()
+
+	byName := make(map[string]PlanResource, len(output.Resources))
+	for _, r := range output.Resources {
+		byName[r.Name] = r
+	}
+	assert.Equal(t, resource.KindSystemPackage, byName["gcloud"].Kind, "sugar package surfaces SystemPackage in JSON")
+	assert.Equal(t, resource.KindSystemPackageSet, byName["dev"].Kind, "directly-authored set stays SystemPackageSet")
+	assert.Equal(t, resource.KindSystemPackage, byName["media"].Kind, "skipped sugar package surfaces SystemPackage")
+	// NodeID (dispatch identity) is unchanged — still SystemPackageSet/<name>.
+	assert.Contains(t, output.Layers[0].Resources, spsNode.String())
+}
+
 func TestBuildOutput_SkipResources(t *testing.T) {
 	t.Parallel()
 

--- a/internal/graph/tree.go
+++ b/internal/graph/tree.go
@@ -13,9 +13,13 @@ import (
 
 // ResourceInfo holds information about a resource for display.
 type ResourceInfo struct {
-	Kind    resource.Kind
-	Name    string
-	Version string
+	Kind resource.Kind
+	// DisplayKind is the surfaced kind when it differs from the dispatch Kind
+	// (e.g. a sugar SystemPackage). Empty means "use Kind". Used for plan
+	// JSON/skip/sort/removal rendering; the NodeID key still uses Kind. (#285)
+	DisplayKind resource.Kind
+	Name        string
+	Version     string
 	// SHA holds the git commit SHA for SHA-pinned tools. Mutually exclusive
 	// with Version (Validate enforces this on the spec side). Stored in full
 	// here; the tree renderer truncates for display.
@@ -26,6 +30,14 @@ type ResourceInfo struct {
 	// for change actions (e.g. plan-time minimumReleaseAge would-skip). It
 	// never affects Action or apply behavior. Empty = no annotation.
 	Note string
+}
+
+// DisplayKindOrKind returns DisplayKind when set, else the dispatch Kind.
+func (r ResourceInfo) DisplayKindOrKind() resource.Kind {
+	if r.DisplayKind != "" {
+		return r.DisplayKind
+	}
+	return r.Kind
 }
 
 // TreePrinter prints dependency graphs as ASCII trees with colors.
@@ -170,8 +182,12 @@ func shortSHA(sha string) string {
 func (p *TreePrinter) formatNode(nodeID NodeID, info ResourceInfo, hasInfo bool) string {
 	var sb strings.Builder
 
-	// Node name (Kind/Name)
+	// Node name (Kind/Name). Surface the display kind when it differs from the
+	// dispatch kind embedded in nodeID (e.g. sugar SystemPackage -> SystemPackage). (#285)
 	nodeName := string(nodeID)
+	if hasInfo && info.DisplayKind != "" {
+		nodeName = fmt.Sprintf("%s/%s", info.DisplayKind, info.Name)
+	}
 
 	if hasInfo {
 		// Version / SHA (mutually exclusive — SHA wins when both are set,
@@ -235,7 +251,7 @@ func (p *TreePrinter) PrintLayers(layers []Layer, resourceInfo map[NodeID]Resour
 	for i, layer := range layers {
 		var nodeNames []string
 		for _, node := range layer.Nodes {
-			nodeNames = append(nodeNames, fmt.Sprintf("%s/%s", node.Kind, node.Name))
+			nodeNames = append(nodeNames, fmt.Sprintf("%s/%s", node.DisplayKindOrKind(), node.Name))
 		}
 		fmt.Fprintf(p.writer, "  Layer %d: %s\n", i+1, strings.Join(nodeNames, ", "))
 	}

--- a/internal/installer/engine/engine.go
+++ b/internal/installer/engine/engine.go
@@ -107,17 +107,21 @@ const MethodCommands = "commands"
 
 // Event represents an engine event for progress reporting.
 type Event struct {
-	Type       EventType
-	Phase      Phase // execution phase (default PhaseDAG)
-	Kind       resource.Kind
-	Name       string
-	Version    string
-	Action     resource.ActionType
-	Error      error
-	Downloaded int64  // bytes downloaded (for EventProgress)
-	Total      int64  // total bytes (-1 if unknown, for EventProgress)
-	Output     string // output line (for EventOutput)
-	Method     string // install method: MethodDownload, "go install", etc.
+	Type  EventType
+	Phase Phase // execution phase (default PhaseDAG)
+	Kind  resource.Kind
+	// DisplayKind is the surfaced kind for user-facing labels when it differs
+	// from the dispatch Kind (e.g. a sugar SystemPackage dispatched as a
+	// SystemPackageSet). Empty means "use Kind". UI keys stay on Kind. (#285)
+	DisplayKind resource.Kind
+	Name        string
+	Version     string
+	Action      resource.ActionType
+	Error       error
+	Downloaded  int64  // bytes downloaded (for EventProgress)
+	Total       int64  // total bytes (-1 if unknown, for EventProgress)
+	Output      string // output line (for EventOutput)
+	Method      string // install method: MethodDownload, "go install", etc.
 
 	// EventLayerStart fields
 	Layer         int        // current layer index (0-based)

--- a/internal/installer/engine/system_engine.go
+++ b/internal/installer/engine/system_engine.go
@@ -157,13 +157,19 @@ func (e *SystemEngine) Apply(ctx context.Context, resources []resource.Resource)
 	// Build resource map for quick lookup
 	resourceMap := BuildResourceMap(resources)
 
+	// Populate each system node's surfaced (display) kind from its resource, so
+	// a sugar SystemPackage shows as SystemPackage/<name> in layer labels while
+	// still dispatching as a SystemPackageSet (#285). Display-only; node.Kind
+	// (the dispatch kind / NodeID) is untouched.
+	graph.SetNodeDisplayKinds(layers, resourceMap)
+
 	totalActions := 0
 
 	// Build node names for all layers (for event reporting)
 	allLayerNodes := make([][]string, len(layers))
 	for i, layer := range layers {
 		for _, node := range layer.Nodes {
-			allLayerNodes[i] = append(allLayerNodes[i], node.ID.String())
+			allLayerNodes[i] = append(allLayerNodes[i], fmt.Sprintf("%s/%s", node.DisplayKindOrKind(), node.Name))
 		}
 	}
 
@@ -286,32 +292,39 @@ func reconcileAndExecute[R resource.Resource, S resource.State](
 		return nil
 	}
 
+	// Surface the authored kind (e.g. SystemPackage) in user-facing labels while
+	// keeping Kind (dispatch) as SystemPackageSet. Display-only (#285).
+	displayKind := resource.DisplayKindOf(res)
+
 	emitter.emitEvent(Event{
-		Type:   EventStart,
-		Kind:   kind,
-		Name:   action.Name,
-		Action: action.Type,
-		Method: methodSystem,
+		Type:        EventStart,
+		Kind:        kind,
+		DisplayKind: displayKind,
+		Name:        action.Name,
+		Action:      action.Type,
+		Method:      methodSystem,
 	})
 
 	if err := exec.Execute(ctx, action); err != nil {
 		emitter.emitEvent(Event{
-			Type:   EventError,
-			Kind:   kind,
-			Name:   action.Name,
-			Action: action.Type,
-			Method: methodSystem,
-			Error:  err,
+			Type:        EventError,
+			Kind:        kind,
+			DisplayKind: displayKind,
+			Name:        action.Name,
+			Action:      action.Type,
+			Method:      methodSystem,
+			Error:       err,
 		})
 		return fmt.Errorf("failed to execute action %s for %s %s: %w", action.Type, kind, action.Name, err)
 	}
 
 	emitter.emitEvent(Event{
-		Type:   EventComplete,
-		Kind:   kind,
-		Name:   action.Name,
-		Action: action.Type,
-		Method: methodSystem,
+		Type:        EventComplete,
+		Kind:        kind,
+		DisplayKind: displayKind,
+		Name:        action.Name,
+		Action:      action.Type,
+		Method:      methodSystem,
 	})
 
 	*totalActions++

--- a/internal/installer/engine/system_engine_test.go
+++ b/internal/installer/engine/system_engine_test.go
@@ -595,6 +595,48 @@ func TestSystemEngine_Apply_Events(t *testing.T) {
 	}
 }
 
+// TestSystemEngine_Apply_Events_DisplayKind pins #285 on the apply path: a sugar
+// SystemPackage (expanded to a single-element set) emits events whose dispatch
+// Kind is SystemPackageSet but whose DisplayKind surfaces the authored
+// SystemPackage, while a directly-authored set leaves DisplayKind empty (so
+// labels fall back to SystemPackageSet). Dispatch is unchanged either way.
+func TestSystemEngine_Apply_Events_DisplayKind(t *testing.T) {
+	t.Parallel()
+	s := newSystemEngineTestSetup(t)
+
+	expanded, err := (&resource.SystemPackage{
+		BaseResource:      resource.BaseResource{Metadata: resource.Metadata{Name: "gcloud"}},
+		SystemPackageSpec: &resource.SystemPackageSpec{InstallerRef: "apt", Package: "google-cloud-cli"},
+	}).Expand()
+	require.NoError(t, err)
+
+	resources := []resource.Resource{
+		testSystemInstaller("apt"),
+		expanded[0], // sugar SystemPackage -> *SystemPackageSet with authoredKind
+		testSystemPackageSet("dev", "apt", "", []string{"jq"}), // directly authored set
+	}
+
+	require.NoError(t, s.engine.Apply(context.Background(), resources))
+
+	starts := make(map[string]Event)
+	for _, e := range s.getEvents() {
+		if e.Type == EventStart {
+			starts[e.Name] = e
+		}
+	}
+
+	// Sugar package: dispatch kind stays SystemPackageSet, display surfaces SystemPackage.
+	require.Contains(t, starts, "gcloud")
+	assert.Equal(t, resource.KindSystemPackageSet, starts["gcloud"].Kind, "dispatch kind must stay SystemPackageSet")
+	assert.Equal(t, resource.KindSystemPackage, starts["gcloud"].DisplayKind, "sugar package must surface SystemPackage")
+
+	// Directly-authored set: DisplayKindOf falls back to the dispatch kind, so
+	// both Kind and DisplayKind are SystemPackageSet (no divergence).
+	require.Contains(t, starts, "dev")
+	assert.Equal(t, resource.KindSystemPackageSet, starts["dev"].Kind)
+	assert.Equal(t, resource.KindSystemPackageSet, starts["dev"].DisplayKind, "directly-authored set surfaces SystemPackageSet")
+}
+
 func TestSystemEngine_Apply_UpgradeRepo(t *testing.T) {
 	t.Parallel()
 	s := newSystemEngineTestSetup(t)

--- a/internal/installer/engine/system_engine_test.go
+++ b/internal/installer/engine/system_engine_test.go
@@ -598,8 +598,10 @@ func TestSystemEngine_Apply_Events(t *testing.T) {
 // TestSystemEngine_Apply_Events_DisplayKind pins #285 on the apply path: a sugar
 // SystemPackage (expanded to a single-element set) emits events whose dispatch
 // Kind is SystemPackageSet but whose DisplayKind surfaces the authored
-// SystemPackage, while a directly-authored set leaves DisplayKind empty (so
-// labels fall back to SystemPackageSet). Dispatch is unchanged either way.
+// SystemPackage, while a directly-authored set emits DisplayKind equal to its
+// dispatch kind (SystemPackageSet) — reconcileAndExecute always sets DisplayKind
+// from resource.DisplayKindOf, which falls back to Kind() for non-sugar resources.
+// Dispatch is unchanged either way.
 func TestSystemEngine_Apply_Events_DisplayKind(t *testing.T) {
 	t.Parallel()
 	s := newSystemEngineTestSetup(t)

--- a/internal/resource/system_package.go
+++ b/internal/resource/system_package.go
@@ -358,9 +358,19 @@ func (s *SystemPackageSetSpec) Dependencies() []Ref {
 type SystemPackageSet struct {
 	BaseResource
 	SystemPackageSetSpec *SystemPackageSetSpec `json:"spec"`
+
+	// authoredKind records the kind the user actually wrote when this set was
+	// produced by expanding a sugar resource (SystemPackage -> single-element
+	// set). Empty for a directly-authored SystemPackageSet. It is display-only:
+	// surfaced via DisplayKindOf for plan/apply output, never used for dispatch,
+	// NodeID, or state (which key on Kind()/name). Unexported and unserialized
+	// so it cannot leak into state.json or the reconciler. (#285)
+	authoredKind Kind
 }
 
-// Kind returns the resource kind (can be called on nil).
+// Kind returns the resource kind (can be called on nil). This is the DISPATCH
+// kind and is always KindSystemPackageSet, including for sugar-expanded sets;
+// the authored kind is surfaced separately via DisplayKindOf (#285).
 func (*SystemPackageSet) Kind() Kind { return KindSystemPackageSet }
 
 // Spec returns the spec as Spec interface.
@@ -603,6 +613,25 @@ func (s *SystemPackage) Expand() ([]Resource, error) {
 				RepositoryRef: s.SystemPackageSpec.RepositoryRef,
 				Packages:      []string{s.SystemPackageSpec.Package},
 			},
+			// Remember the authored kind so plan/apply output surfaces
+			// SystemPackage/<name>, matching what the user wrote, while the
+			// resource still dispatches/installs as a SystemPackageSet (#285).
+			authoredKind: KindSystemPackage,
 		},
 	}, nil
+}
+
+// DisplayKindOf returns the kind to SURFACE to users (plan JSON, progress tree,
+// apply log): a sugar resource's authored kind when set, else the resource's
+// dispatch Kind(). Display-only — never used for dispatch, NodeID, or state, all
+// of which key on Kind()/name. Nil-safe so it can be called on the zero-value
+// resource of a Remove action. (#285)
+func DisplayKindOf(res Resource) Kind {
+	if sps, ok := res.(*SystemPackageSet); ok && sps != nil && sps.authoredKind != "" {
+		return sps.authoredKind
+	}
+	if res == nil {
+		return ""
+	}
+	return res.Kind()
 }

--- a/internal/resource/system_package_test.go
+++ b/internal/resource/system_package_test.go
@@ -339,8 +339,16 @@ func TestSystemPackage_Expand_Basic(t *testing.T) {
 	if set.APIVersion != GroupVersion {
 		t.Errorf("expanded APIVersion = %q, want %q", set.APIVersion, GroupVersion)
 	}
+	// Dispatch kind stays SystemPackageSet (the engine/state key on this), but
+	// the authored kind is preserved for display surfacing (#285).
 	if set.Kind() != KindSystemPackageSet {
 		t.Errorf("expanded Kind = %s, want %s", set.Kind(), KindSystemPackageSet)
+	}
+	if set.authoredKind != KindSystemPackage {
+		t.Errorf("expanded authoredKind = %s, want %s", set.authoredKind, KindSystemPackage)
+	}
+	if got := DisplayKindOf(set); got != KindSystemPackage {
+		t.Errorf("DisplayKindOf(expanded) = %s, want %s", got, KindSystemPackage)
 	}
 	if set.SystemPackageSetSpec.InstallerRef != "apt" {
 		t.Errorf("expanded InstallerRef = %q, want %q", set.SystemPackageSetSpec.InstallerRef, "apt")
@@ -654,6 +662,45 @@ func TestSystemPackage_Expand_Verbatim(t *testing.T) {
 			if got, want := set.SystemPackageSetSpec.Packages, []string{pkg}; !slices.Equal(got, want) {
 				t.Errorf("Packages = %v, want %v (verbatim)", got, want)
 			}
+		})
+	}
+}
+
+// TestDisplayKindOf pins the surfaced-kind helper (#285): a sugar-expanded
+// SystemPackage surfaces as SystemPackage, a directly-authored set surfaces as
+// SystemPackageSet, non-sugar resources surface their own Kind, and nil is safe.
+func TestDisplayKindOf(t *testing.T) {
+	t.Parallel()
+
+	expanded, err := (&SystemPackage{
+		BaseResource:      BaseResource{Metadata: Metadata{Name: "gcloud"}},
+		SystemPackageSpec: &SystemPackageSpec{InstallerRef: "apt", Package: "google-cloud-cli"},
+	}).Expand()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		res  Resource
+		want Kind
+	}{
+		{name: "sugar-expanded SystemPackage surfaces SystemPackage", res: expanded[0], want: KindSystemPackage},
+		{
+			name: "directly-authored set surfaces SystemPackageSet",
+			res:  &SystemPackageSet{BaseResource: BaseResource{ResourceKind: KindSystemPackageSet, Metadata: Metadata{Name: "dev"}}},
+			want: KindSystemPackageSet,
+		},
+		{
+			name: "non-sugar resource surfaces its own kind",
+			res:  &Tool{BaseResource: BaseResource{Metadata: Metadata{Name: "rg"}}},
+			want: KindTool,
+		},
+		{name: "nil interface is empty and safe", res: nil, want: ""},
+		{name: "typed-nil set falls back to dispatch kind", res: (*SystemPackageSet)(nil), want: KindSystemPackageSet},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, DisplayKindOf(tt.res))
 		})
 	}
 }

--- a/internal/ui/cmdview.go
+++ b/internal/ui/cmdview.go
@@ -12,14 +12,26 @@ import (
 
 // cmdTask represents a single command execution task.
 type cmdTask struct {
-	kind      resource.Kind
-	name      string
-	version   string
-	method    string // installation method (e.g., "go install", "brew install")
-	startTime time.Time
-	lastLog   string // most recent log line (for TTY spinner display)
-	done      bool
-	err       error
+	kind resource.Kind
+	// displayKind is the surfaced kind for labels when it differs from the
+	// dispatch kind (e.g. sugar SystemPackage). Empty means "use kind". (#285)
+	displayKind resource.Kind
+	name        string
+	version     string
+	method      string // installation method (e.g., "go install", "brew install")
+	startTime   time.Time
+	lastLog     string // most recent log line (for TTY spinner display)
+	done        bool
+	err         error
+}
+
+// labelKind returns the surfaced kind for display: displayKind when set, else
+// the dispatch kind.
+func (t *cmdTask) labelKind() resource.Kind {
+	if t.displayKind != "" {
+		return t.displayKind
+	}
+	return t.kind
 }
 
 // elapsed returns the duration since task start, rounded to 100ms.
@@ -46,17 +58,19 @@ func NewCommandView(w io.Writer) *CommandView {
 	}
 }
 
-// StartTask begins tracking a new command task.
-func (v *CommandView) StartTask(key string, kind resource.Kind, name, version, method string) {
+// StartTask begins tracking a new command task. displayKind is the surfaced
+// kind for labels (empty => use kind); the task key still uses the dispatch kind.
+func (v *CommandView) StartTask(key string, kind, displayKind resource.Kind, name, version, method string) {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 
 	v.tasks[key] = &cmdTask{
-		kind:      kind,
-		name:      name,
-		version:   version,
-		method:    method,
-		startTime: time.Now(),
+		kind:        kind,
+		displayKind: displayKind,
+		name:        name,
+		version:     version,
+		method:      method,
+		startTime:   time.Now(),
 	}
 }
 
@@ -124,7 +138,7 @@ func (v *CommandView) PrintTaskStart(key string) {
 
 	style := NewStyle()
 	fmt.Fprintf(v.w, " => %s/%s %s (%s)\n",
-		task.kind, style.Path.Sprint(task.name), task.version, task.method)
+		task.labelKind(), style.Path.Sprint(task.name), task.version, task.method)
 }
 
 // PrintOutput prints a single output line for non-TTY output.
@@ -150,10 +164,10 @@ func (v *CommandView) PrintTaskComplete(key string) {
 
 	if task.err != nil {
 		fmt.Fprintf(v.w, " => %s/%s failed (%.1fs): %v\n",
-			task.kind, task.name, elapsed.Seconds(), task.err)
+			task.labelKind(), task.name, elapsed.Seconds(), task.err)
 	} else {
 		fmt.Fprintf(v.w, " => %s/%s %s done (%.1fs)\n",
-			task.kind, style.Path.Sprint(task.name), task.version, elapsed.Seconds())
+			task.labelKind(), style.Path.Sprint(task.name), task.version, elapsed.Seconds())
 	}
 }
 

--- a/internal/ui/cmdview_test.go
+++ b/internal/ui/cmdview_test.go
@@ -15,7 +15,7 @@ func TestCommandView_StartTask(t *testing.T) {
 	var buf bytes.Buffer
 	cv := NewCommandView(&buf)
 
-	cv.StartTask("Tool/rg", resource.KindTool, "rg", "14.1.1", "download")
+	cv.StartTask("Tool/rg", resource.KindTool, "", "rg", "14.1.1", "download")
 
 	cv.mu.Lock()
 	task, ok := cv.tasks["Tool/rg"]
@@ -34,7 +34,7 @@ func TestCommandView_AddOutput(t *testing.T) {
 	var buf bytes.Buffer
 	cv := NewCommandView(&buf)
 
-	cv.StartTask("Tool/gopls", resource.KindTool, "gopls", "0.17.0", "go install")
+	cv.StartTask("Tool/gopls", resource.KindTool, "", "gopls", "0.17.0", "go install")
 	cv.AddOutput("Tool/gopls", "downloading golang.org/x/tools...")
 
 	assert.Equal(t, "downloading golang.org/x/tools...", cv.LastLog("Tool/gopls"))
@@ -54,7 +54,7 @@ func TestCommandView_AddOutput_IgnoresDoneTask(t *testing.T) {
 	var buf bytes.Buffer
 	cv := NewCommandView(&buf)
 
-	cv.StartTask("Tool/rg", resource.KindTool, "rg", "1.0.0", "download")
+	cv.StartTask("Tool/rg", resource.KindTool, "", "rg", "1.0.0", "download")
 	cv.CompleteTask("Tool/rg")
 	cv.AddOutput("Tool/rg", "should be ignored")
 
@@ -72,7 +72,7 @@ func TestCommandView_LastLog(t *testing.T) {
 		{
 			name: "returns last log",
 			setup: func(cv *CommandView) {
-				cv.StartTask("Tool/a", resource.KindTool, "a", "1.0", "go install")
+				cv.StartTask("Tool/a", resource.KindTool, "", "a", "1.0", "go install")
 				cv.AddOutput("Tool/a", "line 1")
 				cv.AddOutput("Tool/a", "line 2")
 			},
@@ -88,7 +88,7 @@ func TestCommandView_LastLog(t *testing.T) {
 		{
 			name: "returns empty after complete",
 			setup: func(cv *CommandView) {
-				cv.StartTask("Tool/b", resource.KindTool, "b", "1.0", "download")
+				cv.StartTask("Tool/b", resource.KindTool, "", "b", "1.0", "download")
 				cv.AddOutput("Tool/b", "some log")
 				cv.CompleteTask("Tool/b")
 			},
@@ -113,7 +113,7 @@ func TestCommandView_CompleteTask(t *testing.T) {
 	var buf bytes.Buffer
 	cv := NewCommandView(&buf)
 
-	cv.StartTask("Tool/rg", resource.KindTool, "rg", "1.0.0", "download")
+	cv.StartTask("Tool/rg", resource.KindTool, "", "rg", "1.0.0", "download")
 	cv.AddOutput("Tool/rg", "some log")
 	cv.CompleteTask("Tool/rg")
 
@@ -131,7 +131,7 @@ func TestCommandView_FailTask(t *testing.T) {
 	var buf bytes.Buffer
 	cv := NewCommandView(&buf)
 
-	cv.StartTask("Tool/rg", resource.KindTool, "rg", "1.0.0", "download")
+	cv.StartTask("Tool/rg", resource.KindTool, "", "rg", "1.0.0", "download")
 	testErr := assert.AnError
 	cv.FailTask("Tool/rg", testErr)
 
@@ -148,7 +148,7 @@ func TestCommandView_PrintTaskStart(t *testing.T) {
 	var buf bytes.Buffer
 	cv := NewCommandView(&buf)
 
-	cv.StartTask("Tool/gopls", resource.KindTool, "gopls", "0.17.0", "go install")
+	cv.StartTask("Tool/gopls", resource.KindTool, "", "gopls", "0.17.0", "go install")
 	cv.PrintTaskStart("Tool/gopls")
 
 	output := buf.String()
@@ -164,8 +164,8 @@ func TestCommandView_PrintTaskStart_HeaderOnce(t *testing.T) {
 	var buf bytes.Buffer
 	cv := NewCommandView(&buf)
 
-	cv.StartTask("Tool/a", resource.KindTool, "a", "1.0", "go install")
-	cv.StartTask("Tool/b", resource.KindTool, "b", "2.0", "go install")
+	cv.StartTask("Tool/a", resource.KindTool, "", "a", "1.0", "go install")
+	cv.StartTask("Tool/b", resource.KindTool, "", "b", "2.0", "go install")
 	cv.PrintTaskStart("Tool/a")
 	cv.PrintTaskStart("Tool/b")
 
@@ -207,7 +207,7 @@ func TestCommandView_PrintTaskComplete_Success(t *testing.T) {
 	var buf bytes.Buffer
 	cv := NewCommandView(&buf)
 
-	cv.StartTask("Tool/gopls", resource.KindTool, "gopls", "0.17.0", "go install")
+	cv.StartTask("Tool/gopls", resource.KindTool, "", "gopls", "0.17.0", "go install")
 	cv.CompleteTask("Tool/gopls")
 	cv.PrintTaskComplete("Tool/gopls")
 
@@ -221,7 +221,7 @@ func TestCommandView_PrintTaskComplete_Error(t *testing.T) {
 	var buf bytes.Buffer
 	cv := NewCommandView(&buf)
 
-	cv.StartTask("Tool/gopls", resource.KindTool, "gopls", "0.17.0", "go install")
+	cv.StartTask("Tool/gopls", resource.KindTool, "", "gopls", "0.17.0", "go install")
 	cv.FailTask("Tool/gopls", assert.AnError)
 	cv.PrintTaskComplete("Tool/gopls")
 
@@ -300,7 +300,7 @@ func TestCommandView_ConcurrentAccess(t *testing.T) {
 
 		go func(k string) {
 			defer wg.Done()
-			cv.StartTask(k, resource.KindTool, "tool", "1.0", "download")
+			cv.StartTask(k, resource.KindTool, "", "tool", "1.0", "download")
 		}(key)
 
 		go func(k string) {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -32,8 +32,12 @@ const (
 
 // taskState holds the state for a single resource being installed.
 type taskState struct {
-	key         string
-	kind        resource.Kind
+	key  string
+	kind resource.Kind
+	// displayKind is the surfaced kind for the label when it differs from the
+	// dispatch kind (e.g. sugar SystemPackage). Empty means "use kind". The
+	// task key still uses kind. (#285)
+	displayKind resource.Kind
 	name        string
 	version     string
 	method      string

--- a/internal/ui/progress.go
+++ b/internal/ui/progress.go
@@ -87,9 +87,20 @@ func (pm *ProgressManager) HandleEvent(event engine.Event, results *ApplyResults
 	}
 }
 
-// resourceKey returns a unique key for a resource.
+// resourceKey returns a unique key for a resource. Keys always use the dispatch
+// Kind (not DisplayKind) so Start/Progress/Complete events for the same task
+// match regardless of display surfacing.
 func resourceKey(kind resource.Kind, name string) string {
 	return fmt.Sprintf("%s/%s", kind, name)
+}
+
+// eventDisplayKind returns the surfaced kind for an event's label: DisplayKind
+// when set, else the dispatch Kind. Used only for user-facing labels, never keys. (#285)
+func eventDisplayKind(event engine.Event) resource.Kind {
+	if event.DisplayKind != "" {
+		return event.DisplayKind
+	}
+	return event.Kind
 }
 
 // isDownloadMethod returns true if the method is a download pattern.
@@ -110,7 +121,7 @@ func (pm *ProgressManager) handleDownloadStart(event engine.Event, key string) {
 			mpb.BarFillerClearOnComplete(),
 			mpb.PrependDecorators(
 				decor.Name(fmt.Sprintf("  %s %s/%s ",
-					style.ActionIcon(event.Action), event.Kind, style.Path.Sprint(event.Name)),
+					style.ActionIcon(event.Action), eventDisplayKind(event), style.Path.Sprint(event.Name)),
 					decor.WC{W: 30, C: decor.DindentRight}),
 				decor.Name(event.Version, decor.WC{W: 12}),
 			),
@@ -126,19 +137,19 @@ func (pm *ProgressManager) handleDownloadStart(event engine.Event, key string) {
 			fmt.Fprintln(pm.w, "Downloads:")
 		}
 		fmt.Fprintf(pm.w, "  %s %s/%s %s\n",
-			style.ActionIcon(event.Action), event.Kind, style.Path.Sprint(event.Name), event.Version)
+			style.ActionIcon(event.Action), eventDisplayKind(event), style.Path.Sprint(event.Name), event.Version)
 		pm.mu.Unlock()
 	}
 }
 
 // handleCommandStart handles EventStart for delegation pattern.
 func (pm *ProgressManager) handleCommandStart(event engine.Event, key string) {
-	pm.cmdView.StartTask(key, event.Kind, event.Name, event.Version, event.Method)
+	pm.cmdView.StartTask(key, event.Kind, event.DisplayKind, event.Name, event.Version, event.Method)
 
 	if pm.isTTY {
 		style := NewStyle()
 		label := fmt.Sprintf(" => %s/%s %s (%s) ",
-			event.Kind, style.Path.Sprint(event.Name), event.Version, event.Method)
+			eventDisplayKind(event), style.Path.Sprint(event.Name), event.Version, event.Method)
 
 		bar, _ := pm.progress.Add(0,
 			mpb.SpinnerStyle(spinnerFrames...).Build(),
@@ -240,7 +251,7 @@ func (pm *ProgressManager) handleError(event engine.Event, results *ApplyResults
 			}
 		}
 		fmt.Fprintf(pm.w, "  %s %s/%s failed: %v\n",
-			style.FailMark, event.Kind, event.Name, event.Error)
+			style.FailMark, eventDisplayKind(event), event.Name, event.Error)
 		pm.mu.Unlock()
 	} else {
 		pm.cmdView.FailTask(key, event.Error)

--- a/internal/ui/render.go
+++ b/internal/ui/render.go
@@ -240,7 +240,11 @@ func spinnerFrame(startTime time.Time) string {
 
 // taskLabel returns the display label for a task, e.g. "Runtime/go 1.25.6" or "Tool/bat 0.25.0 (aqua install)".
 func taskLabel(t *taskState) string {
-	label := fmt.Sprintf("%s/%s", t.kind, t.name)
+	kind := t.kind
+	if t.displayKind != "" {
+		kind = t.displayKind // surface authored kind, e.g. sugar SystemPackage (#285)
+	}
+	label := fmt.Sprintf("%s/%s", kind, t.name)
 	if t.version != "" {
 		label += " " + t.version
 	}

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -129,14 +129,15 @@ func (m *ApplyModel) handleStart(event engine.Event) (tea.Model, tea.Cmd) {
 	}
 
 	m.tasks[key] = &taskState{
-		key:       key,
-		kind:      event.Kind,
-		name:      event.Name,
-		version:   event.Version,
-		method:    event.Method,
-		action:    event.Action,
-		status:    taskRunning,
-		startTime: time.Now(),
+		key:         key,
+		kind:        event.Kind,
+		displayKind: event.DisplayKind,
+		name:        event.Name,
+		version:     event.Version,
+		method:      event.Method,
+		action:      event.Action,
+		status:      taskRunning,
+		startTime:   time.Now(),
 	}
 	m.taskOrder = append(m.taskOrder, key)
 


### PR DESCRIPTION
A resource authored `kind: SystemPackage` is internally expanded to a
single-element SystemPackageSet, and that normalization leaked into the
surfaced kind: plan JSON `.kind`, the progress tree, validate output, and the
apply log all showed `SystemPackageSet/<name>` instead of the authored
`SystemPackage/<name>`.

Decouple display from dispatch. The expanded set records its authored kind in
an unexported, unserialized `authoredKind` field; `resource.DisplayKindOf` is
the single source of truth for the surfaced kind (authored kind when set, else
the dispatch Kind, nil-safe for Remove actions). A display-only `DisplayKind`
flows through `graph.Node`, `graph.ResourceInfo`, and `engine.Event`, each
falling back to the dispatch Kind when empty; label sites read it while map
keys (resourceKey/progressKey/taskKey) and NodeID stay on the dispatch Kind.

Dispatch is entirely unchanged: Kind(), NodeID, the engine `switch node.Kind`,
extractByKind, the reconciler, and state (keyed by name) are untouched, so
idempotency is unaffected. A directly-authored SystemPackageSet still surfaces
as SystemPackageSet. Removals and `tomei logs` surface the dispatch kind by
design (state records no authored kind).

Chosen over making Kind() canonical (which would require updating every
kind-string dispatch site — a silent-non-install footgun) per a 5-round expert
review. Also fixes a latent skip-dedup bug in graph export that keyed on the
displayed kind.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
