### PR TITLE
fix(runtime): pass declared alias/channel version to delegation bootstrap

### DIFF
--- a/cuemodule/presets/rust/rust.cue
+++ b/cuemodule/presets/rust/rust.cue
@@ -23,7 +23,16 @@ import "tomei.terassyi.net/schema"
 		version: string | *"stable"
 		bootstrap: {
 			install: ["curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain {{.Version}}"]
-			update: ["\(_cargoBin)/rustup update {{.Version}}"]
+			// Update the declared toolchain, then (re)assert it as the default. The
+			// second step keeps the runtime tracking the channel even on machines
+			// whose default was previously pinned to a concrete version — otherwise
+			// `rustup update stable` advances the stable channel but leaves rustc on
+			// the old pinned toolchain. rustup accepts channel names ("stable",
+			// "nightly") and exact versions alike, and `rustup default` is idempotent.
+			update: [
+				"\(_cargoBin)/rustup update {{.Version}}",
+				"\(_cargoBin)/rustup default {{.Version}}",
+			]
 			check: ["\(_cargoBin)/rustc --version"]
 			remove: ["\(_cargoBin)/rustup self uninstall -y"]
 			resolveVersion: ["\(_cargoBin)/rustc --version 2>/dev/null | grep -oP '\\d+\\.\\d+\\.\\d+' || echo ''"]

--- a/internal/installer/runtime/installer.go
+++ b/internal/installer/runtime/installer.go
@@ -432,10 +432,22 @@ func (i *Installer) installDelegation(ctx context.Context, spec *resource.Runtim
 	}
 
 	// Execute bootstrap command.
+	//
+	// Bootstrap install/update/check receive the DECLARED spec version, not the
+	// resolved concrete version. Delegation tools (rustup, pnpm, uv, ...) manage
+	// their own version channels, so an alias like "stable"/"latest" must reach
+	// them verbatim: `rustup update {{.Version}}` has to expand to
+	// `rustup update stable`, and `pnpm self-update{{if ne .Version "latest"}}...`
+	// relies on `.Version` being the alias. Passing the resolved concrete version
+	// (e.g. "1.96.0") would freeze the channel to whatever was first installed and
+	// turn updates into no-ops. The resolved version is still recorded in state
+	// (buildStateResolved below) for visibility and drift reporting. For exact
+	// versions spec.Version == resolvedVersion, so this is a no-op there.
+	//
 	// MinimumReleaseAge is exposed to bootstrap/check commands as {{.MinimumReleaseAge}}
 	// for symmetry with the tool-delegation path; tomei does not enforce it here (this is
 	// the runtime's own self-install), so honoring it is the bootstrap command's choice.
-	vars := command.Vars{Version: resolvedVersion, MinimumReleaseAge: spec.MinimumReleaseAge}
+	vars := command.Vars{Version: spec.Version, MinimumReleaseAge: spec.MinimumReleaseAge}
 	if err := i.executeBootstrap(ctx, cmds, vars, env); err != nil {
 		return nil, fmt.Errorf("bootstrap %s failed: %w", errAction, err)
 	}

--- a/internal/installer/runtime/installer_test.go
+++ b/internal/installer/runtime/installer_test.go
@@ -287,13 +287,15 @@ func TestInstaller_Install(t *testing.T) {
 		require.Len(t, runner.captureCalls, 1)
 		assert.Equal(t, []string{"resolve-cmd"}, runner.captureCalls[0].cmds)
 
-		// Verify install was called with resolved version
+		// Bootstrap receives the declared alias/channel, not the resolved concrete
+		// version — so delegation tools that manage their own channels update the
+		// channel rather than pin to a frozen version.
 		require.Len(t, runner.executeWithEnvCalls, 1)
-		assert.Equal(t, "1.83.0", runner.executeWithEnvCalls[0].vars.Version)
+		assert.Equal(t, "stable", runner.executeWithEnvCalls[0].vars.Version)
 
-		// Verify check receives resolved version
+		// Check likewise operates on the declared version.
 		require.Len(t, runner.checkCalls, 1)
-		assert.Equal(t, "1.83.0", runner.checkCalls[0].vars.Version)
+		assert.Equal(t, "stable", runner.checkCalls[0].vars.Version)
 	})
 
 	t.Run("delegation install calls resolveVersion", func(t *testing.T) {
@@ -320,9 +322,9 @@ func TestInstaller_Install(t *testing.T) {
 		require.Len(t, runner.captureCalls, 1)
 		assert.Equal(t, []string{"resolve-cmd"}, runner.captureCalls[0].cmds)
 
-		// install command receives resolved version
+		// install command receives the declared alias/channel, not the resolved version
 		require.Len(t, runner.executeWithEnvCalls, 1)
-		assert.Equal(t, "1.83.0", runner.executeWithEnvCalls[0].vars.Version)
+		assert.Equal(t, "stable", runner.executeWithEnvCalls[0].vars.Version)
 	})
 
 	t.Run("delegation upgrade calls resolveVersion", func(t *testing.T) {
@@ -476,9 +478,10 @@ func TestInstaller_Install(t *testing.T) {
 		assert.Equal(t, resource.VersionAlias, state.VersionKind)
 		assert.Equal(t, "latest", state.SpecVersion)
 
-		// Verify install was called with resolved version
+		// Bootstrap receives the declared alias ("latest"), not the resolved version;
+		// state still records the resolved concrete version above.
 		require.Len(t, runner.executeWithEnvCalls, 1)
-		assert.Equal(t, "1.42.0", runner.executeWithEnvCalls[0].vars.Version)
+		assert.Equal(t, "latest", runner.executeWithEnvCalls[0].vars.Version)
 
 		// Verify no shell capture was called (resolved via http-text, not ExecuteCapture)
 		assert.Empty(t, runner.captureCalls, "http-text resolver should not use ExecuteCapture")


### PR DESCRIPTION
Delegation runtimes (rustup, pnpm, uv, ...) manage their own version
channels, so their bootstrap install/update/check commands must receive
the DECLARED version — the alias/channel like "stable"/"latest" — not the
resolved concrete version. Previously installDelegation bound {{.Version}}
to the resolved concrete version, so `rustup update {{.Version}}` expanded
to `rustup update 1.96.0` (a no-op) instead of `rustup update stable`, and
`pnpm self-update{{if ne .Version "latest"}}...` never hit its guard. This
froze channel/latest runtimes to whatever version was first installed;
`tomei apply --update-runtimes` could never advance them.

Bind bootstrap {{.Version}} to spec.Version instead. The resolved concrete
version is still recorded in state for visibility and drift reporting. For
exact versions spec.Version == resolvedVersion, so this is a no-op there.
Download runtimes (go, zig, ...) are unaffected — installDownload still
uses the resolved version for the tarball URL, which is correct.

Also harden the rust preset: the update command now re-asserts the default
toolchain (`rustup default {{.Version}}`) after updating, so machines whose
default was previously pinned to a concrete version self-heal instead of
leaving rustc on the stale toolchain.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
