### PR TITLE
fix(registry): support url/files in aqua overrides and select the matching binary from multi-binary packages

### DIFF
--- a/docs/cue-schema.md
+++ b/docs/cue-schema.md
@@ -121,6 +121,23 @@ spec: {
 }
 ```
 
+When a registry package ships multiple binaries in one archive (e.g.
+`gravitational/teleport` contains `tbot`, `tctl`, `teleport`, and `tsh`),
+tomei installs the registry file entry whose name matches `spec.binaryName`
+(if set) or the tool name; a name that matches none of the entries is an
+error. Declare one Tool per binary you want:
+
+```cue
+apiVersion: "tomei.terassyi.net/v1beta1"
+kind:       "Tool"
+metadata: name: "tsh"
+spec: {
+    installerRef: "aqua"
+    version:      "v18.1.0"
+    package:      "gravitational/teleport"
+}
+```
+
 #### Via explicit download
 
 ```cue

--- a/internal/installer/tool/installer.go
+++ b/internal/installer/tool/installer.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -263,14 +264,12 @@ func (i *Installer) installByDownload(ctx context.Context, res *resource.Tool, n
 	if cfg.BinaryName == "" {
 		cfg.BinaryName = name
 	}
-	// User spec binaryName takes highest priority
-	if spec.BinaryName != "" {
-		// Preserve original binary name as SrcBinaryName for archive search
-		if cfg.SrcBinaryName == "" {
-			cfg.SrcBinaryName = cfg.BinaryName
-		}
-		cfg.BinaryName = spec.BinaryName
+	// User spec binaryName takes highest priority; preserve the pre-override
+	// binary name as SrcBinaryName for archive search.
+	if spec.BinaryName != "" && cfg.SrcBinaryName == "" {
+		cfg.SrcBinaryName = cfg.BinaryName
 	}
+	cfg.BinaryName = effectiveBinaryName(spec, cfg.BinaryName)
 
 	// Validate effective binary name (after registry mapping and spec override)
 	if err := validateName("binaryName", cfg.BinaryName); err != nil {
@@ -471,12 +470,12 @@ func (i *Installer) installFromRegistry(ctx context.Context, res *resource.Tool,
 		slog.Warn("registry warning", "package", pkgName, "warning", w)
 	}
 
-	// Check for errors from resolution (e.g., unsupported OS/Arch)
+	// Check for errors from resolution (e.g., unsupported OS/Arch, empty URL)
 	if len(resolved.Errors) > 0 {
 		for _, e := range resolved.Errors {
 			slog.Error("registry error", "package", pkgName, "error", e)
 		}
-		return nil, fmt.Errorf("package %s is not supported on this platform: %s", pkgName, resolved.Errors[0])
+		return nil, fmt.Errorf("cannot install package %s: %s", pkgName, resolved.Errors[0])
 	}
 
 	// Build DownloadSource from resolved info
@@ -496,11 +495,10 @@ func (i *Installer) installFromRegistry(ctx context.Context, res *resource.Tool,
 	// Create a modified tool with resolved source for download.
 	resolvedTool := buildResolvedTool(res, source, version)
 
-	// Build install config from resolved files
-	cfg := extractBinaryMapping(name, resolved.Files)
-	if len(resolved.Files) > 1 {
-		slog.Warn("multiple files in registry entry, using first entry only",
-			"package", spec.Package.String(), "fileCount", len(resolved.Files))
+	// Build install config from resolved files.
+	cfg, err := extractBinaryMapping(effectiveBinaryName(spec, name), resolved.Files)
+	if err != nil {
+		return nil, fmt.Errorf("package %s: %w", pkgName, err)
 	}
 
 	// Use existing download logic (name = resource name for storage path)
@@ -539,24 +537,49 @@ func buildResolvedTool(orig *resource.Tool, source *resource.DownloadSource, ver
 	}
 }
 
-// extractBinaryMapping builds an InstallConfig from aqua registry files metadata.
-// It extracts the binary name (files[].name) and source binary name (path.Base of files[].src)
-// from the first entry. Only the first file entry is used; callers should warn on multiple entries.
-func extractBinaryMapping(defaultName string, files []aqua.FileSpec) *installer.InstallConfig {
+// extractBinaryMapping builds an InstallConfig from aqua registry files
+// metadata: binary name from files[].name, source binary name from path.Base
+// of files[].src. When a package ships multiple binaries (e.g.
+// gravitational/teleport), the entry matching desiredName is selected, and no
+// match is an error — installing files[0] instead would silently place the
+// wrong binary. A single unmatched entry is kept: that is the legitimate
+// name-mapping case (tool "cli" → files: [{name: gh}]).
+func extractBinaryMapping(desiredName string, files []aqua.FileSpec) (*installer.InstallConfig, error) {
 	cfg := &installer.InstallConfig{
-		BinaryName: defaultName,
+		BinaryName: desiredName,
 	}
 	if len(files) == 0 {
-		return cfg
+		return cfg, nil
 	}
 	f := files[0]
+	if len(files) > 1 {
+		idx := slices.IndexFunc(files, func(c aqua.FileSpec) bool { return c.Name == desiredName })
+		if idx < 0 {
+			names := make([]string, len(files))
+			for i, c := range files {
+				names[i] = c.Name
+			}
+			return nil, fmt.Errorf("package ships multiple binaries (%s) and none matches %q; set binaryName to select one",
+				strings.Join(names, ", "), desiredName)
+		}
+		f = files[idx]
+	}
 	if f.Name != "" {
 		cfg.BinaryName = f.Name
 	}
 	if f.Src != "" {
 		cfg.SrcBinaryName = path.Base(f.Src)
 	}
-	return cfg
+	return cfg, nil
+}
+
+// effectiveBinaryName returns the binary name a tool installs as: the
+// spec-level binaryName override when set, otherwise the resource name.
+func effectiveBinaryName(spec *resource.ToolSpec, name string) string {
+	if spec.BinaryName != "" {
+		return spec.BinaryName
+	}
+	return name
 }
 
 // createSymlink resolves the bin directory based on Tool.IsPrivileged() and
@@ -828,10 +851,7 @@ func (i *Installer) installByRuntime(ctx context.Context, res *resource.Tool, na
 	}
 
 	// Build variables for command substitution
-	binName := name
-	if spec.BinaryName != "" {
-		binName = spec.BinaryName
-	}
+	binName := effectiveBinaryName(spec, name)
 	// SHA pins this install to a git commit. The preset template
 	// (e.g. "go install {{.Package}}@{{.Version}}") receives the SHA via
 	// .Version, expanding to `@<sha>` without modifying the preset.

--- a/internal/installer/tool/installer_test.go
+++ b/internal/installer/tool/installer_test.go
@@ -8,8 +8,10 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -338,6 +340,80 @@ func TestToolInstaller_Install_GzFormat_SpecBinaryNameOverride(t *testing.T) {
 	info, err := os.Stat(binPath)
 	require.NoError(t, err)
 	assert.NotEqual(t, os.FileMode(0), info.Mode()&0o111, "placed gz binary must be executable")
+}
+
+// TestToolInstaller_Install_MultiFilePackage_SelectsMatchingBinary covers
+// multi-binary packages (e.g. gravitational/teleport): one archive ships
+// several binaries and the registry files[] entry matching the tool name must
+// be selected (not files[0]) and extracted via its src basename.
+func TestToolInstaller_Install_MultiFilePackage_SelectsMatchingBinary(t *testing.T) {
+	t.Parallel()
+	clientContent := []byte("#!/bin/sh\necho client")
+	archive := createMultiFileTarGzContent(t, map[string][]byte{
+		"multitool/agent":     []byte("#!/bin/sh\necho agent"),
+		"multitool/server":    []byte("#!/bin/sh\necho server"),
+		"multitool/multitool": []byte("#!/bin/sh\necho multitool"),
+		"multitool/client":    clientContent,
+	})
+
+	tmpDir := t.TempDir()
+	toolsDir := filepath.Join(tmpDir, "tools")
+	userBinDir := filepath.Join(tmpDir, "bin")
+	cacheDir := t.TempDir()
+	ref := aqua.RegistryRef("v4.465.0")
+	pkg := "example/multitool"
+
+	registryYAML := `packages:
+  - type: http
+    repo_owner: example
+    repo_name: multitool
+    url: https://cdn.example.com/multitool-{{.Version}}-{{.OS}}-{{.Arch}}-bin.{{.Format}}
+    format: tar.gz
+    files:
+      - name: agent
+        src: multitool/agent
+      - name: server
+        src: multitool/server
+      - name: multitool
+        src: multitool/multitool
+      - name: client
+        src: multitool/client
+`
+	cacheFile := filepath.Join(cacheDir, ref.String(), "pkgs", pkg, "registry.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(cacheFile), 0o755))
+	require.NoError(t, os.WriteFile(cacheFile, []byte(registryYAML), 0o644))
+
+	dl := &mockDownloader{archiveData: archive}
+	inst := NewInstaller(dl, place.NewPlacer(toolsDir), userBinDir, "/system-bin")
+	inst.SetResolver(aqua.NewResolver(cacheDir, nil), ref)
+
+	tool := &resource.Tool{
+		BaseResource: resource.BaseResource{
+			Metadata: resource.Metadata{Name: "client"},
+		},
+		ToolSpec: &resource.ToolSpec{
+			InstallerRef: "aqua",
+			Version:      "v1.0.0",
+			Package: &resource.Package{
+				Owner: "example",
+				Repo:  "multitool",
+			},
+		},
+	}
+
+	state, err := inst.Install(context.Background(), tool, tool.Name())
+	require.NoError(t, err)
+	require.NotNil(t, state)
+
+	// The client entry (not files[0] = agent) must be selected and placed.
+	binPath := filepath.Join(toolsDir, "client", "v1.0.0", "client")
+	got, err := os.ReadFile(binPath)
+	require.NoError(t, err)
+	assert.Equal(t, clientContent, got)
+
+	info, err := os.Stat(binPath)
+	require.NoError(t, err)
+	assert.NotEqual(t, os.FileMode(0), info.Mode()&0o111, "placed binary must be executable")
 }
 
 // TestBuildResolvedTool_PreservesPrivileged pins SUB5 #228: the registry
@@ -893,20 +969,31 @@ func TestToolInstaller_InstallFromRegistry_NoRegistryRef(t *testing.T) {
 
 func createTarGzContent(t *testing.T, binaryName string, content []byte) []byte {
 	t.Helper()
+	return createMultiFileTarGzContent(t, map[string][]byte{binaryName: content})
+}
+
+// createMultiFileTarGzContent builds a tar.gz archive containing multiple files,
+// keyed by their in-archive path — the shape of multi-binary packages like
+// gravitational/teleport (teleport/tbot, teleport/tsh, ...).
+func createMultiFileTarGzContent(t *testing.T, files map[string][]byte) []byte {
+	t.Helper()
 
 	var buf bytes.Buffer
 	gw := gzip.NewWriter(&buf)
 	tw := tar.NewWriter(gw)
 
-	hdr := &tar.Header{
-		Name: binaryName,
-		Mode: 0755,
-		Size: int64(len(content)),
+	// Sort paths for deterministic archive layout.
+	for _, p := range slices.Sorted(maps.Keys(files)) {
+		content := files[p]
+		hdr := &tar.Header{
+			Name: p,
+			Mode: 0755,
+			Size: int64(len(content)),
+		}
+		require.NoError(t, tw.WriteHeader(hdr))
+		_, err := tw.Write(content)
+		require.NoError(t, err)
 	}
-	err := tw.WriteHeader(hdr)
-	require.NoError(t, err)
-	_, err = tw.Write(content)
-	require.NoError(t, err)
 
 	require.NoError(t, tw.Close())
 	require.NoError(t, gw.Close())
@@ -1790,23 +1877,33 @@ func TestInstallFromRegistry_ChecksumAlgorithmPropagation(t *testing.T) {
 
 func TestExtractBinaryMapping(t *testing.T) {
 	t.Parallel()
+	// Multi-binary package shape (e.g. gravitational/teleport ships
+	// tbot/tctl/teleport/tsh in one archive).
+	multiToolFiles := []aqua.FileSpec{
+		{Name: "agent", Src: "multitool/agent"},
+		{Name: "server", Src: "multitool/server"},
+		{Name: "multitool", Src: "multitool/multitool"},
+		{Name: "client", Src: "multitool/client"},
+	}
+
 	tests := []struct {
 		name              string
-		defaultName       string
+		desiredName       string
 		files             []aqua.FileSpec
 		wantBinaryName    string
 		wantSrcBinaryName string
+		wantErr           bool
 	}{
 		{
-			name:              "empty files uses default name",
-			defaultName:       "mytool",
+			name:              "empty files uses desired name",
+			desiredName:       "mytool",
 			files:             nil,
 			wantBinaryName:    "mytool",
 			wantSrcBinaryName: "",
 		},
 		{
 			name:        "files[].name overrides binary name",
-			defaultName: "krew",
+			desiredName: "krew",
 			files: []aqua.FileSpec{
 				{Name: "krew", Src: "krew-linux_arm64"},
 			},
@@ -1815,7 +1912,7 @@ func TestExtractBinaryMapping(t *testing.T) {
 		},
 		{
 			name:        "files[].src with path prefix extracts base name",
-			defaultName: "helm",
+			desiredName: "helm",
 			files: []aqua.FileSpec{
 				{Name: "helm", Src: "linux-arm64/helm"},
 			},
@@ -1824,7 +1921,7 @@ func TestExtractBinaryMapping(t *testing.T) {
 		},
 		{
 			name:        "files[].src with deep path extracts base name",
-			defaultName: "gh",
+			desiredName: "gh",
 			files: []aqua.FileSpec{
 				{Name: "gh", Src: "gh_2.86.0_linux_amd64/bin/gh"},
 			},
@@ -1832,8 +1929,8 @@ func TestExtractBinaryMapping(t *testing.T) {
 			wantSrcBinaryName: "gh",
 		},
 		{
-			name:        "files[].name without src",
-			defaultName: "cli",
+			name:        "single unmatched file keeps registry name mapping",
+			desiredName: "cli",
 			files: []aqua.FileSpec{
 				{Name: "gh"},
 			},
@@ -1841,21 +1938,53 @@ func TestExtractBinaryMapping(t *testing.T) {
 			wantSrcBinaryName: "",
 		},
 		{
-			name:        "multiple files uses first entry only",
-			defaultName: "multi",
+			// Installing files[0] would silently place the wrong binary.
+			name:        "multiple files without match is an error",
+			desiredName: "multi",
 			files: []aqua.FileSpec{
 				{Name: "first", Src: "first-bin"},
 				{Name: "second", Src: "second-bin"},
 			},
-			wantBinaryName:    "first",
-			wantSrcBinaryName: "first-bin",
+			wantErr: true,
+		},
+		{
+			// The entry matching the desired name must be selected, not files[0].
+			name:              "multiple files selects entry matching desired name",
+			desiredName:       "client",
+			files:             multiToolFiles,
+			wantBinaryName:    "client",
+			wantSrcBinaryName: "client",
+		},
+		{
+			name:              "multiple files selects non-first match",
+			desiredName:       "server",
+			files:             multiToolFiles,
+			wantBinaryName:    "server",
+			wantSrcBinaryName: "server",
+		},
+		{
+			name:        "multiple files match without src",
+			desiredName: "client",
+			files: []aqua.FileSpec{
+				{Name: "agent"},
+				{Name: "server"},
+				{Name: "client"},
+			},
+			wantBinaryName:    "client",
+			wantSrcBinaryName: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			cfg := extractBinaryMapping(tt.defaultName, tt.files)
+			cfg, err := extractBinaryMapping(tt.desiredName, tt.files)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "binaryName")
+				return
+			}
+			require.NoError(t, err)
 			assert.Equal(t, tt.wantBinaryName, cfg.BinaryName)
 			assert.Equal(t, tt.wantSrcBinaryName, cfg.SrcBinaryName)
 		})

--- a/internal/registry/aqua/override.go
+++ b/internal/registry/aqua/override.go
@@ -16,13 +16,7 @@ func applyOSOverrides(info *PackageInfo, goos, goarch string) *PackageInfo {
 
 	for _, override := range info.Overrides {
 		if matchesOS(override, goos, goarch) {
-			// Apply override fields if they are set
-			if override.Asset != "" {
-				result.Asset = override.Asset
-			}
-			if override.Format != "" {
-				result.Format = override.Format
-			}
+			applyCommonOverrideFields(&result, override.Asset, override.URL, override.Format, override.Files)
 			if override.Replacements != nil {
 				// Merge replacements: start with base, then override
 				merged := make(map[string]string)
@@ -36,6 +30,25 @@ func applyOSOverrides(info *PackageInfo, goos, goarch string) *PackageInfo {
 	}
 
 	return &result
+}
+
+// applyCommonOverrideFields copies the override fields shared by Override and
+// VersionOverride onto result, applying only the values that are set.
+// Replacements is excluded: the two override kinds have different policies
+// (OS overrides merge with the base map, version overrides replace it).
+func applyCommonOverrideFields(result *PackageInfo, asset, url, format string, files []FileSpec) {
+	if asset != "" {
+		result.Asset = asset
+	}
+	if url != "" {
+		result.URL = url
+	}
+	if format != "" {
+		result.Format = format
+	}
+	if files != nil {
+		result.Files = files
+	}
 }
 
 // matchesOS checks if the override matches the given GOOS and GOARCH.

--- a/internal/registry/aqua/override_test.go
+++ b/internal/registry/aqua/override_test.go
@@ -133,6 +133,63 @@ func TestApplyOSOverrides(t *testing.T) {
 			},
 		},
 		{
+			// Some packages (e.g. gravitational/teleport) define url and files
+			// only inside per-OS overrides.
+			name: "url and files override",
+			info: &PackageInfo{
+				Type: "http",
+				Files: []FileSpec{
+					{Name: "server"},
+					{Name: "client"},
+				},
+				Overrides: []Override{
+					{
+						GOOS:   "linux",
+						URL:    "https://cdn.example.com/multitool-{{.Version}}-linux-{{.Arch}}-bin.{{.Format}}",
+						Format: "tar.gz",
+						Files: []FileSpec{
+							{Name: "server", Src: "multitool/server"},
+							{Name: "client", Src: "multitool/client"},
+						},
+					},
+				},
+			},
+			goos:   "linux",
+			goarch: "amd64",
+			check: func(t *testing.T, result *PackageInfo) {
+				assert.Equal(t, "https://cdn.example.com/multitool-{{.Version}}-linux-{{.Arch}}-bin.{{.Format}}", result.URL)
+				assert.Equal(t, "tar.gz", result.Format)
+				assert.Equal(t, []FileSpec{
+					{Name: "server", Src: "multitool/server"},
+					{Name: "client", Src: "multitool/client"},
+				}, result.Files)
+			},
+		},
+		{
+			name: "url and files unset in override keeps base values",
+			info: &PackageInfo{
+				Type:   "http",
+				URL:    "https://example.com/tool-{{.Version}}.tar.gz",
+				Format: "tar.gz",
+				Files: []FileSpec{
+					{Name: "tool", Src: "bin/tool"},
+				},
+				Overrides: []Override{
+					{
+						GOOS:   "windows",
+						Format: "zip",
+					},
+				},
+			},
+			goos:   "windows",
+			goarch: "amd64",
+			check: func(t *testing.T, result *PackageInfo) {
+				assert.Equal(t, "https://example.com/tool-{{.Version}}.tar.gz", result.URL)
+				assert.Equal(t, "zip", result.Format)
+				assert.Equal(t, []FileSpec{{Name: "tool", Src: "bin/tool"}}, result.Files)
+			},
+		},
+		{
 			name: "replacements override",
 			info: &PackageInfo{
 				Type:   "github_release",

--- a/internal/registry/aqua/resolver.go
+++ b/internal/registry/aqua/resolver.go
@@ -181,6 +181,16 @@ func (r *Resolver) ResolveWithOS(ctx context.Context, ref RegistryRef, pkg, vers
 	// 4. Apply OS overrides (e.g., Windows uses .zip instead of .tar.gz)
 	info = applyOSOverrides(info, goos, goarch)
 
+	// A definition whose URL/asset lives only in fields tomei does not support
+	// would otherwise resolve to a broken download URL and surface as a
+	// confusing failure at download time.
+	if missingDownloadSource(info) {
+		result.Errors = append(result.Errors,
+			fmt.Sprintf("package %s has no download source for %s/%s (the registry definition may use fields tomei does not support yet)",
+				pkg, goos, goarch))
+		return result, nil
+	}
+
 	// 5. Apply replacements (e.g., amd64 → x86_64, darwin → macOS)
 	osName := applyReplacement(info.Replacements, goos)
 	archName := applyReplacement(info.Replacements, goarch)
@@ -253,6 +263,20 @@ func (r *Resolver) ResolveWithOS(ctx context.Context, ref RegistryRef, pkg, vers
 	result.Files = info.Files
 
 	return result, nil
+}
+
+// missingDownloadSource reports whether info lacks the source field its
+// package type needs to build a download URL. Mirrors buildURL's type
+// dispatch below — extend both together when adding a package type.
+func missingDownloadSource(info *PackageInfo) bool {
+	switch info.Type {
+	case PackageTypeHTTP:
+		return info.URL == ""
+	case PackageTypeGitHubRelease:
+		return info.Asset == ""
+	default:
+		return false
+	}
 }
 
 // buildURL constructs the download URL based on package type.

--- a/internal/registry/aqua/resolver_test.go
+++ b/internal/registry/aqua/resolver_test.go
@@ -140,6 +140,162 @@ func TestResolver_Resolve_WithOSOverrides(t *testing.T) {
 	assert.Equal(t, extract.ArchiveTypeZip, result.Format)
 }
 
+func TestResolver_Resolve_HTTPWithOverrideURLAndFiles(t *testing.T) {
+	t.Parallel()
+	// Mirrors the shape of packages like gravitational/teleport: type http
+	// where the download url and file mappings are defined only inside
+	// per-OS overrides, and one archive ships multiple binaries.
+	registryYAML := `packages:
+  - type: http
+    repo_owner: example
+    repo_name: multitool
+    files:
+      - name: agent
+      - name: server
+      - name: client
+    overrides:
+      - goos: linux
+        url: https://cdn.example.com/multitool-{{.Version}}-linux-{{.Arch}}-bin.{{.Format}}
+        format: tar.gz
+        files:
+          - name: agent
+            src: multitool/agent
+          - name: server
+            src: multitool/server
+          - name: client
+            src: multitool/client
+      - goos: darwin
+        url: https://cdn.example.com/multitool-tools-{{trimV .Version}}.{{.Format}}
+        format: pkg
+        files:
+          - name: client
+            src: client-{{trimV .Version}}.pkg/Payload/client.app/Contents/MacOS/client
+      - goos: windows
+        url: https://cdn.example.com/multitool-{{.Version}}-windows-amd64-bin.{{.Format}}
+        format: zip
+        files:
+          - name: agent
+          - name: client
+`
+
+	tests := []struct {
+		name       string
+		goos       string
+		goarch     string
+		wantURL    string
+		wantFormat extract.ArchiveType
+		wantFiles  []FileSpec
+	}{
+		{
+			name:       "linux amd64",
+			goos:       "linux",
+			goarch:     "amd64",
+			wantURL:    "https://cdn.example.com/multitool-v1.2.3-linux-amd64-bin.tar.gz",
+			wantFormat: extract.ArchiveTypeTarGz,
+			wantFiles: []FileSpec{
+				{Name: "agent", Src: "multitool/agent"},
+				{Name: "server", Src: "multitool/server"},
+				{Name: "client", Src: "multitool/client"},
+			},
+		},
+		{
+			name:       "darwin arm64",
+			goos:       "darwin",
+			goarch:     "arm64",
+			wantURL:    "https://cdn.example.com/multitool-tools-1.2.3.pkg",
+			wantFormat: extract.ArchiveTypePkg,
+			wantFiles: []FileSpec{
+				{Name: "client", Src: "client-1.2.3.pkg/Payload/client.app/Contents/MacOS/client"},
+			},
+		},
+		{
+			name:       "windows amd64",
+			goos:       "windows",
+			goarch:     "amd64",
+			wantURL:    "https://cdn.example.com/multitool-v1.2.3-windows-amd64-bin.zip",
+			wantFormat: extract.ArchiveTypeZip,
+			wantFiles: []FileSpec{
+				{Name: "agent"},
+				{Name: "client"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cacheDir := t.TempDir()
+			ref := RegistryRef("v4.465.0")
+			pkg := "example/multitool"
+
+			cacheFile := filepath.Join(cacheDir, ref.String(), "pkgs", pkg, "registry.yaml")
+			require.NoError(t, os.MkdirAll(filepath.Dir(cacheFile), 0o755))
+			require.NoError(t, os.WriteFile(cacheFile, []byte(registryYAML), 0o644))
+
+			resolver := NewResolver(cacheDir, nil)
+
+			result, err := resolver.ResolveWithOS(context.Background(), ref, pkg, "v1.2.3", tt.goos, tt.goarch)
+
+			require.NoError(t, err)
+			assert.Empty(t, result.Errors)
+			assert.Equal(t, tt.wantURL, result.URL)
+			assert.Equal(t, tt.wantFormat, result.Format)
+			assert.Equal(t, tt.wantFiles, result.Files)
+		})
+	}
+}
+
+func TestResolver_Resolve_MissingDownloadSource(t *testing.T) {
+	t.Parallel()
+	// Simulates registry definitions whose url/asset lives only in fields
+	// tomei does not support, which would otherwise resolve to a broken
+	// download URL that only fails at download time.
+	tests := []struct {
+		name         string
+		registryYAML string
+	}{
+		{
+			name: "http without url",
+			registryYAML: `packages:
+  - type: http
+    repo_owner: example
+    repo_name: no-url
+    format: tar.gz
+`,
+		},
+		{
+			name: "github_release without asset",
+			registryYAML: `packages:
+  - type: github_release
+    repo_owner: example
+    repo_name: no-asset
+    format: tar.gz
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cacheDir := t.TempDir()
+			ref := RegistryRef("v4.465.0")
+			pkg := "example/tool"
+
+			cacheFile := filepath.Join(cacheDir, ref.String(), "pkgs", pkg, "registry.yaml")
+			require.NoError(t, os.MkdirAll(filepath.Dir(cacheFile), 0o755))
+			require.NoError(t, os.WriteFile(cacheFile, []byte(tt.registryYAML), 0o644))
+
+			resolver := NewResolver(cacheDir, nil)
+
+			result, err := resolver.ResolveWithOS(context.Background(), ref, pkg, "v1.0.0", "linux", "amd64")
+
+			require.NoError(t, err)
+			require.NotEmpty(t, result.Errors)
+			assert.Contains(t, result.Errors[0], "no download source")
+		})
+	}
+}
+
 func TestResolver_Resolve_WithReplacements(t *testing.T) {
 	t.Parallel()
 	cacheDir := t.TempDir()

--- a/internal/registry/aqua/types.go
+++ b/internal/registry/aqua/types.go
@@ -108,6 +108,7 @@ type VersionOverride struct {
 	VersionConstraint string            `yaml:"version_constraint"`
 	Asset             string            `yaml:"asset,omitempty"`
 	URL               string            `yaml:"url,omitempty"`
+	Files             []FileSpec        `yaml:"files,omitempty"`
 	Format            string            `yaml:"format,omitempty"`
 	VersionPrefix     *string           `yaml:"version_prefix,omitempty"`
 	Checksum          *ChecksumSpec     `yaml:"checksum,omitempty"`
@@ -118,10 +119,17 @@ type VersionOverride struct {
 }
 
 // Override specifies OS/Arch-specific configuration overrides.
+//
+// Known unsupported fields from aqua's Override (type, checksum,
+// complete_windows_ext, windows_ext, envs, cosign, slsa_provenance, minisign):
+// packages relying on them resolve without the override applied. The resolver
+// reports an error when this leaves the download URL empty.
 type Override struct {
 	GOOS         string            `yaml:"goos,omitempty"`
 	GOArch       string            `yaml:"goarch,omitempty"`
 	Format       string            `yaml:"format,omitempty"`
 	Asset        string            `yaml:"asset,omitempty"`
+	URL          string            `yaml:"url,omitempty"`
+	Files        []FileSpec        `yaml:"files,omitempty"`
 	Replacements map[string]string `yaml:"replacements,omitempty"`
 }

--- a/internal/registry/aqua/types_test.go
+++ b/internal/registry/aqua/types_test.go
@@ -153,6 +153,32 @@ format: tar.gz
 				Format: "tar.gz",
 			},
 		},
+		{
+			// Some packages (e.g. gravitational/teleport) define the download
+			// url and file mappings only inside per-OS overrides.
+			name: "url and files in overrides",
+			yaml: `
+type: http
+overrides:
+  - goos: linux
+    url: https://cdn.example.com/tool-{{.Version}}.tar.gz
+    files:
+      - name: tool
+        src: dist/tool
+`,
+			expected: PackageInfo{
+				Type: "http",
+				Overrides: []Override{
+					{
+						GOOS: "linux",
+						URL:  "https://cdn.example.com/tool-{{.Version}}.tar.gz",
+						Files: []FileSpec{
+							{Name: "tool", Src: "dist/tool"},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/registry/aqua/version.go
+++ b/internal/registry/aqua/version.go
@@ -71,18 +71,9 @@ func ApplyVersionOverrides(info *PackageInfo, version string) *PackageInfo {
 
 	for _, override := range info.VersionOverrides {
 		if matchVersionConstraint(override.VersionConstraint, version) {
-			// Apply override fields if they are set
-			if override.Asset != "" {
-				result.Asset = override.Asset
-			}
-			if override.URL != "" {
-				result.URL = override.URL
-			}
+			applyCommonOverrideFields(&result, override.Asset, override.URL, override.Format, override.Files)
 			if override.VersionPrefix != nil {
 				result.VersionPrefix = *override.VersionPrefix
-			}
-			if override.Format != "" {
-				result.Format = override.Format
 			}
 			if override.Checksum != nil {
 				result.Checksum = override.Checksum

--- a/internal/registry/aqua/version_test.go
+++ b/internal/registry/aqua/version_test.go
@@ -307,6 +307,29 @@ func TestApplyVersionOverrides(t *testing.T) {
 			},
 		},
 		{
+			name: "files override",
+			info: &PackageInfo{
+				Type:              "http",
+				URL:               "https://cdn.example.com/tool-{{.Version}}.tar.gz",
+				VersionConstraint: `semver(">= 2.0.0")`,
+				Files: []FileSpec{
+					{Name: "tool", Src: "tool"},
+				},
+				VersionOverrides: []VersionOverride{
+					{
+						VersionConstraint: `semver("< 2.0.0")`,
+						Files: []FileSpec{
+							{Name: "tool", Src: "legacy/tool"},
+						},
+					},
+				},
+			},
+			version: "v1.0.0",
+			check: func(t *testing.T, result *PackageInfo) {
+				assert.Equal(t, []FileSpec{{Name: "tool", Src: "legacy/tool"}}, result.Files)
+			},
+		},
+		{
 			name: "version_prefix override",
 			info: &PackageInfo{
 				Type:              "github_release",

--- a/tests/aqua_integration_test.go
+++ b/tests/aqua_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -341,6 +342,38 @@ func TestAquaErrorHandling(t *testing.T) {
 		// linux/arm64 is not in supported_envs (only darwin and linux/amd64)
 		assert.NotEmpty(t, resolved.Errors, "should have errors for unsupported env")
 	})
+}
+
+// TestAquaResolve_Teleport_RealRegistry resolves gravitational/teleport (the
+// motivating case for override url/files support) against the real
+// aqua-registry (raw.githubusercontent.com, no token required).
+//
+// The registry ref is a pinned immutable git tag, so the fetched definition
+// never changes. Assertions are structural (non-empty URL containing the
+// requested version, a tsh file mapping) rather than exact URLs, and the tool
+// version is arbitrary — resolution only renders it into the URL template —
+// so the test does not depend on any specific teleport release existing.
+func TestAquaResolve_Teleport_RealRegistry(t *testing.T) {
+	cacheDir := t.TempDir()
+	resolver := aqua.NewResolver(cacheDir, nil)
+	ctx := context.Background()
+
+	version := "v1.2.3"
+	resolved, err := resolver.ResolveWithOS(ctx, aqua.RegistryRef("v4.465.0"), "gravitational/teleport", version, "linux", "amd64")
+	require.NoError(t, err)
+	require.Empty(t, resolved.Errors)
+
+	assert.True(t, strings.HasPrefix(resolved.URL, "https://"), "resolved URL should be https, got %q", resolved.URL)
+	assert.Contains(t, resolved.URL, version, "resolved URL should contain the requested version")
+	assert.NotEmpty(t, resolved.Format)
+
+	var tshSrc string
+	for _, f := range resolved.Files {
+		if f.Name == "tsh" {
+			tshSrc = f.Src
+		}
+	}
+	assert.NotEmpty(t, tshSrc, "files should contain a tsh entry with a src mapping, got %+v", resolved.Files)
 }
 
 // TestAquaReplacementsMerge tests that replacements are correctly merged


### PR DESCRIPTION
Packages like gravitational/teleport define their download url and file
mappings only inside per-OS overrides, and ship several binaries in one
archive. Previously the OS override merge dropped url/files (resolving to
a broken URL), and the installer always installed files[0].

- Merge url and files from OS overrides, and files from version overrides
  (shared apply helper so the two merge paths cannot drift)
- Select the files[] entry matching binaryName (or the tool name) for
  multi-binary packages; no match is an error instead of silently placing
  the wrong binary
- Report a resolution error when the merged definition still has no
  download source (url/asset only in unsupported fields), instead of
  failing confusingly at download time

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
